### PR TITLE
Spec 001 — a self-sufficient build-tool plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,35 @@ jobs:
       - name: Run CLI checks
         run: Checks/run-cli-checks.sh
 
+  # ── Plugin lane ──────────────────────────────────────────────────
+  # The SPM build-tool plugin, black-box over Checks/PluginFixture: the derived
+  # source closure, the synthesized config, the defaults it supplies and the four
+  # red controls that must stay red. Runs beside `checks` and `cli` rather than
+  # behind them — it needs no simulator, and it is the only lane that exercises
+  # the plugin's own logic (the example lane exercises the plugin, but through
+  # one package shape).
+  plugin:
+    name: Plugin (source closure, synthesized config, red controls)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Cache the fixtures' resolved dependencies
+        # All five fixture packages share one SwiftPM cache, so the pinned
+        # Sourcery artifact bundle and swift-argument-parser are fetched once.
+        uses: actions/cache@v5
+        with:
+          path: .build/plugin-checks/cache
+          key: plugin-checks-${{ runner.os }}-${{ env.SOURCERY_VERSION }}-${{ hashFiles('Package.resolved', 'Package.swift') }}
+          restore-keys: plugin-checks-${{ runner.os }}-${{ env.SOURCERY_VERSION }}-
+
+      - name: Run plugin checks
+        run: Checks/run-plugin-checks.sh
+
   # ── Full lane ────────────────────────────────────────────────────
   # Covers what the fast lane structurally cannot: the RxSwift smart defaults
   # (`Single`, `Observable`, `AnyObserver`, `Disposable`), the RIBs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,22 @@ name: CI
 # Push-triggered on every branch. Tag pushes are excluded: a tag is cut from a
 # commit that was already built, so running again would only duplicate the
 # result.
+#
+# `branches` must be spelled out, and this is the whole trigger — do not
+# "simplify" it back to a bare `tags-ignore`. From the workflow-syntax
+# reference: "If you define only `tags`/`tags-ignore` or only
+# `branches`/`branches-ignore`, the workflow won't run for events affecting the
+# undefined Git ref." A lone `tags-ignore: ['**']` therefore leaves branches
+# undefined *and* excludes every tag, so the push trigger can never fire at all
+# — which is what it did here from the day this file was written until
+# 2026-09-09: every CI run in the history was a manual workflow_dispatch.
+#
+# With `branches` defined and no tag filter, tags are the undefined ref and are
+# excluded on their own, so no `tags-ignore` is needed. `'**'` rather than `'*'`
+# because `*` does not match a `/`, and branches here are named `spec/001-...`.
 on:
   push:
-    tags-ignore: ['**']
+    branches: ['**']
   workflow_dispatch:
 
 concurrency:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ xcuserdata
 .netrc
 .DS_Store
 /Package.resolved
+# The plugin lane's fixtures resolve this package on every run. Their job is to
+# exercise the plugin, not to pin a dependency graph — and an unpinned resolve is
+# what a consumer does.
+Checks/PluginFixture/Package.resolved
+Checks/PluginFixtureRed/*/Package.resolved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,96 @@ templates are distributed through SPM and through the assets a tag publishes on 
 
 ---
 
+## Unreleased — the plugin derives its own sources
+
+**Generated output:** unchanged for any config that does not opt in. The templates did not move a
+byte; the only way this changes what a consumer generates is by scanning more sources, which happens
+only when a config asks for it.
+
+The SPM build-tool plugin used to export **one level** of the package graph as `SOURCERY_TARGET_*`
+variables, and the author hand-listed each variable in `sources:`. A module reachable only
+transitively had no variable and could not be listed at all — so a protocol refining one from a
+module two hops away generated a mock missing those requirements, and the failure surfaced in the
+consumer's build as *"type 'XMock' does not conform to protocol 'Y'"*. That is the gap this closes.
+
+The plugin now **synthesizes the config it runs**: it copies the author's `.Sourcery.<Name>.yml` into
+its work directory, expands what the file declares, appends what it omits, and runs Sourcery against
+the copy. Nothing is parsed as YAML — a build-tool plugin cannot depend on a library, so the rewrite
+is line-level and a construct the plugin does not recognise is one it does not touch.
+
+- **`${SOURCERY_SOURCES}`** — a `sources:` list item that expands to the target's own sources plus the
+  recursive closure of its dependencies, one directory per module, deduplicated and sorted. Not an
+  environment variable, deliberately: nothing exports it, so a substitution that failed to run leaves
+  Sourcery reporting an unexpanded path rather than silently scanning less than intended.
+- **Bare template names** — `- Mocks` resolves to the shipped template. The plugin finds its own
+  package in the graph and exports `SOURCERY_TEMPLATES`. A file of the same name beside your config
+  still wins, so a project with its own `Mocks.swifttemplate` keeps getting its own.
+- **`sources:` and `output:` are supplied when absent.** Both are mandatory to Sourcery today, so a
+  config that omitted either never worked — filling them in cannot change what an existing config
+  means. The smallest config that works is now `templates:` and nothing else.
+- **`args.testable` is supplied when unambiguous** — for a test target with exactly one direct
+  dependency on a module of the root package. With none, or two or more, nothing is inserted and the
+  build log names the candidates.
+- **A wrong `output:` now fails the build.** Outputs are collected only from the directory the
+  prebuild command declared, so a file generated elsewhere is written and then ignored: the target
+  compiles without it and the failure surfaces as a missing type, far from its cause. The error names
+  both paths.
+- **Two configs of one target naming the same template are rejected** at plan time, naming both
+  files.
+
+**Breaking:** nothing, for a config that does not use the new features. Every `SOURCERY_TARGET_*`
+variable keeps its name and value, and a config with no placeholder and no bare name is copied byte
+for byte. Two changes can surface on an existing config:
+
+- a config whose `output:` does not resolve to `${SOURCERY_OUTPUT_DIR}` now fails rather than
+  generating into a directory nothing reads. That configuration never worked; it failed silently.
+- generated files now land in a per-config subdirectory of the plugin's work directory rather than
+  all in one. Nothing outside the plugin names those paths, but it is what makes a target with
+  several configs possible at all — see below.
+
+**Adopting:** optional, and per config. To pick up the closure, replace the hand-listed `sources:`
+entries with `- ${SOURCERY_SOURCES}`; to name templates portably, replace
+`${GIT_ROOT}/templates/Mocks.swifttemplate` with `- Mocks`; to drop the rest, delete `output:` and,
+on a test target with one dependency, `args.testable`.
+
+**Cost, measured.** The derived closure is much larger than what the example used to list — RxSwift,
+RxCocoa, RxRelay, RxBlocking, RxTest, Alamofire, Quick, Nimble and RIBs in full. The example lane
+(`Examples/ExampleProjectSpm/test-ios.sh`), cold, three samples each, Xcode 26.6 / Sourcery 2.3.0:
+
+| | wall time |
+| --- | --- |
+| before (hand-listed sources) | 32s, 29s, 30s |
+| after (the full closure, plus a third target, four specs and a second template) | 36s, 36s, 34s |
+
+About +5s, and not all of it is the closure. The mitigations held in reserve — `sources.exclude`, a
+root-package-only `${SOURCERY_SOURCES_LOCAL}`, or keeping explicit variables — are not needed.
+
+**Two things the spec got wrong, both found by building it:**
+
+- It proposed finding this package in a consumer's graph by looking for a target named
+  `SourcerySwiftCodegenPlugin`. `Package.targets` exposes source-module, binary-artifact and
+  system-library targets only — a **plugin target never appears in it**, so the match could never
+  fire. The plugin matches the manifest name (`SourcerySwiftCodegen`) or the package identity
+  instead, and requires a `templates/` directory to be there. Both live in this repository rather
+  than the consumer's, which is the property the target name was chosen for.
+- It expected two configs of one target to share an output directory, with the second silently
+  overwriting the first when they name the same template. In fact SwiftPM collects a prebuild
+  command's outputs by scanning the whole directory it declared, so two commands declaring one
+  directory makes it attribute every file to both and refuse the build — *"couldn't build <file>.o
+  because of multiple producers"*. Each config now owns a directory nothing else writes to, which is
+  what makes the several-configs-per-target shape the docs recommend work at all. With that split,
+  the shared `--cacheBasePath` and `--buildPath` showed no interference across repeated cold and warm
+  rebuilds, so they stay shared.
+
+**Checking it:** a new lane, `Checks/run-plugin-checks.sh`, black-box over `Checks/PluginFixture` and
+four red-control packages under `Checks/PluginFixtureRed/`. It runs in about a minute, needs no
+simulator, and is the only lane that can test the plugin's own logic — a plugin target cannot be
+imported by a test target. It runs in CI beside `checks` and `cli`.
+
+Design record: [`specs/001-plugin-source-discovery/spec.md`](specs/001-plugin-source-discovery/spec.md).
+
+---
+
 ## 0.7.0 — 2026-09-09
 
 `validate` gains `--template <name>` and a repeatable `--args <key=value>`. Given them, it rebuilds

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,10 @@ Sources/mock-templates/             # the CLI: generate (wraps Sourcery), imprin
   Fingerprint.swift                 # the provenance block — format, render, parse
   SourceSet.swift                   # input enumeration and root-relative paths
 
-Plugins/SourcerySwiftCodegenPlugin/ # SPM prebuild plugin
-Checks/                             # fast lane + CLI lane — see Testing below
+Plugins/SourcerySwiftCodegenPlugin/ # SPM prebuild plugin — one file, no dependencies allowed
+Checks/                             # fast lane + CLI lane + plugin lane — see Testing below
+  PluginFixture/                    # the plugin lane's green package: one target per config shape
+  PluginFixtureRed/                 # four packages that must FAIL, one per red control
 Scripts/assemble-release.sh         # builds the release assets — see Cutting a release
 Examples/ExampleProjectSpm/         # full lane — RxSwift, RIBs, type erasure, the plugin
 specs/                              # design specs, NNN-slug/spec.md — see Keep the documents in their lanes
@@ -124,9 +126,20 @@ its consumers need no Sourcery installation.
 
 ### The SPM plugin
 
-1. `Plugins/SourcerySwiftCodegenPlugin/SourcerySwiftCodegenPlugin.swift`
-2. Conditional compilation for the Swift 5.x vs 6.0+ plugin API differences
-3. Test by building the example project — the fast lane does not exercise the plugin
+1. `Plugins/SourcerySwiftCodegenPlugin/SourcerySwiftCodegenPlugin.swift` — all of it. A build-tool
+   plugin **cannot depend on a library target** (SwiftPM rejects it outright), so there is no Yams, no
+   code shared with `Sources/mock-templates`, and no test target that can import any of these types.
+   Everything is PackagePlugin + Foundation in one file
+2. Three parts, in reading order: `YamlLine` (the line rules), `SourceryConfigSynthesizer` (the
+   rewrite — placeholder, template names, defaults, the `output:` check), and
+   `_createBuildCommands` (discovery, the per-config output directories, the collision check)
+3. The synthesizer never parses YAML. It recognises a mapping key at column 0 and a whole list item,
+   and copies every other byte through. A construct it does not recognise is one it does not touch —
+   which is the whole safety argument, so keep new rules to that shape
+4. Conditional compilation for the Swift 5.x vs 6.0+ plugin API differences
+5. Run `Checks/run-plugin-checks.sh` — black-box over `Checks/PluginFixture`, ~1 minute, no simulator.
+   It is the only lane that can test the plugin at all. `Examples/ExampleProjectSpm/test-ios.sh`
+   covers it too, but through one package shape
 
 ### The `mock-templates` CLI
 
@@ -223,10 +236,15 @@ that does not tell the author what to do.
   inherited requirement only when the inherited protocol is among the `--sources`. A protocol
   refining one from *another module* generates a mock missing those requirements, and the failure
   surfaces in the consumer's build as "type 'XMock' does not conform to protocol 'Y'" — never here.
-  The fix belongs to whatever drives generation: pass the other module's sources too. The Duet
-  reference app's `scripts/generate-mocks.sh` derives them from `swift package dump-package` (every
-  path dependency, plus the framework at its exact pin) rather than listing paths, so a new
-  refinement across a first-party module boundary needs no change to the script.
+  The fix belongs to whatever drives generation: pass the other module's sources too. **On the plugin
+  path, `${SOURCERY_SOURCES}` closes this** — the plugin derives the target's whole dependency
+  closure and splices it into the config it runs, so a refinement across any module boundary needs no
+  config change (spec [001](specs/001-plugin-source-discovery/spec.md);
+  `Checks/PluginFixture/Sources/App` is the reproducer, and
+  `Examples/ExampleProjectSpm`'s `ProfilePersisting` is the same shape on the full lane). On the CLI
+  path it stays the caller's job: the Duet reference app's `scripts/generate-mocks.sh` derives the
+  set from `swift package dump-package` (every path dependency, plus the framework at its exact pin)
+  rather than listing paths, so a new refinement needs no change to the script.
 
 ### SourceryRuntime API notes
 
@@ -248,6 +266,7 @@ protocol work. `Variable.isAsync` and `Variable.throws` carry effectful property
 |------|---------|-------|
 | fast | `Checks/run-checks.sh` | a Swift toolchain; ~10s |
 | CLI | `Checks/run-cli-checks.sh` | a Swift toolchain; ~30s cold, seconds warm |
+| plugin | `Checks/run-plugin-checks.sh` | a Swift toolchain and, once, the network; ~1 min cold |
 | full | `cd Examples/ExampleProjectSpm && ./test-ios.sh` | an iOS Simulator; minutes |
 
 Both check lanes provision the pinned Sourcery through `Checks/ensure-sourcery.sh` — the pin and the
@@ -261,6 +280,14 @@ template's output in one invocation is what keeps a mock and a Component of the 
 disagreeing about isolation.
 
 Adding a template is one line in `TEMPLATES` plus a recorded snapshot.
+
+The plugin lane builds `Checks/PluginFixture` — a package whose targets are one per config shape, over
+a three-level dependency chain (`App` → `Middle` → `Leaf`, with `ExternalKit` arriving through
+`Middle` from a second package) — and then reads what the plugin wrote: the synthesized configs, the
+generated code, and the build's own outcome. Its four red controls live in
+`Checks/PluginFixtureRed/`, one package each, because build planning runs *every* target's plugin: a
+plan-time error in one target fails the build for all of them, so no `--target` can isolate a red
+control that shares a package with a green one. See `Checks/README.md`.
 
 The full lane is Quick + Nimble specs in `Examples/ExampleProjectSpm/Sources/ExampleProjectSpmTests/`,
 driven by the prebuild plugin. It covers what the fast lane structurally cannot: RxSwift smart
@@ -277,6 +304,7 @@ defaults, the RIBs external-annotation pattern, type erasure, and the plugin its
 | fast | `Checks/Snapshots/Components.generated.swift` | the generated Components, as a reviewable diff |
 | fast | `Checks/Behaviour/Main.swift` | call counting, handlers, async suspension, nonisolated access off the main actor, subject-driven streams, cancellation counting, composites; for Components: forwarding identity, per-Component ownership, settable forwarding, parameter shapes, effectful getters |
 | CLI | `Checks/run-cli-checks.sh` | `generate` transparency against the fast lane's snapshot; determinism across runs; `validate` red on a mutated input, an unlisted file, a hand-edited body, a wrong bundle tag, a `--template`/`--args` pair the block does not record; `imprint` recovery |
+| plugin | `Checks/run-plugin-checks.sh` | the derived source closure (splice, sort, absolute paths); passthrough of everything else; the defaults the plugin supplies and the ones it must not; bare template-name resolution and the local file that outranks a shipped one; `args.testable` inserted, declined and left alone; determinism between builds; two configs on one target; and four red controls — a wrong `output:`, a template collision, an unknown template name, a `package:` the plugin must leave alone |
 | full | `SwiftSourceryTemplatesMocksSpec.swift` | mock instantiation, call counting, handler execution |
 | full | `EscapingClosureMocksSpec.swift` | `@escaping` preservation — capture, async dispatch |
 | full | `ReturnTypeOverloadMocksSpec.swift` | return-type-only overload disambiguation |
@@ -286,8 +314,8 @@ defaults, the RIBs external-annotation pattern, type erasure, and the plugin its
 
 ### CI
 
-`.github/workflows/ci.yml` runs all three lanes on every push: fast and CLI in parallel, full gated
-on fast. Xcode is
+`.github/workflows/ci.yml` runs all four lanes on every push: fast, CLI and plugin in parallel, full
+gated on fast. Xcode is
 pinned via `XCODE_VERSION` because the fast lane's gate is *zero diagnostics*: a runner image whose
 compiler emits one new warning would turn it red for a reason unrelated to the templates. The gate has
 been measured to hold on Swift 6.3.3 (Xcode 26.6) and Swift 6.4 (Xcode 27 beta 4), so the pin is for

--- a/Checks/PluginFixture/External/Package.swift
+++ b/Checks/PluginFixture/External/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// A separate package, so `ExternalKit` reaches `App` the way a checkout does:
+// through a dependency of a dependency, with no env var naming it.
+let package = Package(
+  name: "ExternalFixtureKit",
+  products: [
+    .library(name: "ExternalKit", targets: ["ExternalKit"]),
+  ],
+  targets: [
+    .target(name: "ExternalKit"),
+  ]
+)

--- a/Checks/PluginFixture/External/Sources/ExternalKit/ExternalKit.swift
+++ b/Checks/PluginFixture/External/Sources/ExternalKit/ExternalKit.swift
@@ -1,0 +1,5 @@
+// Level 3 of the chain, and in a different package: `App` reaches this only
+// through `Middle`, so no `SOURCERY_TARGET_*` var can name it.
+public protocol Reporting {
+  func report(_ message: String)
+}

--- a/Checks/PluginFixture/Package.swift
+++ b/Checks/PluginFixture/Package.swift
@@ -1,0 +1,68 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// The black-box fixture for the build-tool plugin. A plugin target cannot be
+// imported by a test target (spec 001 §1.5), so everything the plugin does is
+// checked by building this package and reading what it wrote:
+// Checks/run-plugin-checks.sh.
+//
+// The shape that matters is the chain App → Middle → Leaf, with ExternalKit
+// arriving through Middle from a second package. `Leaf` and `ExternalKit` are two
+// levels from `App`, which is exactly the distance no `SOURCERY_TARGET_*` var can
+// reach.
+let package = Package(
+  name: "PluginFixture",
+  platforms: [
+    .macOS(.v13)
+  ],
+  dependencies: [
+    .package(name: "swift-sourcery-templates", path: "../.."),
+    .package(name: "ExternalFixtureKit", path: "External"),
+  ],
+  targets: [
+    .target(name: "Leaf"),
+    .target(
+      name: "Middle",
+      dependencies: [
+        "Leaf",
+        .product(name: "ExternalKit", package: "ExternalFixtureKit"),
+      ]
+    ),
+    // The placeholder shape: the closure plus one hand-listed entry, and two
+    // shipped templates named by name from one config (§4.7).
+    .target(
+      name: "App",
+      dependencies: ["Middle"],
+      plugins: [.plugin(name: "SourcerySwiftCodegenPlugin", package: "swift-sourcery-templates")]
+    ),
+    // The zero-configuration shape: `templates:` and nothing else.
+    .target(
+      name: "Solo",
+      plugins: [.plugin(name: "SourcerySwiftCodegenPlugin", package: "swift-sourcery-templates")]
+    ),
+    // The shape that must come out byte-identical.
+    .target(
+      name: "Verbatim",
+      plugins: [.plugin(name: "SourcerySwiftCodegenPlugin", package: "swift-sourcery-templates")]
+    ),
+    // A template beside the config wins over the shipped one of the same name.
+    // Excluded from the target's sources because SwiftPM has no rule for it.
+    .target(
+      name: "Local",
+      exclude: ["Mocks.swifttemplate"],
+      plugins: [.plugin(name: "SourcerySwiftCodegenPlugin", package: "swift-sourcery-templates")]
+    ),
+    // One direct root-package dependency: `args.testable` is unambiguous.
+    .testTarget(
+      name: "AppTests",
+      dependencies: ["App"],
+      plugins: [.plugin(name: "SourcerySwiftCodegenPlugin", package: "swift-sourcery-templates")]
+    ),
+    // Two: the plugin inserts nothing and names both.
+    .testTarget(
+      name: "AmbiguousTests",
+      dependencies: ["App", "Solo"],
+      plugins: [.plugin(name: "SourcerySwiftCodegenPlugin", package: "swift-sourcery-templates")]
+    ),
+  ]
+)

--- a/Checks/PluginFixture/Sources/App/.Sourcery.App.yml
+++ b/Checks/PluginFixture/Sources/App/.Sourcery.App.yml
@@ -1,0 +1,16 @@
+# The mixed shape of §4.1: the derived closure AND one entry the author picked.
+# Every comment in this file is part of the passthrough gate — the synthesized
+# copy has to carry them through unchanged.
+sources:
+  - ${SOURCERY_SOURCES}
+  - ${SOURCERY_TARGET_App}   # a subset the plugin must not decide, listed by hand
+templates:
+  - Mocks
+  - Component
+args:
+  import:
+    - ExternalKit
+    - Leaf
+    - Middle
+  excludedSwiftLintRules:
+    - line_length

--- a/Checks/PluginFixture/Sources/App/App.swift
+++ b/Checks/PluginFixture/Sources/App/App.swift
@@ -1,0 +1,17 @@
+import ExternalKit
+import Leaf
+import Middle
+
+/// The §6.1 shape. `profileID` is declared here, `cacheLimit` one module away,
+/// `save` two, and `report` two and in another package — so a mock that carries
+/// all four proves the closure reached every level.
+// sourcery: CreateMock
+protocol ProfilePersisting: Caching, Reporting {
+  var profileID: String { get }
+}
+
+/// The generated mock has to satisfy this, which is what turns a missing
+/// inherited requirement into a compile error rather than a silent gap.
+func acceptProfilePersisting(_ value: any ProfilePersisting) -> String {
+  value.profileID
+}

--- a/Checks/PluginFixture/Sources/Leaf/Leaf.swift
+++ b/Checks/PluginFixture/Sources/Leaf/Leaf.swift
@@ -1,0 +1,6 @@
+// Level 3 of the first-party chain. No annotation here: this module is not
+// scanned by a plugin that exports one level of the graph, which is the whole
+// point of the fixture.
+public protocol Persisting {
+  func save(_ value: String, key: String) throws
+}

--- a/Checks/PluginFixture/Sources/Local/.Sourcery.Local.yml
+++ b/Checks/PluginFixture/Sources/Local/.Sourcery.Local.yml
@@ -1,0 +1,4 @@
+sources:
+  - ${SOURCERY_SOURCES}
+templates:
+  - Mocks.swifttemplate

--- a/Checks/PluginFixture/Sources/Local/Local.swift
+++ b/Checks/PluginFixture/Sources/Local/Local.swift
@@ -1,0 +1,7 @@
+// This target ships its own Mocks.swifttemplate beside its config. Rule 2 of
+// §4.5 runs before rule 3, so the local file wins over the shipped template of
+// the same name and no mock is generated here at all.
+// sourcery: CreateMock
+protocol Shadowed {
+  func shadow()
+}

--- a/Checks/PluginFixture/Sources/Local/Mocks.swifttemplate
+++ b/Checks/PluginFixture/Sources/Local/Mocks.swifttemplate
@@ -1,0 +1,1 @@
+// PLUGIN-FIXTURE-LOCAL-TEMPLATE: the file beside the config ran, not the shipped Mocks.

--- a/Checks/PluginFixture/Sources/Middle/Middle.swift
+++ b/Checks/PluginFixture/Sources/Middle/Middle.swift
@@ -1,0 +1,8 @@
+import ExternalKit
+import Leaf
+
+// Level 2. `App` depends on this; `Leaf` and `ExternalKit` are one level deeper
+// still, which is the level with no expressible workaround before spec 001.
+public protocol Caching: Persisting {
+  var cacheLimit: Int { get }
+}

--- a/Checks/PluginFixture/Sources/Solo/.Sourcery.Solo.yml
+++ b/Checks/PluginFixture/Sources/Solo/.Sourcery.Solo.yml
@@ -1,0 +1,3 @@
+# Says only what to generate. `sources:` and `output:` are the plugin's (§4.6).
+templates:
+  - Mocks

--- a/Checks/PluginFixture/Sources/Solo/Solo.swift
+++ b/Checks/PluginFixture/Sources/Solo/Solo.swift
@@ -1,0 +1,6 @@
+// The zero-configuration case: one target, one annotated protocol, and a config
+// that says only what to generate.
+// sourcery: CreateMock
+protocol Greeting {
+  func greet(_ name: String) -> String
+}

--- a/Checks/PluginFixture/Sources/Verbatim/.Sourcery.Verbatim.yml
+++ b/Checks/PluginFixture/Sources/Verbatim/.Sourcery.Verbatim.yml
@@ -1,0 +1,10 @@
+# Today's shape, untouched: no placeholder, no bare name, both keys present.
+# The synthesized copy of this file must be byte-identical to it.
+sources:
+  - ${SOURCERY_TARGET_Verbatim}
+output: ${SOURCERY_OUTPUT_DIR}
+templates:
+  - ${SOURCERY_TEMPLATES}/Mocks.swifttemplate
+args:
+  import:
+    - Foundation

--- a/Checks/PluginFixture/Sources/Verbatim/Verbatim.swift
+++ b/Checks/PluginFixture/Sources/Verbatim/Verbatim.swift
@@ -1,0 +1,6 @@
+// The config beside this target names every path itself, so the synthesized copy
+// must come out byte-identical to it.
+// sourcery: CreateMock
+protocol Counting {
+  var count: Int { get }
+}

--- a/Checks/PluginFixture/Tests/AmbiguousTests/.Sourcery.Mocks.yml
+++ b/Checks/PluginFixture/Tests/AmbiguousTests/.Sourcery.Mocks.yml
@@ -1,0 +1,6 @@
+# Two candidate modules, so the plugin inserts no `args.testable` and says which
+# two it found. Both modules are imported normally instead.
+sources:
+  - ${SOURCERY_TARGET_AmbiguousTests}
+templates:
+  - Mocks

--- a/Checks/PluginFixture/Tests/AmbiguousTests/AmbiguousTests.swift
+++ b/Checks/PluginFixture/Tests/AmbiguousTests/AmbiguousTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+import App
+import Solo
+
+final class AmbiguousTests: XCTestCase {
+  func testTargetBuilds() {
+    XCTAssertTrue(true)
+  }
+}

--- a/Checks/PluginFixture/Tests/AppTests/.Sourcery.Mocks.yml
+++ b/Checks/PluginFixture/Tests/AppTests/.Sourcery.Mocks.yml
@@ -1,0 +1,9 @@
+# One direct root-package dependency, so `args.testable` is the plugin's — and it
+# has to land at the indentation `import:` already uses.
+sources:
+  - ${SOURCERY_TARGET_AppTests}
+templates:
+  - Mocks
+args:
+  import:
+    - Foundation

--- a/Checks/PluginFixture/Tests/AppTests/.Sourcery.Preset.yml
+++ b/Checks/PluginFixture/Tests/AppTests/.Sourcery.Preset.yml
@@ -1,0 +1,8 @@
+# Already names the module under test, so the plugin leaves `args:` alone.
+sources:
+  - ${SOURCERY_TARGET_AppTests}
+templates:
+  - Component
+args:
+  testable:
+    - App

--- a/Checks/PluginFixture/Tests/AppTests/AppTests.swift
+++ b/Checks/PluginFixture/Tests/AppTests/AppTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import App
+
+// `ProfilePersistingMock` is generated into `App` from the closure App reaches:
+// `profileID` is App's, `cacheLimit` is Middle's, `save` is Leaf's and `report`
+// is ExternalKit's. A mock missing any of them does not compile.
+final class AppTests: XCTestCase {
+  func testMockCarriesEveryInheritedRequirement() throws {
+    let mock = ProfilePersistingMock()
+    mock.profileID = "id"
+    try mock.save("value", key: "key")
+    mock.report("message")
+    XCTAssertEqual(mock.saveCallCount, 1)
+    XCTAssertEqual(mock.reportCallCount, 1)
+    XCTAssertEqual(acceptProfilePersisting(mock), "id")
+  }
+}

--- a/Checks/PluginFixtureRed/Collision/Package.swift
+++ b/Checks/PluginFixtureRed/Collision/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// A red control: this package must FAIL to build. Two configs of one target name the same template, so the two would put files declaring the same types on one compile path (§4.7).
+//
+// One package per control, not one package with four targets: build planning runs
+// every target's plugin, so a plan-time error in one target fails the build for
+// all of them and no `--target` can isolate it.
+let package = Package(
+  name: "Collision",
+  platforms: [
+    .macOS(.v13)
+  ],
+  dependencies: [
+    .package(name: "swift-sourcery-templates", path: "../../.."),
+  ],
+  targets: [
+    .target(
+      name: "Collision",
+      plugins: [.plugin(name: "SourcerySwiftCodegenPlugin", package: "swift-sourcery-templates")]
+    ),
+  ]
+)

--- a/Checks/PluginFixtureRed/Collision/Sources/Collision/.Sourcery.First.yml
+++ b/Checks/PluginFixtureRed/Collision/Sources/Collision/.Sourcery.First.yml
@@ -1,0 +1,4 @@
+sources:
+  - ${SOURCERY_SOURCES}
+templates:
+  - Mocks

--- a/Checks/PluginFixtureRed/Collision/Sources/Collision/.Sourcery.Second.yml
+++ b/Checks/PluginFixtureRed/Collision/Sources/Collision/.Sourcery.Second.yml
@@ -1,0 +1,6 @@
+# Same template, same target: one config's output would declare the same types as
+# the other's, so the plugin refuses both.
+sources:
+  - ${SOURCERY_SOURCES}
+templates:
+  - Mocks

--- a/Checks/PluginFixtureRed/Collision/Sources/Collision/Collision.swift
+++ b/Checks/PluginFixtureRed/Collision/Sources/Collision/Collision.swift
@@ -1,0 +1,4 @@
+// sourcery: CreateMock
+protocol CollisionProtocol {
+  func run()
+}

--- a/Checks/PluginFixtureRed/PackageKey/Package.swift
+++ b/Checks/PluginFixtureRed/PackageKey/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// A red control: this package must FAIL to build. It declares `package:` in place of `sources:`. The plugin must append no `sources:` block over it (§1.4/G, and the silent-override case of §1.4/I); Sourcery then fails on `package:`, which needs a toolchain the plugin sandbox does not give it.
+//
+// One package per control, not one package with four targets: build planning runs
+// every target's plugin, so a plan-time error in one target fails the build for
+// all of them and no `--target` can isolate it.
+let package = Package(
+  name: "PackageKey",
+  platforms: [
+    .macOS(.v13)
+  ],
+  dependencies: [
+    .package(name: "swift-sourcery-templates", path: "../../.."),
+  ],
+  targets: [
+    .target(
+      name: "PackageKey",
+      plugins: [.plugin(name: "SourcerySwiftCodegenPlugin", package: "swift-sourcery-templates")]
+    ),
+  ]
+)

--- a/Checks/PluginFixtureRed/PackageKey/Sources/PackageKey/.Sourcery.PackageKey.yml
+++ b/Checks/PluginFixtureRed/PackageKey/Sources/PackageKey/.Sourcery.PackageKey.yml
@@ -1,0 +1,9 @@
+# Declares its inputs with `package:`, which Sourcery accepts in place of
+# `sources:` (§1.4/G). The plugin must append no `sources:` block over it.
+package:
+  path: .
+  target:
+    - PackageKey
+output: ${SOURCERY_OUTPUT_DIR}
+templates:
+  - Mocks

--- a/Checks/PluginFixtureRed/PackageKey/Sources/PackageKey/PackageKey.swift
+++ b/Checks/PluginFixtureRed/PackageKey/Sources/PackageKey/PackageKey.swift
@@ -1,0 +1,4 @@
+// sourcery: CreateMock
+protocol PackageKeyProtocol {
+  func run()
+}

--- a/Checks/PluginFixtureRed/UnknownTemplate/Package.swift
+++ b/Checks/PluginFixtureRed/UnknownTemplate/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// A red control: this package must FAIL to build. Its `templates:` entry names neither a file beside the config nor a shipped template: the plugin warns and Sourcery then fails on it, which is the right outcome for a typo (§4.5 rule 4).
+//
+// One package per control, not one package with four targets: build planning runs
+// every target's plugin, so a plan-time error in one target fails the build for
+// all of them and no `--target` can isolate it.
+let package = Package(
+  name: "UnknownTemplate",
+  platforms: [
+    .macOS(.v13)
+  ],
+  dependencies: [
+    .package(name: "swift-sourcery-templates", path: "../../.."),
+  ],
+  targets: [
+    .target(
+      name: "UnknownTemplate",
+      plugins: [.plugin(name: "SourcerySwiftCodegenPlugin", package: "swift-sourcery-templates")]
+    ),
+  ]
+)

--- a/Checks/PluginFixtureRed/UnknownTemplate/Sources/UnknownTemplate/.Sourcery.UnknownTemplate.yml
+++ b/Checks/PluginFixtureRed/UnknownTemplate/Sources/UnknownTemplate/.Sourcery.UnknownTemplate.yml
@@ -1,0 +1,4 @@
+sources:
+  - ${SOURCERY_SOURCES}
+templates:
+  - Mocsk

--- a/Checks/PluginFixtureRed/UnknownTemplate/Sources/UnknownTemplate/UnknownTemplate.swift
+++ b/Checks/PluginFixtureRed/UnknownTemplate/Sources/UnknownTemplate/UnknownTemplate.swift
@@ -1,0 +1,4 @@
+// sourcery: CreateMock
+protocol UnknownTemplateProtocol {
+  func run()
+}

--- a/Checks/PluginFixtureRed/WrongOutput/Package.swift
+++ b/Checks/PluginFixtureRed/WrongOutput/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// A red control: this package must FAIL to build. Its `output:` names a directory the build does not collect from, which the plugin rejects at plan time rather than generating into a directory nothing reads (D12).
+//
+// One package per control, not one package with four targets: build planning runs
+// every target's plugin, so a plan-time error in one target fails the build for
+// all of them and no `--target` can isolate it.
+let package = Package(
+  name: "WrongOutput",
+  platforms: [
+    .macOS(.v13)
+  ],
+  dependencies: [
+    .package(name: "swift-sourcery-templates", path: "../../.."),
+  ],
+  targets: [
+    .target(
+      name: "WrongOutput",
+      plugins: [.plugin(name: "SourcerySwiftCodegenPlugin", package: "swift-sourcery-templates")]
+    ),
+  ]
+)

--- a/Checks/PluginFixtureRed/WrongOutput/Sources/WrongOutput/.Sourcery.WrongOutput.yml
+++ b/Checks/PluginFixtureRed/WrongOutput/Sources/WrongOutput/.Sourcery.WrongOutput.yml
@@ -1,0 +1,5 @@
+sources:
+  - ${SOURCERY_SOURCES}
+output: /tmp/plugin-fixture-red-wrong-output
+templates:
+  - Mocks

--- a/Checks/PluginFixtureRed/WrongOutput/Sources/WrongOutput/WrongOutput.swift
+++ b/Checks/PluginFixtureRed/WrongOutput/Sources/WrongOutput/WrongOutput.swift
@@ -1,0 +1,4 @@
+// sourcery: CreateMock
+protocol WrongOutputProtocol {
+  func run()
+}

--- a/Checks/README.md
+++ b/Checks/README.md
@@ -1,4 +1,10 @@
-# Checks — the fast lane
+# Checks — the fast lane, and the plugin lane
+
+`run-checks.sh` and `run-cli-checks.sh` cover the templates and the CLI;
+`run-plugin-checks.sh` covers the build-tool plugin over its own fixture packages.
+The fast lane comes first.
+
+## The fast lane
 
 `./run-checks.sh` runs every template in its `TEMPLATES` list over
 [`Fixtures/`](Fixtures) and holds the results to four gates. It needs no
@@ -100,15 +106,7 @@ Four constructs are refused rather than emitted — `static`, `init` and
 controls rather than fixtures: generation fails, so a fixture carrying one would
 fail the whole lane.
 
-## What this lane does not cover
-
-RxSwift smart defaults (`Single`, `Observable`, `AnyObserver`, `Disposable`),
-RIBs protocol annotation, type erasure, and the SPM build-tool plugin. Those
-need the dependencies and the simulator, and they live in
-[`Examples/ExampleProjectSpm`](../Examples/ExampleProjectSpm) — run
-`./test-ios.sh` there. Run both before cutting a tag.
-
-## Adding a check
+## Adding a check to the fast lane
 
 1. Add the protocol shape to the fixture file it belongs in. If it comes from a
    consumer, say which one in a comment — a fixture nobody has in production is
@@ -117,3 +115,80 @@ need the dependencies and the simulator, and they live in
    the review: it is the only place the generated output is visible.
 3. Add a behaviour check if the shape has runtime semantics (a stream to drive,
    a suspension to observe, a counter to assert).
+
+## What this lane does not cover
+
+RxSwift smart defaults (`Single`, `Observable`, `AnyObserver`, `Disposable`),
+RIBs protocol annotation and type erasure. Those need the dependencies and the
+simulator, and they live in
+[`Examples/ExampleProjectSpm`](../Examples/ExampleProjectSpm) — run
+`./test-ios.sh` there. The build-tool plugin has a lane of its own, below. Run
+all of them before cutting a tag.
+
+# The plugin lane
+
+```bash
+Checks/run-plugin-checks.sh          # ~1 min cold, no simulator
+Checks/run-plugin-checks.sh --keep   # keep the plugin outputs too (faster, less cold)
+```
+
+A build-tool plugin may not depend on a library target, so no test target can
+import [`SourcerySwiftCodegenPlugin.swift`](../Plugins/SourcerySwiftCodegenPlugin/SourcerySwiftCodegenPlugin.swift).
+Every gate is therefore black-box: build a fixture package, then read the
+synthesized configs under `.sourceryConfigs/`, the generated code under
+`.generatedFiles/`, and the build's own outcome.
+
+## The green package
+
+[`PluginFixture/`](PluginFixture) must build. Its shape is the chain
+`App` → `Middle` → `Leaf`, with `ExternalKit` arriving through `Middle` from a
+second package — so `Leaf` and `ExternalKit` sit two levels from `App`, which is
+exactly the distance no `SOURCERY_TARGET_*` variable reaches.
+
+| target | config shape it carries |
+| --- | --- |
+| `App` | the placeholder plus one hand-listed entry, and two shipped templates named by name from one config |
+| `Solo` | zero configuration: `templates:` and nothing else |
+| `Verbatim` | declares every path itself — the copy must be byte-identical |
+| `Local` | ships its own `Mocks.swifttemplate` beside its config, which has to outrank the shipped one |
+| `AppTests` | a test target with one direct root-package dependency, and *two* configs |
+| `AmbiguousTests` | a test target with two, so `args.testable` cannot be derived |
+
+| gate | what it proves |
+| --- | --- |
+| **splice** | `${SOURCERY_SOURCES}` expands to one quoted, absolute directory per module in the closure, sorted, with `Leaf` and `ExternalKit` present — the case no env var can express |
+| **passthrough** | every other line of the config, comments and blank lines included, survives in order |
+| **defaults** | a config carrying only `templates:` gains a `sources:` block holding the closure and an `output:` holding the absolute output directory, and generates |
+| **no-defaults** | a config declaring both keys is copied byte for byte |
+| **testable** | one direct root-package dependency inserts `testable: [<module>]` at the siblings' indentation; two insert nothing and name both; a config that already declares it is untouched; no non-test target gets one |
+| **bare name** | `- Mocks` resolves to the shipped template; a file beside the config wins over the shipped one of the same name, and it is the local one that runs |
+| **generation** | the mock for the `Leaf`-refining protocol carries `save` (two modules away), `report` (two modules away, another package), `cacheLimit` and `profileID`, and the fixture's tests pass against it |
+| **determinism** | a second build leaves every synthesized config byte-identical — the prebuild command re-runs every build, and a config that churns invalidates Sourcery's cache every time |
+| **shared cache** | a target with two configs, rebuilt with the caches dropped, produces the same output both times |
+
+## The red controls
+
+[`PluginFixtureRed/`](PluginFixtureRed) holds four packages that must **fail**,
+each matched on its diagnostic. One package each: build planning runs every
+target's plugin, so a plan-time error in one target fails the build for all of
+them and no `--target` can isolate it.
+
+| package | must fail because |
+| --- | --- |
+| `WrongOutput` | its `output:` names a directory the build does not collect from — the error names both paths |
+| `Collision` | two configs of one target name the same template, so both would put files declaring the same types on one compile path |
+| `UnknownTemplate` | its `templates:` entry names nothing; the plugin warns and lists the shipped templates, then Sourcery fails |
+| `PackageKey` | it declares `package:` in place of `sources:`; the gate is that **no** `sources:` block was appended over it |
+
+A red control that stops failing is a gate that stopped gating, so each one
+matches on the diagnostic text, not merely on a non-zero exit.
+
+## Adding a check to the plugin lane
+
+1. Decide whether the new rule is green or red. Green means a config shape that
+   must work: add a target to `PluginFixture` carrying it, one target per shape,
+   so each target's failure names the shape it broke.
+2. Red means a config the plugin must refuse: add a package under
+   `PluginFixtureRed/`, never a target beside a green one — a plan-time error
+   fails the whole package, so a red control has to be alone.
+3. Assert on the diagnostic text, not just on the exit status.

--- a/Checks/run-plugin-checks.sh
+++ b/Checks/run-plugin-checks.sh
@@ -1,0 +1,466 @@
+#!/bin/bash
+#
+# Plugin checks — the build-tool plugin, black-box.
+#
+# A plugin target cannot be imported by a test target (spec 001 §1.5: a plugin
+# may not depend on a library), so there is no unit test that can reach any of
+# this file's types. Every gate below builds a fixture package and reads what the
+# plugin wrote: the synthesized configs under `.sourceryConfigs/`, the generated
+# code under `.generatedFiles/`, and the build's own success or failure.
+#
+#   green lane   Checks/PluginFixture — a package that must build, carrying one
+#                target per config shape the spec defines, and a three-level
+#                dependency chain (App → Middle → Leaf, with ExternalKit arriving
+#                through Middle from a second package) so the closure has
+#                something to reach that no env var can name.
+#   red lane     Checks/PluginFixtureRed/* — four packages, each of which must
+#                FAIL, for a reason this script matches on. One package per
+#                control: build planning runs every target's plugin, so a
+#                plan-time error in one target fails the build for all of them.
+#
+# Usage:
+#   Checks/run-plugin-checks.sh            # run the gates
+#   Checks/run-plugin-checks.sh --keep     # keep the resolved dependencies AND
+#                                          # the plugin outputs (faster, but the
+#                                          # cold-cache gate no longer runs cold)
+#
+# Needs no simulator. It does need the toolchain and, once, the network: the
+# fixtures resolve this package, which pulls swift-argument-parser and the pinned
+# Sourcery artifact bundle. Both are cached under .build/plugin-checks/cache and
+# reused by all five fixture packages.
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GIT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+WORK_DIR="$GIT_ROOT/.build/plugin-checks"
+CACHE_DIR="$WORK_DIR/cache"
+FIXTURE_DIR="$SCRIPT_DIR/PluginFixture"
+FIXTURE_SCRATCH="$WORK_DIR/fixture"
+RED_DIR="$SCRIPT_DIR/PluginFixtureRed"
+
+KEEP=0
+[ "$1" = "--keep" ] && KEEP=1
+
+mkdir -p "$CACHE_DIR"
+
+FAILURES=0
+fail() { echo "  FAIL: $1"; FAILURES=$((FAILURES + 1)); }
+pass() { echo "  ok: $1"; }
+
+SWIFT_FLAGS=(--cache-path "$CACHE_DIR")
+
+# ── Helpers ───────────────────────────────────────────────────────
+
+# The synthesized copy of <config> for <target>.
+synthesized() {
+  find "$FIXTURE_SCRATCH/plugins/outputs" -path "*/$1/*/.sourceryConfigs/$2" -type f 2>/dev/null | head -1
+}
+
+# A file Sourcery generated for <target> from <config-directory>.
+generated() {
+  find "$FIXTURE_SCRATCH/plugins/outputs" -path "*/$1/*/.generatedFiles/$2/$3" -type f 2>/dev/null | head -1
+}
+
+# The lines of a `sources:`/`templates:` block that the plugin wrote: quoted
+# absolute paths, one per line, unquoted here for legibility.
+block_paths() {   # file key
+  awk -v key="$2" '
+    $0 ~ "^" key ":" { inblock = 1; next }
+    /^[A-Za-z_]/     { inblock = 0 }
+    inblock && /^[ \t]*- "/ {
+      line = $0
+      sub(/^[ \t]*- "/, "", line)
+      sub(/"[ \t]*$/, "", line)
+      print line
+    }
+  ' "$1"
+}
+
+# Every line of <original> is present in <synthesized>, in the same order, except
+# the lines named after the two file arguments — which are exactly the lines the
+# plugin is allowed to rewrite. This is the passthrough gate: a config's comments,
+# blank lines and untouched keys have to survive byte for byte.
+check_passthrough() {
+  local original="$1" synthesized="$2"; shift 2
+  local skiplist="$WORK_DIR/passthrough-rewritable"
+  printf '%s\n' "$@" > "$skiplist"
+  awk -v skipfile="$skiplist" -v origfile="$original" '
+    FILENAME == skipfile { skip[$0] = 1; next }
+    FILENAME == origfile { orig[++o] = $0; next }
+    { syn[++s] = $0 }
+    END {
+      j = 1
+      for (i = 1; i <= o; i++) {
+        if (orig[i] in skip) continue
+        found = 0
+        while (j <= s) { if (syn[j++] == orig[i]) { found = 1; break } }
+        if (!found) { print "missing or out of order: [" orig[i] "]"; exit 1 }
+      }
+    }
+  ' "$skiplist" "$original" "$synthesized"
+}
+
+# ── 0. Typecheck both plugin API surfaces ─────────────────────────
+# The fixture packages exercise the SPM path only. `XcodeBuildToolPlugin` lives
+# behind `#if canImport(XcodeProjectPlugin)`, which is false in a package build —
+# so without this gate the Xcode half of the file is never compiled by anything,
+# and it degrades silently rather than safely. Xcode ships an XcodeProjectPlugin
+# module beside SwiftPM; compiling against it is the whole check.
+echo "── typecheck ──"
+PLUGIN_SOURCE="$GIT_ROOT/Plugins/SourcerySwiftCodegenPlugin/SourcerySwiftCodegenPlugin.swift"
+XCODE_PLUGIN_API="$(xcode-select -p)/../SharedFrameworks/SwiftPM.framework/Versions/A/SharedSupport/PluginAPI"
+TOOLCHAIN_PLUGIN_API="$(dirname "$(dirname "$(xcrun --find swift)")")/lib/swift/pm/PluginAPI"
+
+typecheck_plugin() {   # label search-path
+  local label="$1" search_path="$2"
+  if [ ! -d "$search_path" ]; then
+    echo "  skipped $label: no PluginAPI at $search_path"
+    return
+  fi
+  local log="$WORK_DIR/typecheck-$label.log"
+  # -package-description-version is what SwiftPM passes; without it the API's
+  # own availability annotations make `sourceModule` and friends unavailable.
+  if xcrun swiftc -typecheck -swift-version 5 \
+       -I "$search_path" \
+       -package-description-version 5.9 \
+       -parse-as-library \
+       "$PLUGIN_SOURCE" > "$log" 2>&1; then
+    pass "$label: clean"
+  else
+    head -20 "$log"
+    fail "$label: the plugin does not compile against this PluginAPI"
+  fi
+}
+
+mkdir -p "$WORK_DIR"
+typecheck_plugin "spm-only" "$TOOLCHAIN_PLUGIN_API"
+typecheck_plugin "with-xcodeprojectplugin" "$XCODE_PLUGIN_API"
+echo ""
+
+# ── 1. Build the green fixture, cold ──────────────────────────────
+echo "── building the fixture ──"
+if [ "$KEEP" = "0" ]; then
+  # Keep the resolved dependencies and the downloaded artifact bundle; drop
+  # everything the plugin produced, so the caches below really are cold.
+  rm -rf "$FIXTURE_SCRATCH/plugins/outputs"
+fi
+
+BUILD_LOG="$WORK_DIR/fixture-build.log"
+mkdir -p "$WORK_DIR"
+COLD_START=$SECONDS
+if ! swift build --package-path "$FIXTURE_DIR" --scratch-path "$FIXTURE_SCRATCH" \
+      "${SWIFT_FLAGS[@]}" --build-tests -v > "$BUILD_LOG" 2>&1; then
+  tail -30 "$BUILD_LOG"
+  echo "FAIL: the fixture package did not build — every gate below depends on it"
+  exit 1
+fi
+COLD_SECONDS=$((SECONDS - COLD_START))
+echo "  built in ${COLD_SECONDS}s (cold plugin outputs)"
+
+APP_CONFIG="$(synthesized App .Sourcery.App.yml)"
+SOLO_CONFIG="$(synthesized Solo .Sourcery.Solo.yml)"
+VERBATIM_CONFIG="$(synthesized Verbatim .Sourcery.Verbatim.yml)"
+LOCAL_CONFIG="$(synthesized Local .Sourcery.Local.yml)"
+APPTESTS_MOCKS="$(synthesized AppTests .Sourcery.Mocks.yml)"
+APPTESTS_PRESET="$(synthesized AppTests .Sourcery.Preset.yml)"
+AMBIGUOUS_CONFIG="$(synthesized AmbiguousTests .Sourcery.Mocks.yml)"
+
+for f in "$APP_CONFIG" "$SOLO_CONFIG" "$VERBATIM_CONFIG" "$LOCAL_CONFIG" \
+         "$APPTESTS_MOCKS" "$APPTESTS_PRESET" "$AMBIGUOUS_CONFIG"; do
+  [ -n "$f" ] && [ -f "$f" ] || { echo "FAIL: the plugin wrote no synthesized config where one was expected"; exit 1; }
+done
+
+# ── 2. Splice ─────────────────────────────────────────────────────
+# The closure App reaches is App, Middle, Leaf and ExternalKit. Leaf is two
+# levels down and ExternalKit two levels down in another package: neither has a
+# SOURCERY_TARGET_* var, so neither could be listed before this spec.
+echo ""
+echo "── splice ──"
+APP_SOURCES="$(block_paths "$APP_CONFIG" sources)"
+for module in App Middle Leaf ExternalKit; do
+  if printf '%s\n' "$APP_SOURCES" | grep -qE "/$module\$"; then
+    pass "the closure reached $module"
+  else
+    fail "the closure is missing $module"
+  fi
+done
+if [ "$(printf '%s\n' "$APP_SOURCES" | wc -l | tr -d ' ')" = "4" ]; then
+  pass "four directories, one per source module"
+else
+  fail "expected four directories, got: $(printf '%s\n' "$APP_SOURCES" | tr '\n' ' ')"
+fi
+if [ "$APP_SOURCES" = "$(printf '%s\n' "$APP_SOURCES" | LC_ALL=C sort)" ]; then
+  pass "sorted lexicographically"
+else
+  fail "the spliced directories are not sorted — the config is not stable between resolutions"
+fi
+if printf '%s\n' "$APP_SOURCES" | grep -qv '^/'; then
+  fail "a spliced source entry is not an absolute path"
+else
+  pass "every spliced entry is absolute"
+fi
+# The author's own entry survives beside the derived ones.
+if grep -qF '${SOURCERY_TARGET_App}   # a subset the plugin must not decide, listed by hand' "$APP_CONFIG"; then
+  pass "the hand-listed entry beside the placeholder is untouched, comment and all"
+else
+  fail "the hand-listed source entry did not survive the splice"
+fi
+
+# ── 3. Passthrough ────────────────────────────────────────────────
+echo ""
+echo "── passthrough ──"
+if check_passthrough "$FIXTURE_DIR/Sources/App/.Sourcery.App.yml" "$APP_CONFIG" \
+     '  - ${SOURCERY_SOURCES}' '  - Mocks' '  - Component'; then
+  pass "every line but the placeholder and the two template names is carried through verbatim"
+else
+  fail "the synthesized config does not carry the author's lines through"
+fi
+
+# ── 4. Defaults ───────────────────────────────────────────────────
+# A config that says only what to generate is a complete config: `sources:` and
+# `output:` are mandatory to Sourcery and have one right answer each (§4.6).
+echo ""
+echo "── defaults ──"
+SOLO_SOURCES="$(block_paths "$SOLO_CONFIG" sources)"
+if [ "$SOLO_SOURCES" = "$FIXTURE_DIR/Sources/Solo" ]; then
+  pass "sources: appended, holding the closure"
+else
+  fail "sources: was not appended as expected (got '$SOLO_SOURCES')"
+fi
+SOLO_OUTPUT="$(grep '^output:' "$SOLO_CONFIG" | sed 's/^output: "//; s/"$//')"
+if [ -d "$SOLO_OUTPUT" ] && [ -f "$SOLO_OUTPUT/Mocks.generated.swift" ]; then
+  pass "output: appended as an absolute path, and Sourcery generated into it"
+else
+  fail "output: was not appended to an existing directory holding the generated file (got '$SOLO_OUTPUT')"
+fi
+if grep -q 'class GreetingMock' "$SOLO_OUTPUT/Mocks.generated.swift" 2>/dev/null; then
+  pass "the zero-configuration target generated its mock"
+else
+  fail "the zero-configuration target generated no mock"
+fi
+
+# ── 5. No-defaults ────────────────────────────────────────────────
+# A config that declares its inputs and its output keeps them — including one
+# that declares `package:` rather than `sources:`, which Sourcery accepts in its
+# place. Appending over either would override a deliberate choice, silently.
+echo ""
+echo "── no-defaults ──"
+if diff -q "$FIXTURE_DIR/Sources/Verbatim/.Sourcery.Verbatim.yml" "$VERBATIM_CONFIG" > /dev/null; then
+  pass "a config declaring everything comes out byte-identical"
+else
+  diff -u "$FIXTURE_DIR/Sources/Verbatim/.Sourcery.Verbatim.yml" "$VERBATIM_CONFIG" | head -20
+  fail "a config declaring everything was rewritten"
+fi
+
+# ── 6. Testable ───────────────────────────────────────────────────
+echo ""
+echo "── testable ──"
+if grep -qx '  testable: \[App\]' "$APPTESTS_MOCKS"; then
+  pass "one direct root-package dependency: testable inserted at the siblings' indentation"
+else
+  fail "testable was not inserted for the unambiguous test target"
+  grep -A3 '^args:' "$APPTESTS_MOCKS" || true
+fi
+if diff -q "$FIXTURE_DIR/Tests/AppTests/.Sourcery.Preset.yml" \
+           <(sed 's|^templates:|templates:|' "$APPTESTS_PRESET") > /dev/null 2>&1 \
+   || [ "$(grep -cE '^[[:space:]]*testable[[:space:]]*:' "$APPTESTS_PRESET")" = "1" ]; then
+  pass "a config that already names testable is left alone"
+else
+  fail "a config that already declares testable was edited"
+fi
+if grep -qE '^[[:space:]]*testable[[:space:]]*:' "$AMBIGUOUS_CONFIG"; then
+  fail "testable was inserted for a test target with two candidate modules"
+else
+  pass "two candidates: nothing inserted"
+fi
+if grep -qE 'AmbiguousTests.*directly depends on 2 root-package modules \(App, Solo\)' "$BUILD_LOG" \
+   || grep -qE 'directly depends on 2 root-package modules \(App, Solo\)' "$BUILD_LOG"; then
+  pass "and the build log names both candidates"
+else
+  fail "the build log does not name the two candidate modules"
+fi
+for target_config in "$APP_CONFIG" "$SOLO_CONFIG" "$LOCAL_CONFIG"; do
+  if grep -qE '^[[:space:]]*testable[[:space:]]*:' "$target_config"; then
+    fail "testable was inserted into a non-test target's config ($target_config)"
+  fi
+done
+pass "no non-test target got a testable"
+
+# ── 7. Bare names ─────────────────────────────────────────────────
+echo ""
+echo "── bare name ──"
+APP_TEMPLATES="$(block_paths "$APP_CONFIG" templates)"
+if [ "$APP_TEMPLATES" = "$GIT_ROOT/templates/Mocks.swifttemplate
+$GIT_ROOT/templates/Component.swifttemplate" ]; then
+  pass "- Mocks and - Component resolved to the shipped files, in the order written"
+else
+  fail "bare template names did not resolve to the shipped templates (got: $APP_TEMPLATES)"
+fi
+LOCAL_TEMPLATE="$(block_paths "$LOCAL_CONFIG" templates)"
+if [ "$LOCAL_TEMPLATE" = "$FIXTURE_DIR/Sources/Local/Mocks.swifttemplate" ]; then
+  pass "a template beside the config wins over the shipped one of the same name"
+else
+  fail "the template beside the config did not win (got '$LOCAL_TEMPLATE')"
+fi
+LOCAL_OUT="$(generated Local Sourcery.Local Mocks.generated.swift)"
+if [ -n "$LOCAL_OUT" ] && grep -q 'PLUGIN-FIXTURE-LOCAL-TEMPLATE' "$LOCAL_OUT"; then
+  pass "and it is the local template that ran"
+else
+  fail "the shipped Mocks template ran where the local one should have"
+fi
+
+# ── 8. Generation ─────────────────────────────────────────────────
+# The §6.1 failure, at fast-lane speed: `ProfilePersisting` refines `Caching`
+# (Middle), `Persisting` (Leaf, two levels) and `Reporting` (ExternalKit, two
+# levels and another package). A mock missing any of them does not compile, and
+# the specs below assert it records.
+echo ""
+echo "── generation ──"
+APP_MOCK="$(generated App Sourcery.App Mocks.generated.swift)"
+if [ -z "$APP_MOCK" ]; then
+  fail "no mock was generated for App"
+else
+  for requirement in "func save(" "func report(" "var cacheLimit" "var profileID"; do
+    if grep -qF "$requirement" "$APP_MOCK"; then
+      pass "the mock carries '$requirement'"
+    else
+      fail "the mock is missing '$requirement' — the closure did not reach the module declaring it"
+    fi
+  done
+fi
+if [ -n "$(generated App Sourcery.App Component.generated.swift)" ]; then
+  pass "one config, two templates, two generated files"
+else
+  fail "the second template of App's config generated nothing"
+fi
+if swift test --package-path "$FIXTURE_DIR" --scratch-path "$FIXTURE_SCRATCH" \
+     "${SWIFT_FLAGS[@]}" > "$WORK_DIR/fixture-test.log" 2>&1; then
+  pass "the fixture's specs pass against the generated mock"
+else
+  tail -20 "$WORK_DIR/fixture-test.log"
+  fail "the fixture's specs did not pass"
+fi
+
+# ── 9. Determinism ────────────────────────────────────────────────
+# The prebuild command re-runs on every build, so whatever the plugin writes at
+# plan time has to be byte-identical between runs that resolve the same graph, or
+# Sourcery's cache is invalidated every time (§1.5).
+echo ""
+echo "── determinism ──"
+SNAPSHOT="$WORK_DIR/configs-before"
+rm -rf "$SNAPSHOT"; mkdir -p "$SNAPSHOT"
+i=0
+while IFS= read -r config; do
+  i=$((i + 1))
+  cp "$config" "$SNAPSHOT/$i-$(basename "$config")"
+done < <(find "$FIXTURE_SCRATCH/plugins/outputs" -path "*/.sourceryConfigs/*" -type f | sort)
+
+WARM_START=$SECONDS
+swift build --package-path "$FIXTURE_DIR" --scratch-path "$FIXTURE_SCRATCH" \
+  "${SWIFT_FLAGS[@]}" --build-tests > "$WORK_DIR/fixture-rebuild.log" 2>&1
+WARM_SECONDS=$((SECONDS - WARM_START))
+
+DRIFT=0
+i=0
+while IFS= read -r config; do
+  i=$((i + 1))
+  if ! diff -q "$SNAPSHOT/$i-$(basename "$config")" "$config" > /dev/null; then
+    diff -u "$SNAPSHOT/$i-$(basename "$config")" "$config" | head -10
+    DRIFT=$((DRIFT + 1))
+  fi
+done < <(find "$FIXTURE_SCRATCH/plugins/outputs" -path "*/.sourceryConfigs/*" -type f | sort)
+if [ "$DRIFT" = "0" ]; then
+  pass "$i synthesized configs, all byte-identical on a second build (warm: ${WARM_SECONDS}s)"
+else
+  fail "$DRIFT synthesized config(s) changed between two builds of the same graph"
+fi
+
+# ── 10. The shared per-target cache and build directory ────────────
+# Open question from §7, measured rather than argued: a target's configs share one
+# --cacheBasePath and one --buildPath. AppTests carries two. Build it again and
+# report whether the two runs interfered — a Sourcery error, a cache-recovery
+# line, or a change in what was generated.
+echo ""
+echo "── shared cache (two configs, one target) ──"
+APPTESTS_MOCK_OUT="$(generated AppTests Sourcery.Mocks Mocks.generated.swift)"
+APPTESTS_COMPONENT_OUT="$(generated AppTests Sourcery.Preset Component.generated.swift)"
+if [ -n "$APPTESTS_MOCK_OUT" ] && [ -n "$APPTESTS_COMPONENT_OUT" ]; then
+  pass "both configs of one target generated, into directories of their own"
+else
+  fail "a target with two configs did not produce both outputs"
+fi
+cp "$APPTESTS_MOCK_OUT" "$WORK_DIR/apptests-mocks-before" 2>/dev/null || true
+cp "$APPTESTS_COMPONENT_OUT" "$WORK_DIR/apptests-component-before" 2>/dev/null || true
+INTERFERENCE=0
+for run in 1 2; do
+  rm -rf "$FIXTURE_SCRATCH"/plugins/outputs/*/AppTests/*/SourcerySwiftCodegenPlugin/.sourceryCaches
+  swift build --package-path "$FIXTURE_DIR" --scratch-path "$FIXTURE_SCRATCH" \
+    "${SWIFT_FLAGS[@]}" --build-tests > "$WORK_DIR/fixture-shared-cache-$run.log" 2>&1 \
+    || { fail "build $run of the two-config target failed"; INTERFERENCE=1; }
+  if grep -qiE "recovering with a full rebuild|cache.*corrupt" "$WORK_DIR/fixture-shared-cache-$run.log"; then
+    fail "run $run reported a cache problem"
+    INTERFERENCE=1
+  fi
+done
+if ! diff -q "$WORK_DIR/apptests-mocks-before" "$(generated AppTests Sourcery.Mocks Mocks.generated.swift)" > /dev/null \
+   || ! diff -q "$WORK_DIR/apptests-component-before" "$(generated AppTests Sourcery.Preset Component.generated.swift)" > /dev/null; then
+  fail "the two configs of one target produced different output on a rebuild"
+  INTERFERENCE=1
+fi
+[ "$INTERFERENCE" = "0" ] && pass "two cold-cache rebuilds, no interference between the two configs"
+
+# ── 11. Red controls ──────────────────────────────────────────────
+# Each of these must fail, and fail for the reason named. A red control that
+# stops failing is a gate that stopped gating.
+echo ""
+echo "── red controls ──"
+red_control() {   # name expected-pattern description
+  local name="$1" pattern="$2" description="$3"
+  local log="$WORK_DIR/red-$name.log"
+  if swift build --package-path "$RED_DIR/$name" --scratch-path "$WORK_DIR/red/$name" \
+       "${SWIFT_FLAGS[@]}" > "$log" 2>&1; then
+    fail "$name built, and it must not: $description"
+    return
+  fi
+  if grep -qE "$pattern" "$log"; then
+    pass "$name fails: $description"
+  else
+    tail -15 "$log"
+    fail "$name failed, but not with the expected diagnostic ($pattern)"
+  fi
+}
+
+red_control WrongOutput \
+  "\`output:\` resolves to '/tmp/plugin-fixture-red-wrong-output', but the build collects generated files only from" \
+  "an output: the build does not collect from is named, with both paths, and stops the build"
+red_control Collision \
+  "\.Sourcery\.First\.yml and \.Sourcery\.Second\.yml both generate 'Mocks\.generated\.swift'" \
+  "two configs of one target naming one template are refused by name, not silently overwritten"
+red_control UnknownTemplate \
+  "template 'Mocsk' is neither a file beside the config nor a shipped template" \
+  "an unresolvable template name warns, lists the shipped templates, and then fails"
+red_control PackageKey \
+  "Invalid sources|fatalError|package" \
+  "a config declaring package: is left alone and fails on its own terms"
+
+# ...and the last one has a second half: the plugin must not have appended
+# `sources:` over the author's `package:`.
+PACKAGEKEY_CONFIG="$(find "$WORK_DIR/red/PackageKey" -path "*/.sourceryConfigs/*" -type f 2>/dev/null | head -1)"
+if [ -n "$PACKAGEKEY_CONFIG" ] && ! grep -q '^sources:' "$PACKAGEKEY_CONFIG"; then
+  pass "and no sources: block was appended over the author's package:"
+elif [ -z "$PACKAGEKEY_CONFIG" ]; then
+  fail "PackageKey wrote no synthesized config to inspect"
+else
+  fail "a sources: block was appended over a config that declares package:"
+fi
+
+# ── Result ────────────────────────────────────────────────────────
+echo ""
+if [ "$FAILURES" = "0" ]; then
+  echo "ALL PLUGIN CHECKS PASSED  (cold ${COLD_SECONDS}s, warm ${WARM_SECONDS}s)"
+else
+  echo "$FAILURES CHECK(S) FAILED"
+  exit 1
+fi

--- a/Examples/ExampleProjectSpm/Package.swift
+++ b/Examples/ExampleProjectSpm/Package.swift
@@ -18,9 +18,14 @@ let package = Package(
     .package(name: "swift-sourcery-templates", path: "../.."),
   ],
   targets: [
+    // Two levels below the test target: `ExampleProjectSpmTests` depends on
+    // `ExampleProjectSpm`, which depends on this. No env var names it, so the
+    // config can only reach it through ${SOURCERY_SOURCES}.
+    .target(name: "ExampleProjectSpmCore"),
     .target(
       name: "ExampleProjectSpm",
       dependencies: [
+        "ExampleProjectSpmCore",
         .product(name: "Alamofire", package: "Alamofire"),
         .product(name: "RIBs", package: "RIBs"),
         .product(name: "RxSwift", package: "RxSwift"),

--- a/Examples/ExampleProjectSpm/Sources/ExampleProjectSpm/.Sourcery.TypeErase.yml
+++ b/Examples/ExampleProjectSpm/Sources/ExampleProjectSpm/.Sourcery.TypeErase.yml
@@ -1,12 +1,13 @@
-# package:
-#   path: ../.. #${SOURCERY_PACKAGE_PATH}
-#   target:
-#     - ExampleProjectSpm
-sources:
-  - ${SOURCERY_TARGET_ExampleProjectSpm}
-output: ${SOURCERY_OUTPUT_DIR}
+# The zero-configuration shape: this config names two templates and the arguments
+# they need, and says nothing about where to read or where to write. The closure
+# is a superset of this target's own sources, and the output directory is the one
+# the build collects from — both are the plugin's to supply (spec 001 §4.6).
+#
+# Two templates from one config, so Sourcery writes TypeErase.generated.swift and
+# Component.generated.swift side by side (§1.4/F).
 templates:
-  - ${GIT_ROOT}/templates/TypeErase.swifttemplate
+  - TypeErase
+  - Component
 args:
   import:
     - RIBs

--- a/Examples/ExampleProjectSpm/Sources/ExampleProjectSpm/Protocols/Protocols.swift
+++ b/Examples/ExampleProjectSpm/Sources/ExampleProjectSpm/Protocols/Protocols.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import UIKit
+import ExampleProjectSpmCore
 import RxSwift
 import Alamofire // for `Result`
 import SwiftUI
@@ -433,4 +434,18 @@ protocol EscapingClosureService: AnyObject {
     using transformer: (String) -> String,
     completion: @escaping (_ output: String) -> Void
   )
+}
+
+// MARK: - Refining a protocol from another module
+//
+// `Persisting` lives in `ExampleProjectSpmCore`, which the test target reaches
+// only through this one. Sourcery only knows the declarations it parses, so a
+// mock generated without `ExampleProjectSpmCore` in the source set carries
+// `profileID` and not `save` — and the failure surfaces as "type
+// 'ProfilePersistingMock' does not conform to protocol 'ProfilePersisting'" in
+// the consumer's build, never here. ${SOURCERY_SOURCES} is what closes it.
+
+/// sourcery: CreateMock
+protocol ProfilePersisting: Persisting {
+    var profileID: String { get }
 }

--- a/Examples/ExampleProjectSpm/Sources/ExampleProjectSpmCore/Persisting.swift
+++ b/Examples/ExampleProjectSpm/Sources/ExampleProjectSpmCore/Persisting.swift
@@ -1,0 +1,18 @@
+//
+//  Persisting.swift
+//  ExampleProjectSpmCore
+//
+//  A module `ExampleProjectSpmTests` reaches only through `ExampleProjectSpm`.
+//  Nothing here is annotated: the point is that a protocol *refining* this one,
+//  one module away, generates a mock that has to carry these requirements too.
+//  Before the plugin derived its own source closure there was no
+//  `SOURCERY_TARGET_*` var naming this directory, so there was no way to write a
+//  config that scanned it — the pitfall CONTRIBUTING describes as surfacing only
+//  in a consumer's build.
+//
+
+import Foundation
+
+public protocol Persisting {
+    func save(_ data: Data, key: String) throws
+}

--- a/Examples/ExampleProjectSpm/Sources/ExampleProjectSpmTests/.Sourcery.Mocks.yml
+++ b/Examples/ExampleProjectSpm/Sources/ExampleProjectSpmTests/.Sourcery.Mocks.yml
@@ -1,21 +1,25 @@
-# package:
-#   path: ../.. #${SOURCERY_PACKAGE_PATH}
-#   target:
-#     - ExampleProjectSpm
-#     - ExampleProjectSpmTests
+# What to generate, and nothing else.
+#
+# `sources:` is the derived closure plus one directory the author picked: the
+# annotations that teach Sourcery about RIBs' protocols live in a subdirectory of
+# this target, and a subset of a directory is the one thing derivation must not
+# decide. Everything else the closure supplies — including RIBs itself, which
+# used to need a hand-written ${SOURCERY_TARGET_..._DEP_RIBs_MODULE_RIBs} line,
+# and ExampleProjectSpmCore, which no var could name at all.
+#
+# `output:` and `args.testable` are the plugin's (spec 001 §4.6): there is one
+# directory this target's build collects from, and one module it directly
+# depends on.
 sources:
-  - ${SOURCERY_TARGET_ExampleProjectSpm}
-  - ${SOURCERY_TARGET_ExampleProjectSpm_DEP_RIBs_MODULE_RIBs}
+  - ${SOURCERY_SOURCES}
   - ${SOURCERY_TARGET_ExampleProjectSpmTests}/SourceryAnnotations
-output: ${SOURCERY_OUTPUT_DIR}
 templates:
-  - ${GIT_ROOT}/templates/Mocks.swifttemplate
+  - Mocks
 args:
-  testable:
-    - ExampleProjectSpm
   import:
     - Alamofire
     - Combine
+    - ExampleProjectSpmCore
     - RIBs
     - RxBlocking
     - RxSwift

--- a/Examples/ExampleProjectSpm/Sources/ExampleProjectSpmTests/SwiftSourceryTemplatesMocksSpec.swift
+++ b/Examples/ExampleProjectSpm/Sources/ExampleProjectSpmTests/SwiftSourceryTemplatesMocksSpec.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2018 AlbumPrinter BV. All rights reserved.
 //
 
+import Foundation
 import Quick
 import Nimble
 import RxSwift
@@ -55,5 +56,38 @@ class SwiftSourceryTemplatesMocksSpec: QuickSpec {
         } // context("entityObserver.on() called")
       }
     } // describe("mock with AnyObserver")
+
+    // The transitive first-party case. `ProfilePersisting` refines `Persisting`,
+    // which lives in ExampleProjectSpmCore — a module this test target reaches
+    // only through ExampleProjectSpm, and which no SOURCERY_TARGET_* var names.
+    // Before the plugin derived its own source closure the generated mock
+    // carried `profileID` and not `save`, and this file did not compile.
+    describe("mock of a protocol refining another module's protocol") {
+      var sut: ProfilePersistingMock!
+      beforeEach {
+        sut = ProfilePersistingMock()
+      }
+      it("starts with no recorded calls") {
+        expect(sut.saveCallCount) == 0
+        expect(sut.saveArgs).to(beEmpty())
+      }
+      context("save() called with the inherited requirement's signature") {
+        beforeEach {
+          try? sut.save(Data([0x01, 0x02]), key: "profile")
+        }
+        it("records the call") {
+          expect(sut.saveCallCount) == 1
+        }
+        it("records both arguments") {
+          expect(sut.saveArgs.count) == 1
+          expect(sut.saveArgs.first?.data) == Data([0x01, 0x02])
+          expect(sut.saveArgs.first?.key) == "profile"
+        }
+      } // context("save() called")
+      it("still carries the refining protocol's own requirement") {
+        sut.profileID = "abc"
+        expect(sut.profileID) == "abc"
+      }
+    } // describe("mock of a protocol refining another module's protocol")
   }
 }

--- a/Plugins/SourcerySwiftCodegenPlugin/SourcerySwiftCodegenPlugin.swift
+++ b/Plugins/SourcerySwiftCodegenPlugin/SourcerySwiftCodegenPlugin.swift
@@ -1,16 +1,65 @@
 import Foundation
 import PackagePlugin
 
+// The plugin is one file on purpose: a build-tool plugin cannot depend on a
+// library target, so there is no Yams, no shared code with Sources/mock-templates
+// and no unit-test target that can import any of this. See
+// specs/001-plugin-source-discovery/spec.md §1.5, and Checks/run-plugin-checks.sh
+// for the black-box lane that stands in for the tests this file cannot have.
+
+/// This package's manifest name, used to find it in a consumer's graph (§4.5).
+/// The manifest name lives in this repository, so it survives a consumer
+/// vendoring the package under another directory name — which is what changes
+/// the identity below.
+let pluginPackageName = "SourcerySwiftCodegen"
+
+/// The identity a consumer gets from the canonical repository URL. Checked
+/// alongside the manifest name so a fork that renamed one of the two is still
+/// recognised.
+let pluginPackageIdentity = "swift-sourcery-templates"
+
+/// The list item an author writes where the derived source closure should go.
+/// Deliberately not an env var (§9, D7): nothing exports `SOURCERY_SOURCES`, so a
+/// substitution that failed to run leaves Sourcery reporting an unexpanded path
+/// instead of silently scanning less than intended.
+let sourcesPlaceholder = "${SOURCERY_SOURCES}"
+
 protocol CodegenPluginContext {
   var rootDirectory: PackagePlugin.Path { get }
   var pluginWorkDirectory: PackagePlugin.Path { get }
   func tool(named name: String) throws -> PackagePlugin.PluginContext.Tool
   var environmentVars: [String: String] { get }
+
+  /// The `templates/` directory of the package shipping this plugin, when the
+  /// graph can be walked for it (§4.5). `nil` in Xcode projects, where
+  /// `XcodePluginContext` exposes no package graph — a bare template name then
+  /// stays unresolved and warns.
+  var shippedTemplatesDirectory: PackagePlugin.Path? { get }
 }
 
 protocol CodegenPluginTarget {
   var name: String { get }
   func sourceryConfigFileLocations(rootDirectory: Path) -> Set<Path>
+
+  /// The directories `${SOURCERY_SOURCES}` expands to: the target's own sources
+  /// plus the recursive closure of its dependencies, first-party and external
+  /// alike (§3.1). Deduplicated, descendants of another entry dropped, sorted.
+  var derivedSourceRoots: [Path] { get }
+
+  /// The module `args.testable` names when exactly one module can be meant (§4.6).
+  var testableDefault: TestableDefault { get }
+}
+
+/// What the plugin can say about the module under test (§4.6, D11). Derived from
+/// the *direct* target dependencies, never the closure: the module a test target
+/// tests is the one it depends on, not one it reaches through that.
+enum TestableDefault {
+  /// Not a test target, or a context with no graph to derive from.
+  case notApplicable
+  /// Exactly one candidate — not a guess, the answer.
+  case unambiguous(String)
+  /// Zero, or more than one. The plugin inserts nothing and names what it found.
+  case ambiguous([String])
 }
 
 private func gitRootDirectory(_ path: Path) -> String {
@@ -63,14 +112,528 @@ private func locateSourceryExecutable(_ context: CodegenPluginContext) throws ->
 
 enum SourcerySwiftCodegenPluginError: Error, LocalizedError {
   case sourceryNotFound(path: String)
+  case configUnreadable(path: String, underlying: String)
+  case configurationRejected(target: String, reasons: [String])
 
   var errorDescription: String? {
     switch self {
     case .sourceryNotFound(let path):
       return "Could not locate Sourcery executable in the tool path '\(path)'"
+    case .configUnreadable(let path, let underlying):
+      return "Could not read the Sourcery config at '\(path)': \(underlying)"
+    case .configurationRejected(let target, let reasons):
+      return "Target \"\(target)\": the Sourcery configuration was rejected:\n - "
+        + reasons.joined(separator: "\n - ")
     }
   }
 }
+
+// MARK: - Reading a config by line, not by parser
+
+// D1: a hand-written YAML parser deciding what a consumer's config means is a
+// much larger liability than a line-level substitution, so the synthesizer
+// recognises exactly the shapes it rewrites — a mapping key at a known
+// indentation, and a whole list item — and copies every other byte through.
+
+/// A `key:` mapping entry: its indentation, its name and whatever follows the colon.
+struct MappingKey {
+  let indent: Int
+  let name: String
+  let value: String
+}
+
+/// A `- value` sequence entry: its indentation and the value.
+struct ListItem {
+  let indent: Int
+  let value: String
+}
+
+enum YamlLine {
+  /// The number of leading spaces, or `nil` for a blank line or one indented with
+  /// a tab (which is not YAML indentation, so such a line is never read as nested).
+  static func indent(of line: String) -> Int? {
+    var count = 0
+    for character in line {
+      if character == " " {
+        count += 1
+      } else if character == "\t" || character == "\r" {
+        return nil
+      } else {
+        return count
+      }
+    }
+    return nil
+  }
+
+  static func isBlankOrComment(_ line: String) -> Bool {
+    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty || trimmed.hasPrefix("#")
+  }
+
+  /// The mapping key this line declares, if it declares one.
+  static func mappingKey(of line: String) -> MappingKey? {
+    guard let indent = indent(of: line) else { return nil }
+    var rest = Substring(line).dropFirst(indent)
+    guard let first = rest.first, first.isLetter || first == "_" else { return nil }
+    var name = ""
+    while let character = rest.first, character.isLetter || character.isNumber || character == "_" || character == "-" || character == "." {
+      name.append(character)
+      rest = rest.dropFirst()
+    }
+    while rest.first == " " { rest = rest.dropFirst() }
+    guard rest.first == ":" else { return nil }
+    rest = rest.dropFirst()
+    return MappingKey(indent: indent, name: name, value: String(rest).trimmingCharacters(in: .whitespacesAndNewlines))
+  }
+
+  /// The sequence entry this line declares, if it declares one.
+  static func listItem(of line: String) -> ListItem? {
+    guard let indent = indent(of: line) else { return nil }
+    var rest = Substring(line).dropFirst(indent)
+    guard rest.first == "-" else { return nil }
+    rest = rest.dropFirst()
+    guard rest.isEmpty || rest.first == " " else { return nil }
+    return ListItem(indent: indent, value: String(rest).trimmingCharacters(in: .whitespacesAndNewlines))
+  }
+
+  /// A scalar with its surrounding quotes removed, and a trailing `# comment`
+  /// dropped when the value was not quoted.
+  static func scalar(_ raw: String) -> String {
+    let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    if value.count >= 2, let first = value.first, first == "\"" || first == "'", value.last == first {
+      let inner = String(value.dropFirst().dropLast())
+      return first == "\"" ? inner.replacingOccurrences(of: "\\\"", with: "\"") : inner
+    }
+    // An unquoted scalar ends at a ` #` comment.
+    if let range = value.range(of: " #") {
+      return String(value[value.startIndex..<range.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    return value
+  }
+
+  /// A path emitted by the plugin, as a double-quoted YAML scalar. Paths contain
+  /// spaces routinely — a DerivedData path always can — so quoting is not optional.
+  static func quoted(_ path: String) -> String {
+    let escaped = path
+      .replacingOccurrences(of: "\\", with: "\\\\")
+      .replacingOccurrences(of: "\"", with: "\\\"")
+    return "\"\(escaped)\""
+  }
+}
+
+/// The output subdirectory a config owns, from its file name: `.Sourcery.Mocks.yml`
+/// becomes `Sourcery.Mocks`. Stable across builds, and legible in a build log.
+func directoryName(for configFileName: String) -> String {
+  var name = configFileName
+  while name.hasPrefix(".") { name.removeFirst() }
+  if let dot = name.range(of: ".", options: .backwards) {
+    name = String(name[name.startIndex..<dot.lowerBound])
+  }
+  let allowed = name.map { character -> Character in
+    character.isLetter || character.isNumber || character == "." || character == "-" || character == "_" ? character : "_"
+  }
+  let sanitized = String(allowed)
+  return sanitized.isEmpty ? "Sourcery" : sanitized
+}
+
+/// `.`/`..` removed, `~` expanded and any trailing slash dropped, so two spellings
+/// of one directory compare equal.
+func normalizedPath(_ path: String) -> String {
+  var standardized = ((path as NSString).expandingTildeInPath as NSString).standardizingPath
+  while standardized.count > 1 && standardized.hasSuffix("/") {
+    standardized.removeLast()
+  }
+  return standardized
+}
+
+/// Deduplicated, with any path contained in another dropped, then sorted (§3.3).
+/// `recursiveTargetDependencies` promises a dependency order, not a stable one
+/// across resolutions, and the synthesized config has to be byte-identical
+/// between builds or Sourcery's cache is invalidated every time (§1.5).
+func normalizedSourceRoots(_ paths: [Path]) -> [Path] {
+  var unique: [String] = []
+  var seen = Set<String>()
+  for path in paths {
+    let normalized = normalizedPath(path.string)
+    if seen.insert(normalized).inserted {
+      unique.append(normalized)
+    }
+  }
+  let kept = unique.filter { candidate in
+    !unique.contains { other in other != candidate && candidate.hasPrefix(other + "/") }
+  }
+  return kept.sorted().map { Path($0) }
+}
+
+// MARK: - Config synthesis (§4)
+
+/// Copies an author's Sourcery config into the plugin's work directory, expanding
+/// what it declares and appending what it omits (§4.2):
+///
+///   1. `- ${SOURCERY_SOURCES}` becomes one quoted directory per module in the closure.
+///   2. A bare `templates:` entry becomes the absolute path of the template it names.
+///   3. `sources:` and `output:` are appended when the document declares neither
+///      them nor an equivalent, and `args.testable` is inserted when the module
+///      under test is unambiguous.
+///   4. An `output:` the config declares is verified against the directory the
+///      build actually collects from — a mismatch is an error, not a rewrite.
+///   5. Every other byte is copied through, comments and all.
+///
+/// A config with no placeholder, no bare name, both keys present and an
+/// `args.testable` of its own comes out byte-identical.
+struct SourceryConfigSynthesizer {
+  let configPath: Path
+  let sourceRoots: [Path]
+  let shippedTemplatesDirectory: Path?
+  let generatedFilesDir: Path
+  let testableDefault: TestableDefault
+  let environmentVars: [String: String]
+
+  struct Result {
+    var text = ""
+    var remarks: [String] = []
+    var warnings: [String] = []
+    var errors: [String] = []
+    /// The `<name>.generated.swift` files this config will write, one per
+    /// `templates:` entry (§1.4/F). Used for the collision check of §4.7.
+    var generatedFileStems: [String] = []
+  }
+
+  /// What a first pass can see about the document, so the second pass can insert
+  /// into it without re-deriving state mid-rewrite.
+  private struct Shape {
+    var topLevelKeys: Set<String> = []
+    var argsLine: Int?
+    var argsIsFlowStyle = false
+    var argsChildIndent: Int?
+    var argsHasTestable = false
+  }
+
+  private func scan(_ lines: [String]) -> Shape {
+    var shape = Shape()
+    var currentTopKey: String?
+    for (index, line) in lines.enumerated() {
+      if YamlLine.isBlankOrComment(line) { continue }
+      if let key = YamlLine.mappingKey(of: line), key.indent == 0 {
+        // Column 0 only. This is the shape of every config this repo ships or
+        // documents, and a commented-out `# package:` block cannot match it.
+        shape.topLevelKeys.insert(key.name)
+        currentTopKey = key.name
+        if key.name == "args" {
+          shape.argsLine = index
+          shape.argsIsFlowStyle = key.value.hasPrefix("{")
+        }
+        continue
+      }
+      guard let indent = YamlLine.indent(of: line), indent > 0 else {
+        currentTopKey = nil
+        continue
+      }
+      if currentTopKey == "args" {
+        if shape.argsChildIndent == nil { shape.argsChildIndent = indent }
+        if let key = YamlLine.mappingKey(of: line), key.name == "testable", key.indent == shape.argsChildIndent {
+          shape.argsHasTestable = true
+        }
+      }
+    }
+    return shape
+  }
+
+  func synthesize(_ original: String) -> Result {
+    var result = Result()
+    let lines = original.components(separatedBy: "\n")
+    let shape = scan(lines)
+    var rewritten: [String] = []
+    rewritten.reserveCapacity(lines.count + sourceRoots.count + 8)
+
+    var currentTopKey: String?
+    var expandedPlaceholder = false
+    var suppliedDefaults: [String] = []
+    // Values already reported by the template rules, so the relative-path audit
+    // does not report them a second time.
+    var reportedValues = Set<String>()
+
+    for (index, line) in lines.enumerated() {
+      if !YamlLine.isBlankOrComment(line) {
+        if let key = YamlLine.mappingKey(of: line), key.indent == 0 {
+          currentTopKey = key.name
+        } else if let indent = YamlLine.indent(of: line), indent == 0 {
+          currentTopKey = nil
+        }
+      }
+
+      // 1. The source closure.
+      if currentTopKey == "sources",
+         let item = YamlLine.listItem(of: line),
+         YamlLine.scalar(item.value) == sourcesPlaceholder {
+        let padding = String(repeating: " ", count: item.indent)
+        for root in sourceRoots {
+          rewritten.append("\(padding)- \(YamlLine.quoted(root.string))")
+        }
+        expandedPlaceholder = true
+        continue
+      }
+      // The placeholder is recognised only under `sources:` (§4.1). Anywhere else
+      // it would reach Sourcery unexpanded, so say so rather than let it fail
+      // with a path nobody wrote.
+      if currentTopKey != "sources",
+         let item = YamlLine.listItem(of: line),
+         YamlLine.scalar(item.value) == sourcesPlaceholder {
+        result.warnings.append(
+          "\(configPath.lastComponent):\(index + 1): \(sourcesPlaceholder) is only expanded under `sources:`, and this one is under `\(currentTopKey ?? "no key")`. Left as written.")
+        rewritten.append(line)
+        continue
+      }
+
+      // 2. Bare template names.
+      if currentTopKey == "templates", let item = YamlLine.listItem(of: line), !item.value.isEmpty {
+        let named = YamlLine.scalar(item.value)
+        let resolution = resolveTemplate(named)
+        if let stem = resolution.stem {
+          result.generatedFileStems.append(stem)
+        }
+        if let remark = resolution.remark { result.remarks.append(remark) }
+        if let warning = resolution.warning {
+          result.warnings.append(warning)
+          reportedValues.insert(named)
+        }
+        if let resolved = resolution.path {
+          rewritten.append("\(String(repeating: " ", count: item.indent))- \(YamlLine.quoted(resolved.string))")
+          continue
+        }
+        rewritten.append(line)
+        continue
+      }
+
+      rewritten.append(line)
+
+      // 3. `args.testable`, the one nested insert (§4.6).
+      if let argsLine = shape.argsLine, index == argsLine, case let .unambiguous(module) = testableDefault {
+        if shape.argsHasTestable {
+          result.remarks.append("\(configPath.lastComponent): `args.testable` is already set — left as written.")
+        } else if shape.argsIsFlowStyle {
+          result.remarks.append("\(configPath.lastComponent): `args:` is written in flow style, so `testable: [\(module)]` was not inserted. Add it by hand if the mocks need it.")
+        } else if let childIndent = shape.argsChildIndent {
+          rewritten.append("\(String(repeating: " ", count: childIndent))testable: [\(module)]")
+          suppliedDefaults.append("args.testable: [\(module)]")
+        } else {
+          result.remarks.append("\(configPath.lastComponent): `args:` has no entries to match the indentation of, so `testable: [\(module)]` was not inserted.")
+        }
+      }
+    }
+
+    // 3 (continued). The keys with a single right answer, appended (D10).
+    var appended: [String] = []
+    let declaresInputs = !shape.topLevelKeys.isDisjoint(with: ["sources", "project", "package"])
+    if !declaresInputs {
+      appended.append("sources:")
+      for root in sourceRoots {
+        appended.append("  - \(YamlLine.quoted(root.string))")
+      }
+      suppliedDefaults.append("sources: the derived closure (\(sourceRoots.count) director\(sourceRoots.count == 1 ? "y" : "ies"))")
+    }
+    if !shape.topLevelKeys.contains("output") {
+      appended.append("output: \(YamlLine.quoted(generatedFilesDir.string))")
+      suppliedDefaults.append("output: \(generatedFilesDir.string)")
+    }
+    if !shape.argsHasTestable, case .ambiguous(let candidates) = testableDefault {
+      result.remarks.append(
+        candidates.isEmpty
+          ? "\(configPath.lastComponent): no root-package module is a direct dependency of the test target, so `args.testable` was not inserted."
+          : "\(configPath.lastComponent): the test target directly depends on \(candidates.count) root-package modules (\(candidates.joined(separator: ", "))), so `args.testable` was not inserted — name the one the mocks belong to.")
+    }
+
+    if !appended.isEmpty {
+      // Splice the block on with exactly one trailing newline, whatever the
+      // original ended with.
+      while let last = rewritten.last, last.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        rewritten.removeLast()
+      }
+      rewritten.append(contentsOf: appended)
+      rewritten.append("")
+    }
+
+    if !suppliedDefaults.isEmpty {
+      result.remarks.append("\(configPath.lastComponent): the plugin supplied \(suppliedDefaults.joined(separator: "; ")).")
+    }
+    if expandedPlaceholder {
+      result.remarks.append("\(configPath.lastComponent): \(sourcesPlaceholder) expanded to \(sourceRoots.count) director\(sourceRoots.count == 1 ? "y" : "ies").")
+    }
+
+    result.text = rewritten.joined(separator: "\n")
+
+    // 4. Verify an `output:` the config declares, and 5's contract: absolute paths.
+    verifyOutput(rewritten, into: &result)
+    auditRelativePaths(rewritten, reportedValues: reportedValues, into: &result)
+
+    return result
+  }
+
+  // MARK: Template resolution (§4.5)
+
+  private struct TemplateResolution {
+    var path: Path?
+    var stem: String?
+    var remark: String?
+    var warning: String?
+  }
+
+  private func resolveTemplate(_ named: String) -> TemplateResolution {
+    // 1. A path. Left alone — but its basename still tells us what Sourcery will
+    //    write, which is what the collision check of §4.7 needs.
+    if named.contains("/") || named.hasPrefix("$") {
+      let last = String(named.split(separator: "/").last ?? "")
+      return TemplateResolution(path: nil, stem: last.contains("$") ? nil : Path(last).stem)
+    }
+
+    // 2. A file beside the author's config — today's meaning of a relative entry.
+    //    Ordered before the shipped templates so a consumer with its own
+    //    `Mocks.swifttemplate` keeps getting its own file.
+    let beside = configPath.removingLastComponent().appending(named)
+    if beside.fileExists && !beside.isDirectory {
+      return TemplateResolution(
+        path: beside,
+        stem: beside.stem,
+        remark: "\(configPath.lastComponent): template '\(named)' resolved to the file beside the config, \(beside.string).")
+    }
+
+    // 3. A template shipped by this package.
+    if let templatesDirectory = shippedTemplatesDirectory {
+      for candidate in [templatesDirectory.appending(named + ".swifttemplate"), templatesDirectory.appending(named)] {
+        // `_header.swifttemplate` is an include, not something to run.
+        guard candidate.fileExists, !candidate.isDirectory, !candidate.lastComponent.hasPrefix("_") else { continue }
+        return TemplateResolution(
+          path: candidate,
+          stem: candidate.stem,
+          remark: "\(configPath.lastComponent): template '\(named)' resolved to the shipped \(candidate.lastComponent).")
+      }
+    }
+
+    // 4. Neither. Sourcery then fails on it, which is the right outcome for a typo.
+    let shipped = shippedTemplatesDirectory.map { listShippedTemplates($0) } ?? []
+    let available = shipped.isEmpty
+      ? "no shipped templates are reachable from here — an Xcode project has no package graph to find them in, so name the template by path"
+      : "the shipped templates are \(shipped.joined(separator: ", "))"
+    return TemplateResolution(
+      path: nil,
+      stem: Path(named).stem,
+      warning: "\(configPath.lastComponent): template '\(named)' is neither a file beside the config nor a shipped template — \(available).")
+  }
+
+  private func listShippedTemplates(_ directory: Path) -> [String] {
+    let contents = (try? FileManager.default.contentsOfDirectory(atPath: directory.string)) ?? []
+    return contents
+      .filter { $0.hasSuffix(".swifttemplate") && !$0.hasPrefix("_") }
+      .map { Path($0).stem }
+      .sorted()
+  }
+
+  // MARK: `output:` verification (§4.6, D12)
+
+  private func verifyOutput(_ lines: [String], into result: inout Result) {
+    var currentTopKey: String?
+    var outputIndent: Int?
+    var declaredValue: String?
+    var sawObjectForm = false
+
+    for line in lines {
+      if YamlLine.isBlankOrComment(line) { continue }
+      if let key = YamlLine.mappingKey(of: line), key.indent == 0 {
+        currentTopKey = key.name
+        if key.name == "output" {
+          if key.value.isEmpty {
+            sawObjectForm = true
+            outputIndent = nil
+          } else {
+            declaredValue = YamlLine.scalar(key.value)
+          }
+        }
+        continue
+      }
+      guard currentTopKey == "output", sawObjectForm else { continue }
+      guard let key = YamlLine.mappingKey(of: line), key.indent > 0 else { continue }
+      if outputIndent == nil { outputIndent = key.indent }
+      if key.name == "path", key.indent == outputIndent {
+        declaredValue = YamlLine.scalar(key.value)
+      }
+    }
+
+    guard let declared = declaredValue else {
+      if sawObjectForm {
+        result.warnings.append("\(configPath.lastComponent): `output:` is an object with no `path:` the line rules can read, so the output directory was not verified. It must be \(generatedFilesDir.string).")
+      }
+      return
+    }
+
+    let expanded = expandEnvironment(declared)
+    if expanded.contains("$") {
+      result.warnings.append("\(configPath.lastComponent): `output:` still contains an unexpanded variable after substitution ('\(expanded)'), so the output directory was not verified. It must be \(generatedFilesDir.string).")
+      return
+    }
+    // A relative value means "relative to the config file's directory" — the
+    // author's directory, which is what it means today (§1.4/A).
+    let absolute = expanded.hasPrefix("/")
+      ? expanded
+      : configPath.removingLastComponent().appending(expanded).string
+    let required = normalizedPath(generatedFilesDir.string)
+    let resolved = normalizedPath(absolute)
+    guard resolved != required,
+          (resolved as NSString).resolvingSymlinksInPath != (required as NSString).resolvingSymlinksInPath else {
+      return
+    }
+    // Outputs are collected only from the command's `outputFilesDirectory`, so a
+    // file written anywhere else is written and then ignored: the target compiles
+    // without it and the failure surfaces as a missing type, far from its cause.
+    result.errors.append(
+      "\(configPath.lastComponent): `output:` resolves to '\(resolved)', but the build collects generated files only from '\(required)'. Remove the key and let the plugin supply it, or set it to ${SOURCERY_OUTPUT_DIR}.")
+  }
+
+  private func expandEnvironment(_ value: String) -> String {
+    var expanded = value
+    for (name, replacement) in environmentVars {
+      expanded = expanded.replacingOccurrences(of: "${\(name)}", with: replacement)
+    }
+    return expanded
+  }
+
+  // MARK: The absolute-path contract (§4.3)
+
+  /// The synthesized copy lives in `pluginWorkDirectory`, and a relative path in a
+  /// config resolves against the config file's own directory (§1.4/A) — so a
+  /// relative path that works today would silently resolve somewhere else. The
+  /// plugin does not rewrite them (that needs the parser it does not have); it
+  /// names them. A warning, not an error: the heuristic is not good enough to
+  /// block a build on.
+  private func auditRelativePaths(_ lines: [String], reportedValues: Set<String>, into result: inout Result) {
+    let pathKeys: Set<String> = ["sources", "templates", "output"]
+    var currentTopKey: String?
+    for (index, line) in lines.enumerated() {
+      if YamlLine.isBlankOrComment(line) { continue }
+      var value: String?
+      if let key = YamlLine.mappingKey(of: line) {
+        if key.indent == 0 {
+          currentTopKey = key.name
+          value = key.value.isEmpty ? nil : YamlLine.scalar(key.value)
+        } else if currentTopKey == "output" && key.name == "path" {
+          value = YamlLine.scalar(key.value)
+        }
+      } else if let item = YamlLine.listItem(of: line), !item.value.isEmpty {
+        value = YamlLine.scalar(item.value)
+      } else if let indent = YamlLine.indent(of: line), indent == 0 {
+        currentTopKey = nil
+      }
+
+      guard let currentTopKey, pathKeys.contains(currentTopKey) else { continue }
+      guard let value, !value.isEmpty, !reportedValues.contains(value) else { continue }
+      guard let first = value.unicodeScalars.first else { continue }
+      guard CharacterSet.alphanumerics.contains(first) || first == "." || first == "_" else { continue }
+      result.warnings.append(
+        "\(configPath.lastComponent):\(index + 1): '\(value)' under `\(currentTopKey):` looks like a relative path. The plugin runs a copy of this config from its own work directory, where a relative path means something else — write it absolutely, or name a shipped template by name.")
+    }
+  }
+}
+
+// MARK: - The plugin
 
 @main
 struct SourcerySwiftCodegenPlugin {
@@ -88,7 +651,7 @@ struct SourcerySwiftCodegenPlugin {
         Diagnostics.error("\(e)")
         return []
       }
-    }
+    }.sorted { $0.string < $1.string }
     Diagnostics.remark("Target \"\(target.name)\"\n - looking for Sourcery configs in: \(sourceryConfigFileLocations)\n - found configs: \(sourceryConfigFilePaths.map { $0.lastComponent })")
 
     // Write caches "SourceryCaches" subdirectory of the plugin work directory
@@ -101,25 +664,136 @@ struct SourcerySwiftCodegenPlugin {
     let perTargetBuildDir = context.pluginWorkDirectory.appending(".sourceryBuild")
     try FileManager.default.createDirectory(atPath: perTargetBuildDir.string, withIntermediateDirectories: true)
 
-    // Write generated files to the "GeneratedFiles" subdirectory of the plugin work directory
-    // (which is unique for each plugin and target).
-    let generatedFilesDir = context.pluginWorkDirectory.appending(".generatedFiles")
-    try FileManager.default.createDirectory(atPath: generatedFilesDir.string, withIntermediateDirectories: true)
+    // Generated files go under ".generatedFiles", one subdirectory per config.
+    //
+    // Per config, not per target, and that is not a tidiness choice: a prebuild
+    // command's outputs are collected by scanning the whole directory it declared,
+    // so two commands of one target declaring one directory makes SwiftPM attribute
+    // every file in it to both of them and refuse the build outright —
+    // "couldn't build <file>.o because of multiple producers". A target carrying
+    // several configs is the shape §4.7 encourages, so each config owns a
+    // directory nothing else writes to.
+    let generatedFilesRoot = context.pluginWorkDirectory.appending(".generatedFiles")
+    try FileManager.default.createDirectory(atPath: generatedFilesRoot.string, withIntermediateDirectories: true)
 
-    let environmentVars = [
-      "SOURCERY_OUTPUT_DIR": generatedFilesDir.string
-    ].merging(context.environmentVars, uniquingKeysWith: { k, _ in k })
+    // The configs the plugin actually runs: a copy of each authored config with
+    // the closure spliced in and the omitted keys supplied (§4.4).
+    let synthesizedConfigsDir = context.pluginWorkDirectory.appending(".sourceryConfigs")
+    try FileManager.default.createDirectory(atPath: synthesizedConfigsDir.string, withIntermediateDirectories: true)
 
-    return sourceryConfigFilePaths.map { configFilePath in
+    var sharedEnvironmentVars = context.environmentVars
+    if let templatesDirectory = context.shippedTemplatesDirectory {
+      sharedEnvironmentVars["SOURCERY_TEMPLATES"] = templatesDirectory.string
+    }
+
+    let sourceRoots = target.derivedSourceRoots
+    Diagnostics.remark("Target \"\(target.name)\": \(sourcesPlaceholder) resolves to \(sourceRoots.count) source director\(sourceRoots.count == 1 ? "y" : "ies").")
+
+    struct RunnableConfig {
+      let original: Path
+      let synthesized: Path
+      let outputDir: Path
+      let environmentVars: [String: String]
+    }
+
+    var errors: [String] = []
+    // §4.7: the configs of one target all put their output on that target's compile
+    // path, so two of them naming the same template produce two files declaring the
+    // same types. Caught here, where the config can be named, rather than as a
+    // redeclaration error in generated code.
+    var stemOwners: [String: Path] = [:]
+    var runnableConfigs: [RunnableConfig] = []
+
+    // Two configs of one target must not land on one synthesized file or one
+    // output directory. Distinct names normally guarantee both, but the discovery
+    // regex accepts any `*.sourcery*.yml` and `directoryName(for:)` strips leading
+    // dots, so `.Sourcery.A.yml` and `..Sourcery.A.yml` would collide — and a
+    // collision here is the "multiple producers" build failure again, with nothing
+    // naming its cause.
+    var usedFileNames = Set<String>()
+    var usedDirectoryNames = Set<String>()
+    func claim(_ preferred: String, from taken: inout Set<String>, extension suffix: String) -> String {
+      if taken.insert(preferred).inserted { return preferred }
+      var attempt = 2
+      while true {
+        let candidate = suffix.isEmpty ? "\(preferred)-\(attempt)" : "\(Path(preferred).stem)-\(attempt).\(suffix)"
+        if taken.insert(candidate).inserted { return candidate }
+        attempt += 1
+      }
+    }
+
+    for configFilePath in sourceryConfigFilePaths {
+      let original: String
+      do {
+        original = try String(contentsOfFile: configFilePath.string, encoding: .utf8)
+      } catch let error {
+        throw SourcerySwiftCodegenPluginError.configUnreadable(path: configFilePath.string, underlying: "\(error)")
+      }
+
+      // Keep the author's basename so the command's displayName, and any Sourcery
+      // diagnostic naming the config, still name something they recognise.
+      let fileName = claim(
+        configFilePath.lastComponent,
+        from: &usedFileNames,
+        extension: configFilePath.extension ?? "yml")
+      let outputDir = generatedFilesRoot.appending(
+        claim(directoryName(for: fileName), from: &usedDirectoryNames, extension: ""))
+      try FileManager.default.createDirectory(atPath: outputDir.string, withIntermediateDirectories: true)
+
+      var environmentVars = sharedEnvironmentVars
+      environmentVars["SOURCERY_OUTPUT_DIR"] = outputDir.string
+
+      let synthesizer = SourceryConfigSynthesizer(
+        configPath: configFilePath,
+        sourceRoots: sourceRoots,
+        shippedTemplatesDirectory: context.shippedTemplatesDirectory,
+        generatedFilesDir: outputDir,
+        testableDefault: target.testableDefault,
+        environmentVars: environmentVars)
+      let result = synthesizer.synthesize(original)
+
+      result.remarks.forEach { Diagnostics.remark($0) }
+      result.warnings.forEach { Diagnostics.warning($0) }
+      errors.append(contentsOf: result.errors)
+
+      for stem in result.generatedFileStems {
+        if let owner = stemOwners[stem], owner != configFilePath {
+          errors.append("\(owner.lastComponent) and \(configFilePath.lastComponent) both generate '\(stem).generated.swift' onto this target's compile path, so the two would declare the same types. Give the target one config per template, or split them across targets.")
+        } else {
+          stemOwners[stem] = configFilePath
+        }
+      }
+
+      let synthesizedPath = synthesizedConfigsDir.appending(fileName)
+      // Written only when the bytes changed: the prebuild command re-runs on every
+      // build, and rewriting an identical file for no reason is noise (§1.5).
+      let existing = try? String(contentsOfFile: synthesizedPath.string, encoding: .utf8)
+      if existing != result.text {
+        try result.text.write(toFile: synthesizedPath.string, atomically: true, encoding: .utf8)
+      }
+      runnableConfigs.append(RunnableConfig(
+        original: configFilePath,
+        synthesized: synthesizedPath,
+        outputDir: outputDir,
+        environmentVars: environmentVars))
+    }
+
+    guard errors.isEmpty else {
+      errors.forEach { Diagnostics.error("Target \"\(target.name)\": \($0)") }
+      throw SourcerySwiftCodegenPluginError.configurationRejected(target: target.name, reasons: errors)
+    }
+
+    return runnableConfigs.map { config in
       let command = Self._createCommand(
         context: context,
         target: target,
-        configFilePath: configFilePath,
+        displayConfigName: config.original.lastComponent,
+        configFilePath: config.synthesized,
         sourcery: sourcery,
         perTargetCachesFilesDir: perTargetCachesFilesDir,
         perTargetBuildDir: perTargetBuildDir,
-        environmentVars: environmentVars,
-        generatedFilesDir: generatedFilesDir)
+        environmentVars: config.environmentVars,
+        generatedFilesDir: config.outputDir)
 
       Diagnostics.remark("\(command)")
 
@@ -131,6 +805,7 @@ struct SourcerySwiftCodegenPlugin {
   private static func _createCommand(
     context: CodegenPluginContext,
     target: CodegenPluginTarget,
+    displayConfigName: String,
     configFilePath: Path,
     sourcery: Path,
     perTargetCachesFilesDir: Path,
@@ -139,7 +814,7 @@ struct SourcerySwiftCodegenPlugin {
     generatedFilesDir: Path
   ) -> Command {
     Command.prebuildCommand(
-      displayName: "Target \(target.name): running Sourcery with config: \(configFilePath.lastComponent)",
+      displayName: "Target \(target.name): running Sourcery with config: \(displayConfigName)",
       executable: sourcery,
       arguments: [
         "--config",
@@ -158,6 +833,7 @@ struct SourcerySwiftCodegenPlugin {
   private static func _createCommand(
     context: CodegenPluginContext,
     target: CodegenPluginTarget,
+    displayConfigName: String,
     configFilePath: Path,
     sourcery: Path,
     perTargetCachesFilesDir: Path,
@@ -166,7 +842,7 @@ struct SourcerySwiftCodegenPlugin {
     generatedFilesDir: Path
   ) -> Command {
     Command._prebuildCommand(
-      displayName: "Target \(target.name): running Sourcery with config: \(configFilePath.lastComponent)",
+      displayName: "Target \(target.name): running Sourcery with config: \(displayConfigName)",
       executable: sourcery,
       arguments: [
         "--config",
@@ -189,12 +865,41 @@ struct SourcerySwiftCodegenPlugin {
 
 let rgSourcery = try! Regex("[^/:]*\\.sourcery([^/:]*)\\.yml$").ignoresCase()
 
-func wrap(_ target: PackagePlugin.Target) -> TargetWrapper {
-  TargetWrapper(target)
+func wrap(_ target: PackagePlugin.Target, in package: PackagePlugin.Package) -> TargetWrapper {
+  TargetWrapper(target, rootPackage: package)
 }
 
 extension PackagePlugin.PluginContext: CodegenPluginContext {
   var rootDirectory: PackagePlugin.Path { `package`.directory }
+
+  /// The `templates/` directory of whichever package in the graph is this one
+  /// (§4.5). Breadth-first and deduplicated by package id, because a consumer may
+  /// reach this package through a shared first-party one rather than declaring it
+  /// directly.
+  ///
+  /// The spec proposed matching on the plugin *target's* name. That is not
+  /// available: `Package.targets` exposes source-module, binary-artifact and
+  /// system-library targets only — a plugin target never appears in it, so the
+  /// match would never fire. `displayName` is the manifest's own `name:`, which
+  /// serves the same purpose the target name was chosen for: it is written in this
+  /// repository, not in the consumer's, so vendoring the package under another
+  /// directory name changes the identity and leaves the match intact. The
+  /// `templates/` directory has to be there too, so a consumer package that
+  /// happens to share the name cannot be mistaken for this one.
+  var shippedTemplatesDirectory: PackagePlugin.Path? {
+    var seen = Set<Package.ID>()
+    var queue: [Package] = [`package`]
+    while !queue.isEmpty {
+      let current = queue.removeFirst()
+      guard seen.insert(current.id).inserted else { continue }
+      if current.displayName == pluginPackageName || current.id == pluginPackageIdentity {
+        let templates = current.directory.appending("templates")
+        if templates.isDirectory { return templates }
+      }
+      queue.append(contentsOf: current.dependencies.map { $0.package })
+    }
+    return nil
+  }
 
   var environmentVars: [String : String] {
     let environmentVars =
@@ -236,17 +941,58 @@ extension TargetDependency {
 
 struct TargetWrapper: CodegenPluginTarget {
   let wrapped: PackagePlugin.Target
-  init(_ target: PackagePlugin.Target) { self.wrapped = target }
+  let rootPackage: PackagePlugin.Package
+  init(_ target: PackagePlugin.Target, rootPackage: PackagePlugin.Package) {
+    self.wrapped = target
+    self.rootPackage = rootPackage
+  }
 
   var name: String { wrapped.name }
   func sourceryConfigFileLocations(rootDirectory: PackagePlugin.Path) -> Set<Path> {
     [wrapped.directory]
   }
+
+  /// §3.1. `recursiveTargetDependencies` is the transitive closure and does not
+  /// include the receiver, so the target's own directory is prepended.
+  /// `compactMap { $0.sourceModule }` drops binary targets, system libraries and
+  /// plugin targets; `.macro` and `.snippet` are filtered out because a macro
+  /// target's sources are compiler-plugin code and a snippet is not part of the
+  /// module surface — neither can contribute a protocol a mock is generated from.
+  var derivedSourceRoots: [Path] {
+    let modules: [any SourceModuleTarget] =
+      ([wrapped] + wrapped.recursiveTargetDependencies).compactMap { $0.sourceModule }
+    return normalizedSourceRoots(
+      modules
+        .filter { $0.kind == .generic || $0.kind == .executable || $0.kind == .test }
+        .map { $0.directory })
+  }
+
+  /// §4.6, D11: the candidates are the test target's *direct* `.target`
+  /// dependencies whose module is in the root package and is not itself a test
+  /// module. The module a test target tests is the one it depends on; a module it
+  /// reaches only through that one is not, and restricting to `.target` keeps
+  /// first-party modules from other packages out.
+  var testableDefault: TestableDefault {
+    guard let module = wrapped.sourceModule, module.kind == .test else { return .notApplicable }
+    let rootPackageTargetNames = Set(rootPackage.targets.map { $0.name })
+    var candidates: [String] = []
+    for dependency in wrapped.dependencies {
+      guard case let .target(dependencyTarget) = dependency,
+            rootPackageTargetNames.contains(dependencyTarget.name),
+            let dependencyModule = dependencyTarget.sourceModule,
+            dependencyModule.kind != .test,
+            !candidates.contains(dependencyModule.moduleName)
+      else { continue }
+      candidates.append(dependencyModule.moduleName)
+    }
+    if candidates.count == 1 { return .unambiguous(candidates[0]) }
+    return .ambiguous(candidates.sorted())
+  }
 }
 
 extension SourcerySwiftCodegenPlugin: PackagePlugin.BuildToolPlugin {
   func createBuildCommands(context: PackagePlugin.PluginContext, target: PackagePlugin.Target) throws -> [Command] {
-    return try _createBuildCommands(context: context, target: wrap(target))
+    return try _createBuildCommands(context: context, target: wrap(target, in: context.package))
   }
 }
 
@@ -258,6 +1004,11 @@ import XcodeProjectPlugin
 
 extension XcodeProjectPlugin.XcodePluginContext: CodegenPluginContext {
   var rootDirectory: PackagePlugin.Path { xcodeProject.directory }
+
+  /// §3.4, §4.5: `XcodePluginContext` exposes no package graph, so there is
+  /// nothing to find the shipped templates in. A bare template name warns and
+  /// fails; Xcode consumers keep naming templates by path.
+  var shippedTemplatesDirectory: PackagePlugin.Path? { nil }
 
   var environmentVars: [String : String] {
     let environmentVars =
@@ -317,6 +1068,21 @@ extension XcodeProjectPlugin.XcodeTarget: CodegenPluginTarget {
       return res
     })
   }
+
+  /// §3.4. `XcodeTarget` has no `recursiveTargetDependencies`, so the placeholder
+  /// expands to the target's own input-file directories plus the `.product` module
+  /// directories already reachable — strictly better than nothing, and still not a
+  /// closure. Full derivation is SPM-only, and the README says so.
+  var derivedSourceRoots: [Path] {
+    let inputDirectories = inputFiles
+      .filter { $0.type == .source }
+      .map { $0.path.removingLastComponent() }
+    let productDirectories = dependencies.flatMap { $0.dependencyInfoArray.map { $0.1 } }
+    return normalizedSourceRoots(inputDirectories + productDirectories)
+  }
+
+  /// No package graph, so no way to tell a root-package module from any other.
+  var testableDefault: TestableDefault { .notApplicable }
 }
 
 extension PackagePlugin.Path {

--- a/README.md
+++ b/README.md
@@ -226,10 +226,11 @@ the same helpers, so they cannot disagree about which member is `nonisolated`.
 | lane | command | covers |
 | --- | --- | --- |
 | fast | `Checks/run-checks.sh` | snapshot of every template's generated output, both language modes, runtime behaviour. Mocks and Components are typechecked together, so the two cannot disagree about isolation. No simulator, no third-party packages, seconds |
+| plugin | `Checks/run-plugin-checks.sh` | the SPM build-tool plugin, black-box over a fixture package: the derived source closure, the synthesized config, the defaults it supplies, and four red controls that must stay red. No simulator |
 | full | `Examples/ExampleProjectSpm/test-ios.sh` | RxSwift smart defaults, RIBs external annotation, type erasure, the SPM plugin. Needs an iOS Simulator |
 
-Both run on every push ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)), the fast lane first.
-Run both locally before cutting a tag.
+All of them run on every push ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)), the fast lane
+first. Run them locally before cutting a tag.
 
 Release notes, including what each version changes in the generated output and what breaks:
 [CHANGELOG.md](CHANGELOG.md). Working on the templates themselves — layout, where to change what, the
@@ -315,49 +316,164 @@ xattr -dr com.apple.quarantine <...Derived Data Folder>/SourcePackages/checkouts
 
 2. Configuring code generation
 
-The codegeneration is configured per target in an SPM project. Put a `*.sourcery.yml` config file in the target's source folder
-(refer to the [example project](Examples/ExampleProjectSpm/)):
+Code generation is configured per target. Put a `*.sourcery*.yml` config file in the target's
+source folder (refer to the [example project](Examples/ExampleProjectSpm/)):
 
 <img src="/docs/img/sourcery_target_config.png" alt="Sourcery config files per target" style="height: 332px;"/>
 
-Here, `ExampleProjectSpm` and `ExampleProjectSpmTests` are product targets, for which we want to enable code generation.
-We want to generate type erasures and interface mocks. Type erasure classes should be available for use in the main target,
-while mocks should be available in the test target.
+Here, `ExampleProjectSpm` and `ExampleProjectSpmTests` are product targets for which code generation
+is enabled. Type erasures should be available in the main target, mocks in the test target — so each
+target carries its own config, and each target's generated files land on that target's compile path.
 
-Here is caveat: Some mock classes should be generated for interfaces that are declared in external packages (e.g. for the `RIBs` package).
-We need to (a) include the external package sources in the config file:
+**A config says what to generate. The plugin supplies where.** The smallest config that works is
+three lines:
 
+```yml
+# .Sourcery.Mocks.yml — beside the target it generates for
+templates:
+  - Mocks
 ```
-# .Sourcery.Mocks.yml
+
+That is a complete config. The plugin fills in the target's sources, the output directory the build
+actually collects from, and — for a test target that directly depends on exactly one module of your
+package — `args.testable`.
+
+#### Where to read: the source closure
+
+`${SOURCERY_SOURCES}` expands to the target's own sources **plus the recursive closure of its
+dependencies**, first-party and external alike, one directory per module:
+
+```yml
 sources:
-  - ${SOURCERY_TARGET_ExampleProjectSpm}
-  - ${SOURCERY_TARGET_ExampleProjectSpmTests}/SourceryAnnotations
-  - ${SOURCERY_TARGET_ExampleProjectSpm_DEP_RIBs_MODULE_RIBs}
+  - ${SOURCERY_SOURCES}
+  - ${SOURCERY_TARGET_MyModuleTests}/SourceryAnnotations   # a subset — yours to choose
 ```
 
-We're doing a little trickery here to work around an issue with Sourcery — when invoked from a build tool SPM plugin,
-Sourcery cannot analyze the package structure, so the plugin exports the package structure via environment variables.
-In the excample above:
+This is what lets a mock carry requirements a protocol inherits from a module further down the graph.
+A protocol refining one from a package your target reaches only through another package has no
+`SOURCERY_TARGET_*` variable naming it, and no config could reach it before — the mock came out
+missing those requirements, and the failure showed up as *"does not conform to protocol"* in the
+consumer's build. `${SOURCERY_SOURCES}` closes that.
 
-- `SOURCERY_TARGET_ExampleProjectSpm` refers to the `ExampleProjectSpm` target source location;
-- `SOURCERY_TARGET_ExampleProjectSpmTests` refers to the `ExampleProjectSpmTests` target source location;
-- `SOURCERY_TARGET_ExampleProjectSpm_DEP_RIBs_MODULE_RIBs` refers to the `RIBs` module source location (`RIBs` is the dependency of the `ExampleProjectSpm` target).
+There are three ways a config can say what to read, and the plugin treats them differently:
 
-The plugin exports all package dependencies' source locations via environment variable similarly:
+| the config | what is scanned |
+| --- | --- |
+| no `sources:`, `project:` or `package:` key | the closure, appended by the plugin |
+| `sources:` containing `- ${SOURCERY_SOURCES}` | the closure, **plus** every other entry in the list |
+| `sources:` without the placeholder | exactly what is listed — the pre-0.3 behaviour, untouched |
 
-- `SOURCERY_TARGET_<target_name>_DEP_<dependecy_module>_MODULE_RIBs`
-- `SOURCERY_TARGET_<target_name>_DEP_<dependecy_target>_TARGET_RIBs`
+`${SOURCERY_SOURCES}` is deliberately **not** an environment variable: nothing exports it, so if the
+plugin ever failed to substitute it, Sourcery would report an unexpanded path rather than silently
+scanning less than you meant.
+
+#### Naming a template
+
+A `templates:` entry can be the bare name of a template this package ships:
+
+```yml
+templates:
+  - Mocks        # or Component, or TypeErase
+```
+
+The plugin finds its own package in your dependency graph and resolves the name to the file. A name
+is resolved in this order, first match winning:
+
+1. it contains `/` or starts with `$` — a path, left as written;
+2. a file of that exact name sits beside your config — yours wins, so a project with its own
+   `Mocks.swifttemplate` keeps getting its own;
+3. a template shipped by this package;
+4. neither — the plugin warns, lists the shipped templates, and Sourcery then fails on it.
+
+`SOURCERY_TEMPLATES` is exported too, pointing at the shipped `templates/` directory, for a config
+that would rather write the path itself.
+
+#### Where to write
+
+`output:` is the plugin's. A prebuild command's outputs are collected only from the directory it
+declared, so a file generated anywhere else is written and then ignored — the target compiles without
+it, and the failure surfaces as a missing type far from its cause. So:
+
+- omit `output:` and the plugin supplies it;
+- write `output: ${SOURCERY_OUTPUT_DIR}` and it resolves to the same directory;
+- name any other directory and **the build fails**, naming both paths.
+
+#### The options that stay yours
+
+`args.import`, `args.excludedSwiftLintRules` and the choice of template have no single right answer,
+so the plugin carries them through unread. `args.testable` is the one exception, and only where the
+answer is unambiguous: for a test target with exactly one direct dependency on a module of your own
+package, the plugin inserts `testable: [<module>]`. With none, or with two or more, it inserts
+nothing and names the candidates in the build log.
+
+#### One config, several templates
+
+Sourcery writes one `<Template>.generated.swift` per `templates:` entry, so one config can drive
+several:
+
+```yml
+# Sources/MyModule/.Sourcery.Components.yml
+templates:
+  - Component
+  - TypeErase
+```
+
+A target may also carry several configs. Two configs of one target that name the same template are
+rejected at plan time, naming both files — they would otherwise put two files declaring the same
+types on one compile path.
+
+#### Paths must be absolute
+
+The plugin runs a *copy* of your config from its own work directory, and a relative path in a Sourcery
+config resolves against the config file's own directory. So every path a rewritten config contains has
+to be absolute. The exported variables already are, and the two rules above remove the reasons to
+write a relative path at all. The plugin warns when it sees one; it does not rewrite it.
+
+#### The exported variables
+
+Every variable below keeps the name and value it has always had; `${SOURCERY_SOURCES}` and
+`SOURCERY_TEMPLATES` are additions, and nothing was removed. A config written before 0.3 still means
+exactly what it meant.
+
+| variable | value |
+| --- | --- |
+| `SOURCERY_SOURCES` | *not a variable* — the placeholder the plugin expands to the source closure |
+| `SOURCERY_TEMPLATES` | the shipped `templates/` directory (SPM only) |
+| `SOURCERY_OUTPUT_DIR` | the directory this config's output is collected from |
+| `SOURCERY_PACKAGE` | the root package directory (`SOURCERY_PROJECT` in an Xcode project) |
+| `SOURCERY_TARGET_<target>` | that target's source directory |
+| `SOURCERY_TARGET_<target>_DEP_<target>` | a directly-depended target's source directory |
+| `SOURCERY_TARGET_<target>_DEP_<product>_MODULE_<module>` | a module of a directly-depended product |
+| `SOURCERY_TARGET_<target>_DEP_<product>_TARGET_<target>` | a target of a directly-depended product |
+| `GIT_ROOT` | `git rev-parse --show-toplevel` from the package directory |
+
+The `_DEP_` variables are one level deep: they name a target's *direct* dependencies only. Reaching
+further is what `${SOURCERY_SOURCES}` is for.
 
 > [!NOTE]
 > For the complete Sourcery config file reference, please refer to the [official documentation](https://krzysztofzablocki.github.io/Sourcery/).
 
+#### Xcode projects
+
+In an Xcode project (rather than a Swift package) the plugin runs through `XcodeBuildToolPlugin`,
+which is handed no package graph. Two features degrade there, and the build log says so:
+
+- `${SOURCERY_SOURCES}` expands to the target's own input-file directories plus the module directories
+  of its product dependencies — better than nothing, but not a closure;
+- `SOURCERY_TEMPLATES` is not exported and a bare template name does not resolve, so name templates by
+  path.
+
+Everything else — the defaults, the `output:` check, the passthrough — works the same.
+
 3. Finding the generated files
 
-The above might seem tricky at first. The plugin helps debug setup issues by emitting invocation and debug logs to the build log:
+The plugin emits its invocation and what it derived to the build log:
 
 <img src="/docs/img/command_invocation_log.png" alt="Command invocation log" style="height: 260px;"/>
 
-The invocation log also contains all exported environment variables for the dependencies.
+The log names every exported environment variable, every default the plugin supplied and every
+template name it resolved, so a config's effective meaning is always visible from the build alone.
+Run `swift build -v` to see the remarks as well as the warnings.
 
 ### Standalone CLI (pre-generated mocks)
 

--- a/specs/001-plugin-source-discovery/spec.md
+++ b/specs/001-plugin-source-discovery/spec.md
@@ -1,0 +1,814 @@
+# 001 — A self-sufficient build-tool plugin: a derived source closure, a synthesized config, and the options the author keeps
+
+**Status:** Draft, 2026-09-09. Nothing implemented. Every measurement in §1.4 and §1.5 was run
+against this checkout on 2026-09-09 with Sourcery 2.3.0 and the Xcode 26.5 toolchain.
+**Scope:** `Plugins/SourcerySwiftCodegenPlugin/SourcerySwiftCodegenPlugin.swift`,
+`Examples/ExampleProjectSpm/`, `Checks/`, README and CONTRIBUTING. No template change. No change to
+`mock-templates` — the CLI stays policy-free (§9, D6).
+**Baseline:** `master` at `4b1d0bb` ("Retire the CocoaPods distribution").
+**Relates to:**
+- `2a2857c` on branch `tt` (2024-02-28, message "tt", never merged) — the first attempt at exactly
+  this. §1.3 records what it did and §1.4/A the measurement that shows why it could not have worked.
+- [CONTRIBUTING.md §Pitfalls](../../CONTRIBUTING.md) — "Sourcery only knows the declarations it
+  parses": a protocol refining one from another module generates a mock missing those requirements.
+  That pitfall is the user-visible symptom this spec removes for the plugin path.
+- [README.md](../../README.md) — the `SOURCERY_TARGET_*` env-var contract this spec extends without
+  breaking.
+
+---
+
+## 0. TL;DR
+
+1. The plugin exports **one level** of the package graph as env vars, and the author hand-lists each
+   var in `sources:`. A module reachable only transitively has no var and cannot be listed at all
+   (§1.1). That is the gap.
+2. The information was never missing. `Target.recursiveTargetDependencies` and the recursive
+   `Package.dependencies[].package` walk give the plugin the full closure (§1.4/E). **Injection** is
+   the wall: with `--config` in play Sourcery discards command-line `--sources`, and a config entry
+   cannot fan one env var into many (§1.4/A, measured).
+3. So the plugin **synthesizes a config**. It copies the author's `.Sourcery.<Name>.yml` byte for
+   byte into `pluginWorkDirectory`, replacing a declared placeholder line — `- ${SOURCERY_SOURCES}` —
+   with one `- "<dir>"` line per module directory in the closure, and runs Sourcery against the copy
+   (§4). A config that declares no inputs and no output gets both appended, which is free: Sourcery
+   rejects a config missing either key today (§1.4/G, §1.4/H), so nothing that works now changes
+   meaning.
+4. **Directories, not files.** `2a2857c` joined every source file path of the closure into one env
+   var; this derivation emits one directory per source module — 30-odd lines instead of thousands,
+   and stable across an added file, which keeps Sourcery's cache warm (§3.2, §9 D2).
+5. **The author keeps every option with more than one right answer.** `args.import`,
+   `excludedSwiftLintRules` and the choice of template are authored intent, and the copy carries them
+   through unread. What has a single right answer, the plugin supplies: the output directory, and
+   `args.testable` when the test target depends on exactly one first-party module (§5, §4.6).
+6. Second self-sufficiency gap, same size: a consumer has **no way to name the shipped templates**.
+   The example writes `${GIT_ROOT}/templates/Mocks.swifttemplate`, which only resolves because the
+   example lives inside this repo. The plugin finds its own package in the graph, exports
+   `SOURCERY_TEMPLATES`, and resolves a **bare template name** — `- Mocks` — to the shipped file, so
+   a consumer names a template the way the CLI's fingerprint already records it (§4.5).
+7. A target may carry several configs, and a config several templates: Sourcery writes one
+   `<Template>.generated.swift` per `templates:` entry (§1.4/F). Mocks beside the test target,
+   Component and TypeErase beside the sources — that is the adopter shape, and it is what the naming
+   rules have to serve (§4.6).
+8. The example package grows a third target whose protocol is reachable only transitively, and the
+   mocks config drops its explicit `RIBs` line. Both are red controls: they fail to compile on
+   today's plugin and pass after (§6).
+9. Backward compatible. Every `SOURCERY_TARGET_*` var keeps its name and value; a config with no
+   placeholder is copied unchanged, and a `templates:` entry that names a real file today keeps
+   naming it (§9, D5 and D8).
+
+---
+
+## 1. Current state (verified 2026-09-09)
+
+### 1.1 The plugin exports one level
+
+`PluginContext.environmentVars` (`SourcerySwiftCodegenPlugin.swift:199-215`) iterates
+`package.targets` — the **root package's** targets only — and, per target, its **direct**
+`dependencies`:
+
+| dependency case | exported | what it misses |
+| --- | --- | --- |
+| `.target(t)` (`:221-222`) | `SOURCERY_TARGET_<owner>_DEP_<t.name>` → `t.directory` | `t`'s own dependencies |
+| `.product(p)` (`:224-229`) | `…_DEP_<p.name>_MODULE_<module>` and `…_DEP_<p.name>_TARGET_<target>` per entry of `p.sourceModules` / `p.targets` | the targets those targets depend on, and every package deeper in the graph |
+
+Plus `SOURCERY_TARGET_<t.name>` → the target's own directory, `GIT_ROOT` (`:16-47`, a `git
+rev-parse` subprocess), `SOURCERY_PACKAGE` and `SOURCERY_OUTPUT_DIR` (`:109-111`).
+
+The config then names each var by hand. In
+`Examples/ExampleProjectSpm/Sources/ExampleProjectSpmTests/.Sourcery.Mocks.yml`:
+
+```yml
+sources:
+  - ${SOURCERY_TARGET_ExampleProjectSpm}
+  - ${SOURCERY_TARGET_ExampleProjectSpm_DEP_RIBs_MODULE_RIBs}
+  - ${SOURCERY_TARGET_ExampleProjectSpmTests}/SourceryAnnotations
+```
+
+Two consequences, both real today:
+
+- **A transitively-reachable module cannot be listed.** There is no var for it. The author's only
+  recourse is a literal path into `.build/checkouts/…` or DerivedData, which is not portable.
+- **The Xcode path is worse.** `XcodeTargetDependency.dependencyInfoArray` (`:280-299`) returns `[]`
+  for the `.target` case outright, and `XcodePluginContext.environmentVars` (`:262-278`) never
+  exports a `SOURCERY_TARGET_<name>` for the target itself.
+
+### 1.2 The CLI does not resolve anything
+
+Worth stating because the recollection that prompted this spec had it the other way round.
+`mock-templates` takes a repeatable `--sources` (`Commands.swift:20-21`) and
+`SourceSet.enumerate` walks exactly those roots (`SourceSet.swift:14-51`). The doc comment at
+`Commands.swift:15-18` is the design:
+
+> The tool is policy-free — it hashes the files it is pointed at and knows nothing about who calls it
+> or why; pin policy and source-set derivation live in the calling script.
+
+The transitive index a consumer gets comes from **its own script**: CONTRIBUTING records that the
+reference app's `scripts/generate-mocks.sh` derives it from `swift package dump-package`. So the CLI
+path is self-sufficient only because a shell script can run arbitrary commands. The plugin cannot;
+it has to derive the same set from inside SwiftPM. This spec closes that asymmetry on the plugin
+side and changes nothing about the CLI.
+
+### 1.3 What `2a2857c` tried
+
+```swift
+let transitiveTargetSourceFiles: String = t.recursiveTargetDependencies
+  .flatMap { t in t.sourceModule?.sourceFiles.map { $0.path.string } ?? [] }
+  .joined(separator: ", ")
+…
+("SOURCERY_TARGET_\(t.name)_FILES", "[\(transitiveTargetSourceFiles)]"),
+```
+
+with the config collapsed to `- ${SOURCERY_TARGET_ExampleProjectSpm_FILES}` and the hand-listed roots
+commented out. The resolution half is right and this spec keeps it. The injection half bet that
+Sourcery expands `${}` **before** parsing the YAML, so that a `[a, b, c]` string would re-parse as a
+flow sequence. It does not (§1.4/A). The commit is one commit past `cbc6ad0` on branch `tt`, never
+merged; its `Package.swift` change to a local path dependency landed on `master` separately.
+
+### 1.4 Measured facts about Sourcery 2.3.0
+
+All nine were run against
+`.build/sourcery-2.3.0/sourcery-2.3.0.artifactbundle/sourcery/bin/sourcery`.
+
+**A. `${VAR}` expands after parsing, into one scalar, resolved against the config's directory.**
+With `sources: [- ${TEST_FILES}]` and `TEST_FILES="[/…/a/A.swift, /…/b/B.swift]"`:
+
+```
+error: '/…/envtest/[/…/a/A.swift, /…/b/B.swift]' does not exist or is not readable.
+```
+
+One path, brackets and comma included, prefixed with the config file's own directory. The same
+config with a single path in the var generates fine. **This kills the aggregate-env-var route for
+good, and it is also the constraint behind §4.3** — a synthesized config in a different directory
+changes what every *relative* path in it means.
+
+**B. `--config` discards command-line inputs.** The binary carries the string:
+
+> `Using configuration file at '…'. WARNING: Ignoring the parameters passed in the command line.`
+
+So the plugin cannot pass a derived `--sources` alongside the author's `--config`. Either the config
+carries the sources or they are not passed.
+
+**C. Directories are accepted, and overlap is harmless.** A `sources:` list holding a directory, the
+same directory again, and a file already inside it parsed each type once
+(`// parsed protocols: Alpha Beta`). Dedup is a size and legibility concern, not a correctness one.
+
+**D. `sources:` also takes the `include:` / `exclude:` form,** and `exclude` is honoured (excluding
+`b/B.swift` dropped `Beta`). Any placeholder design has to work inside `include:` too.
+
+**E. PackagePlugin exposes the whole graph.** From the Xcode 26.5 plugin API interface:
+`Target.recursiveTargetDependencies: [any Target]`, `Target.sourceModule: (any SourceModuleTarget)?`,
+`SourceModuleTarget.{moduleName, kind, sourceFiles}`, `ModuleKind.{generic, executable, snippet,
+test, macro}`, and `Package.dependencies: [PackageDependency]` where `PackageDependency.package` is a
+full `Package` with its own `targets`, `directoryURL` and `dependencies`. Access was never the
+blocker.
+
+**F. One output file per template, named after the template.** A config naming two templates with a
+directory `output:` wrote `t.generated.swift` and `t2.generated.swift`. So a config is a
+(sources, args, output) tuple that can drive several templates, and a generated file's name comes
+from its template, never from the config's name. §4.7, D8 and D9 rest on this.
+
+**G. A config without sources is fatal.**
+
+```
+error: … 'Invalid sources. 'sources', 'project' or 'package' key are missing.'
+```
+
+Note the alternatives: `project:` and `package:` also satisfy the requirement, so "has no sources"
+means none of the three keys is present (§4.6).
+
+**H. A config without `output:` is fatal.**
+
+```
+error: … 'Invalid output. 'output' key is missing or is not a string or object.'
+```
+
+Despite `--output`'s "Default is current path" in `--help`, the config path requires the key. **G and
+H together are what make §4.6's defaults strictly additive**: no config that works today omits either
+key, so filling them in cannot change the meaning of anything that already runs.
+
+**I. A duplicate top-level key is silent, and the last one wins.** A config with two `output:` keys
+generated into the second directory and reported nothing. This is what makes §4.2's step 3 the one
+rule that can change a build's meaning if it misreads the document, and it is why that step logs.
+
+### 1.5 The plugin's hard constraints
+
+**It cannot depend on a library.** Measured — a package declaring
+`.plugin(name: "P", capability: .buildTool, dependencies: ["Lib"])` fails to build:
+
+```
+error: plugin 'P' cannot depend on 'Lib' of type 'library'; this dependency is unsupported
+```
+
+So: no Yams, no shared code with `Sources/mock-templates`, no unit-test target that imports the
+plugin's types. Everything the plugin does is PackagePlugin + Foundation in one file, and every check
+on it is black-box (§7).
+
+**It may write only under `pluginWorkDirectory`.** Already relied on — `_createBuildCommands`
+creates three directories there (`:96-107`) — and it is where the synthesized config goes.
+
+**Its prebuild command re-runs on every build.** Whatever the plugin writes at plan time has to be
+byte-identical between runs that resolve the same graph, or Sourcery's cache
+(`--cacheBasePath`, `:147-148`) is invalidated every time.
+
+---
+
+## 2. The rule after this spec
+
+A target's Sourcery config declares **what to generate**: which templates, with which arguments. The
+plugin supplies **where** — the target's own sources plus the recursive closure of its dependencies,
+first-party and external alike, as directories; the output directory the build actually consumes, and
+an error if the config names another; the absolute path of a template named by name; and the module
+under test where only one module can be meant. The two meet in a config the plugin synthesizes into
+its work directory by copying the author's file, expanding what it declares and appending what it
+omits.
+
+The smallest config that works becomes `templates:` plus `args:`. An author who wants today's
+behaviour writes the file they write today and gets it back byte-identical.
+
+---
+
+## 3. Derivation
+
+### 3.1 The closure
+
+For the target being built:
+
+```swift
+func sourceRoots(for target: Target) -> [Path] {
+  let modules: [any SourceModuleTarget] =
+    ([target] + target.recursiveTargetDependencies).compactMap { $0.sourceModule }
+  return modules
+    .filter { $0.kind == .generic || $0.kind == .executable || $0.kind == .test }
+    .map { $0.directory }
+}
+```
+
+- `recursiveTargetDependencies` is the transitive closure and does **not** include the receiver, so
+  the target's own directory is prepended.
+- `compactMap { $0.sourceModule }` drops binary targets, system libraries and plugin targets — they
+  have no Swift sources to parse.
+- `.macro` and `.snippet` are filtered out: a macro target's sources are compiler-plugin code, and a
+  snippet is not part of the module surface. Neither can contribute a protocol a mock is generated
+  from.
+
+### 3.2 Directories, not files
+
+`2a2857c` enumerated `sourceFiles` per module. Three reasons this emits `directory` instead:
+
+- **Size.** The example package's closure is RxSwift, RxRelay, RxCocoa, RxBlocking, RxTest, RIBs,
+  Alamofire, Quick, Nimble and the local targets — thousands of files, one env var or one config in
+  the hundreds of kilobytes. As directories it is roughly 30 lines.
+- **Cache stability.** A file added to any module in the closure rewrites a file list and
+  invalidates the Sourcery cache for every target. A directory list is stable until the graph
+  changes.
+- **It is what the author would have written.** The `sources:` entries being replaced are
+  directories.
+
+Measurement A showed overlap is harmless, so `${SOURCERY_TARGET_ExampleProjectSpmTests}/SourceryAnnotations`
+may sit beside a derived entry that already contains it.
+
+### 3.3 Determinism and dedup
+
+The emitted list is: deduplicated by resolved path, with any path that is a descendant of another
+emitted path dropped, then **sorted lexicographically**. `recursiveTargetDependencies` promises a
+dependency order, not a stable one across resolutions, and §1.5 requires byte-identical output
+between builds.
+
+### 3.4 The Xcode path
+
+`XcodeTarget` has no `recursiveTargetDependencies` and `XcodePluginContext` has no package graph. The
+placeholder therefore expands, in the Xcode path, to the target's own input-file directories plus the
+`.product` module directories already reachable at `:287-292` — strictly better than today's `[]` for
+the `.target` case, and still not a closure. The plugin emits `Diagnostics.remark` naming what it
+resolved, and the README says plainly that full derivation is SPM-only. Going further is deferred,
+not dismissed — §11.2.
+
+---
+
+## 4. Injection: the synthesized config
+
+### 4.1 Three ways a config says what to read
+
+| the config | what is scanned |
+| --- | --- |
+| no `sources:`, `project:` or `package:` key at all | the closure — the plugin appends it (§4.6). The zero-configuration case, and fatal today (§1.4/G), so nothing changes meaning |
+| `sources:` containing `- ${SOURCERY_SOURCES}` | the closure, **plus** every other entry in the list |
+| `sources:` without the placeholder | exactly what is listed — today's behaviour, untouched |
+
+The placeholder exists for the middle row, and the middle row is not hypothetical: the example's
+mocks config wants the closure *and* one hand-picked subdirectory
+(`${SOURCERY_TARGET_ExampleProjectSpmTests}/SourceryAnnotations`), which is a subset of a module and
+therefore the one thing derivation must not decide.
+
+It is recognised only as a **whole list item** under `sources:` or `sources.include:` (measurement D
+says both forms exist), and it is deliberately **not** an env var — nothing exports
+`SOURCERY_SOURCES`, so if the plugin's substitution ever failed to run, Sourcery would report an
+unexpanded path rather than silently scanning less than intended.
+
+### 4.2 The transform
+
+Line-oriented, no YAML parsing (§1.5 forbids Yams anyway). Read the author's config as UTF-8 text and
+apply, in order:
+
+1. **Expand the placeholder.** For each line whose content, after trimming, is exactly
+   `- ${SOURCERY_SOURCES}` (a trailing comment allowed), replace it with one line per derived root at
+   the same indentation, each path a **double-quoted YAML scalar** with `\` and `"` escaped — paths
+   contain spaces, and a DerivedData path routinely does. More than one placeholder line → each is
+   expanded; measurement C says the resulting overlap is harmless.
+2. **Resolve bare template names.** For each whole list item under `templates:` that names a shipped
+   template rather than a path, rewrite it to the absolute quoted path (§4.5).
+3. **Fill in what the config leaves out.** Append `sources:` and `output:` when the document declares
+   neither them nor an equivalent, and insert `args.testable` when the module under test is
+   unambiguous (§4.6).
+4. **Verify `output:` when the config declares it.** A value that does not resolve to the plugin's
+   output directory is a `Diagnostics.error`, not a rewrite (§4.6).
+5. Every other byte is copied through, comments and all.
+
+A config with no placeholder, no bare name, both keys present and an `args.testable` of its own comes
+out byte-identical, and the plugin behaves exactly as it does today.
+
+Rules 1 and 2 are "replace one line with N lines", rule 3 is "append a block at the end" — except for
+`args.testable`, the single nested insert, whose indentation rule §4.6 states exactly — and rule 4
+only reads. That is why they can be trusted without a parser: a construct the plugin does not
+recognise is a construct it does not touch.
+
+Rule 3 is the exception worth stating plainly. A duplicate top-level key is **not** an error —
+Sourcery takes the last one silently (§1.4/I) — so a key appended because the plugin misread the
+document would override what the author wrote, with nothing in the log. Three things bound that:
+detection is a `^<key>\s*:` match at column 0, which is the shape of every config this repo ships or
+documents and which a comment line cannot match (the commented-out `# package:` blocks in both
+example configs are correctly invisible to it); a config in flow style (`{sources: […]}`) or split
+across YAML documents is outside the contract and documented as such; and the plugin emits a
+`Diagnostics.remark` naming every default it supplied, so the build log always distinguishes what
+came from the file from what came from the plugin.
+
+### 4.3 Relocation: absolute paths only
+
+Measurement A: relative paths in a config resolve against **the config file's directory**. The
+synthesized copy lives in `pluginWorkDirectory`, so a relative `templates:` or `output:` that works
+today would silently resolve somewhere else.
+
+The contract is therefore: **a config the plugin rewrites must express every path absolutely.** The
+exported vars already do this — every config in the repo complies — and the two rewrites remove the
+reasons to write a relative path at all: §4.5 rule 2 resolves a template file beside the config to
+its absolute path, and §4.6 supplies the output directory. The plugin does not attempt to rewrite
+relative paths (that needs the parser it does not have); it emits a `Diagnostics.warning` when a
+spliced config contains a line matching `^\s*-?\s*[A-Za-z0-9_.]` under a path key, naming the file
+and the line. A warning, not an error: the heuristic is not good enough to block a build on.
+
+### 4.4 Where it goes
+
+`pluginWorkDirectory/.sourceryConfigs/<original file name>` — one per discovered config, keeping the
+original basename so the prebuild command's `displayName` (`:142`) still names something the author
+recognises, and so a Sourcery diagnostic naming the config is traceable. The `.sourceryConfigs`
+directory is created beside the three that already exist (`:96-107`), and the command's `--config`
+(`:145-146`) points at the copy.
+
+Writing happens in `_createBuildCommands`, at plan time — the same place and the same sandbox as the
+existing `createDirectory` calls.
+
+### 4.5 Naming a template: `SOURCERY_TEMPLATES`, and bare names
+
+Today a consumer cannot portably name the templates it depends on. `${GIT_ROOT}/templates/…` works
+only for a config inside this repository; a real consumer would have to hard-code
+`.build/checkouts/…` or a DerivedData path — a path that moves with the resolution, and in Xcode with
+the DerivedData directory.
+
+**Finding the directory.** Walk the package graph — `context.package`, then
+`package.dependencies[].package` recursively, deduplicating by `Package.id` — for the package whose
+`targets` contain one named `SourcerySwiftCodegenPlugin`, and export:
+
+```
+SOURCERY_TEMPLATES = <that package's directoryURL>/templates
+```
+
+Matching on the **plugin target's name** rather than the package name is deliberate: the package's
+manifest name is `SourcerySwiftCodegen`, its identity is `swift-sourcery-templates`, and a consumer
+vendoring it under another directory name changes the identity but not the target name the consumer
+had to write in `plugins:`. The walk is recursive because a consumer may reach the plugin through a
+shared first-party package rather than declaring it itself.
+
+**Naming the template.** With the directory known, a `templates:` entry can be a bare name:
+
+```yml
+templates:
+  - Mocks
+  - Component
+```
+
+Resolution, per whole list item under `templates:`, in order — the first match wins:
+
+1. The item contains `/` or starts with `$` — a path. Left alone.
+2. A file of that exact name exists **beside the author's config** — today's meaning of a relative
+   entry. Rewritten to that absolute path, so the relocation of §4.3 does not break it, and a
+   `Diagnostics.remark` says which file it resolved to.
+3. `<templates dir>/<item>.swifttemplate` or `<templates dir>/<item>` exists, and its basename does
+   not start with `_` — a shipped template. Rewritten to that absolute path.
+4. Neither — left alone, and `Diagnostics.warning` names the item and lists the shipped templates.
+   Sourcery then fails on it, which is the correct outcome for a typo.
+
+Ordering 2 before 3 is what makes this backward compatible: a consumer with its own `Mocks.stencil`
+beside its config keeps getting its own file. The `_` exclusion is not cosmetic —
+`templates/_header.swifttemplate` is an include (`include("_header")` in all three top-level
+templates), not something to run, so the resolvable set is exactly `Component`, `Mocks`, `TypeErase`.
+
+Both `- Mocks` and `- Mocks.swifttemplate` resolve. The bare form is the documented one, and it
+matches how `mock-templates` already records a template in the fingerprint: by basename
+(`mockTemplatesConfigDescription`, `Commands.swift:10-13`). A config that names `Mocks` and a CLI
+invocation that passes an absolute path to the same file produce the same `config:` line, so the two
+paths describe generation identically.
+
+**Why not name the template from the config's filename** — `.Sourcery.Mocks.yml` implying
+`Mocks.swifttemplate`: a config can drive several templates and Sourcery writes one
+`<Template>.generated.swift` per entry (§1.4/F), so a filename cannot carry the list. The discovery
+regex (`:190`) also accepts any name, and the CocoaPods-era configs used `.sourcery-mocks.yml`, so
+giving the middle segment meaning would reinterpret files that already exist. Rejected outright, not
+kept as a fallback (D9): only `templates:` entries are acted on, and a config that omits the key has
+nothing to generate and says so.
+
+**Xcode.** `XcodePluginContext` has no package graph, so `SOURCERY_TEMPLATES` is not exported and
+rule 3 never fires; a bare name warns and fails. Xcode consumers keep writing paths, and the
+`Diagnostics.remark` says why.
+
+### 4.6 The keys the plugin fills in
+
+`sources:` and `output:` are mandatory today — a config missing either fails to load (§1.4/G,
+§1.4/H) — so supplying them cannot change what an existing config means. That makes the
+zero-configuration case worth serving: a config that says only *what to generate* is a complete
+config. The smallest useful one is four lines:
+
+```yml
+# .Sourcery.Mocks.yml — beside the test target
+templates:
+  - Mocks
+```
+
+| key | absent | present |
+| --- | --- | --- |
+| `sources:` (or `project:` / `package:`) | the derived closure is appended, exactly as the placeholder would have expanded it | untouched — the author is naming inputs deliberately |
+| `output:` | the plugin's `generatedFilesDir` is appended, as an absolute quoted path | **verified, and a mismatch is fatal** — see below |
+| `args.testable` | the module under test, when there is exactly one | untouched |
+
+`project:` and `package:` are checked alongside `sources:` because Sourcery accepts any of the three
+as the input declaration (§1.4/G) — appending sources to a config that legitimately uses `package:`
+would override a deliberate choice, silently (§1.4/I).
+
+**`output:` is the plugin's, and disagreeing about it is an error.** A prebuild command's outputs are
+collected from the `outputFilesDirectory` it declared (`:154`); a file written anywhere else is
+written and then ignored, so the target compiles without it and the failure surfaces as a missing
+type, far from its cause. The plugin therefore does not merely default the key — when the config
+supplies one, it expands `${…}` in the value from the env map it is about to pass, standardizes it,
+and compares:
+
+- equal to `generatedFilesDir` → left as written (this is what `${SOURCERY_OUTPUT_DIR}` resolves to).
+- anything else, a subdirectory included → `Diagnostics.error` naming the config, the resolved path
+  and the required one. Loud, not silently rewritten: rewriting would hide an author's intent, and
+  the intent is wrong in a way only they can fix.
+- an object-form `output:` (Sourcery accepts a mapping with `path:`, per §1.4/H's message) → the
+  nested `path:` scalar is checked the same way; a shape the line rules cannot read is a
+  `Diagnostics.warning` saying the output was not verified.
+
+Appending the absolute path rather than `${SOURCERY_OUTPUT_DIR}` is deliberate: the synthesized file
+is the plugin's own, and a literal path is one less expansion between the plugin and the directory
+the build actually consumes. The env var keeps being exported for configs that write it themselves.
+
+**`args.testable`, when the answer is unambiguous.** For a target of kind `.test`, the candidates are
+its **direct** `.target(_)` dependencies whose module is in the root package and is not itself a test
+module. Exactly one candidate → the plugin inserts `testable: [<moduleName>]` under `args:`. Zero, or
+two or more → nothing is inserted, and a `Diagnostics.remark` names the candidates so the author
+knows why they have to write it.
+
+Direct dependencies, not the closure, and that distinction is load-bearing: §6.1 adds
+`ExampleProjectSpmCore` beneath `ExampleProjectSpm`, so the closure has two root-package modules
+while the direct dependencies still have one. The module a test target is testing is the one it
+depends on; a module it reaches only through that one is not. Restricting candidates to `.target`
+dependencies keeps first-party modules from *other* packages out, which is the same judgement and
+also the shape every example has.
+
+The insertion is the one nested edit in §4.2, so its line rule is stated exactly:
+
+- No top-level `args:` → append `args:` with a two-space-indented `testable:` block at the end.
+- `args:` present → take the indentation of the first following line that is neither blank nor a
+  comment and is indented further than `args:` itself, and insert `testable:` at that indentation
+  immediately after the `args:` line. Matching the siblings' indentation is what keeps the mapping
+  parseable.
+- `args:` present with a `testable:` already under it, or written in flow style (`args: {…}`), or
+  with no more-indented line following → nothing is inserted, and the plugin says so.
+
+A `testable` arg the template ignores is harmless — `Component` and `TypeErase` never read it — so
+the rule keys off the target's kind rather than the template's name.
+
+### 4.7 Several configs, several templates
+
+Both multiplicities already work and the naming rules are built for them:
+
+- **Per target**, the plugin discovers every file in the target's directory matching
+  `[^/:]*\.sourcery([^/:]*)\.yml$` (`:83-91`, `:190`) and emits one prebuild command per config
+  (`:113-127`). Non-recursive, so configs live at the target root.
+- **Per config**, `templates:` may list several, and Sourcery writes one
+  `<Template>.generated.swift` per entry into the output directory (§1.4/F).
+
+The adopter shape this is meant to serve:
+
+```
+Sources/MyModule/.Sourcery.Components.yml       templates: [Component, TypeErase]
+Tests/MyModuleTests/.Sourcery.Mocks.yml         templates: [Mocks], args.testable: [MyModule]
+```
+
+The split is forced by the generated code's audience — mocks belong to the test target, type erasures
+and Components to the module — and the plugin already puts each target's output on that target's
+compile path. Splitting *within* a target, on the other hand, is a choice between one config naming
+two templates and two configs naming one each; they generate the same files.
+
+One sharp edge to keep: every config of a target shares one `generatedFilesDir` (`:106`), so two
+configs of the same target that name the same template write the same
+`<Template>.generated.swift` and the second silently wins. The plugin detects that at plan time — the
+resolved template basenames per target are known once rule 2 of §4.2 has run — and emits a
+`Diagnostics.error` naming both configs. The related unknown — those configs also share one
+`--cacheBasePath` and one `--buildPath` — is measured by the fixture rather than argued about (§7).
+
+---
+
+## 5. What the plugin does *not* take over
+
+The question this spec had to answer: with sources derived, should the plugin also supply
+`@testable import` / `import` module names, lint exclusions and the rest? **No.** The synthesized
+config carries them through unread. Here is the reasoning per option, because "the plugin could
+compute it" is true of several of them and still wrong. The line between the two columns is not
+"could the plugin work it out" but **"is there one right answer"**: a derivation that is right most
+of the time is worse than no derivation, because the config no longer says what happens.
+
+| option | derivable? | verdict |
+| --- | --- | --- |
+| `args.testable` | When the test target directly depends on exactly one root-package non-test module — yes | **Defaulted when unambiguous** (§4.6). One candidate is not a guess, it is the answer. Two or more and the plugin inserts nothing and names them: only the author knows which module the mocks belong to, and a wrong guess emits `@testable import` of a module the file never references — a warning in every consumer build. |
+| `args.import` | No | **Author's.** The imports a generated file needs are a function of the types appearing in the emitted signatures, not of the dependency list. Importing the closure would emit `import Quick` into a mocks file: unused-import noise in a repo whose fast lane gates on zero diagnostics. |
+| `args.excludedSwiftLintRules` | No | **Author's.** Consumer lint policy. |
+| `templates` | The *path*, yes; the *choice*, no | **Author's, with the path resolved.** Which template runs is the whole reason a target carries several configs. §4.5 resolves a bare name to the shipped file so the choice can be written portably; the choice itself stays authored, and a config that omits `templates:` has nothing to generate. |
+| `output` | Yes | **The plugin's** (§4.6). Outputs are collected only from `outputFilesDirectory` (`:154`), so there is exactly one right answer: supplied when omitted, and a config that names a different one fails loudly rather than generating into a directory nothing reads. |
+| `sources` | Yes | **Derived** — appended when the config declares no inputs, expanded in place where the placeholder appears (§4.1). |
+
+The shape this lands on: a config says *what to generate*, and every part of *where to read and where
+to write* has a defensible single answer the plugin fills in. What the plugin never does is guess at
+an option whose right value depends on what the author meant — and where an option is unambiguous in
+one package and ambiguous in the next, it fills in only the first case and says why in the second.
+
+---
+
+## 6. Examples
+
+### 6.1 A third target — the transitive first-party case
+
+The pitfall CONTRIBUTING documents ("Sourcery only knows the declarations it parses") has no example
+reproducing it. Add `Examples/ExampleProjectSpm/Sources/ExampleProjectSpmCore/`:
+
+```swift
+// ExampleProjectSpmCore — no annotation here; this module is not scanned today.
+public protocol Persisting {
+  func save(_ data: Data, key: String) throws
+}
+```
+
+`ExampleProjectSpm` depends on it and refines it:
+
+```swift
+// sourcery: CreateMock
+protocol ProfilePersisting: Persisting {
+  var profileID: String { get }
+}
+```
+
+`ExampleProjectSpmTests` depends on `ExampleProjectSpm` only — so `Persisting` is reachable exactly
+one level deeper than any exported var, which is the case with no expressible workaround today. It is
+also the case that separates §4.6's two candidate rules: the test target's *closure* now holds two
+root-package modules, its *direct* dependencies still hold one, and `args.testable` keeps defaulting
+to `ExampleProjectSpm` because D11 chose the latter.
+
+**Red control:** on today's plugin the generated `ProfilePersistingMock` carries `profileID` and not
+`save`, and the test target fails to compile with "type 'ProfilePersistingMock' does not conform to
+protocol 'ProfilePersisting'" — the failure mode CONTRIBUTING describes as surfacing only in a
+consumer's build. After this spec it compiles, and a spec in
+`SwiftSourceryTemplatesMocksSpec.swift` asserts `saveCallCount` / `saveArgs` record.
+
+### 6.2 The transitive external case
+
+Drop this line from `.Sourcery.Mocks.yml`:
+
+```yml
+  - ${SOURCERY_TARGET_ExampleProjectSpm_DEP_RIBs_MODULE_RIBs}
+```
+
+The existing `RIBs+SourceryAnnotations.swift` extensions keep generating their mocks only if the
+derived closure really reaches an external checkout. The existing RIBs specs are the assertion; no
+new test needed.
+
+### 6.3 Consumer-shaped configs
+
+The examples stop being the only configs that could have been written the way they are. Both drop
+`${GIT_ROOT}/templates/…` for a bare template name; `GIT_ROOT` keeps being exported, since it is
+public contract and a consumer may still want it.
+
+`.Sourcery.Mocks.yml`, beside the test target — the mixed case, keeping one hand-picked subset:
+
+```yml
+sources:
+  - ${SOURCERY_SOURCES}
+  - ${SOURCERY_TARGET_ExampleProjectSpmTests}/SourceryAnnotations
+templates:
+  - Mocks
+args:
+  import: [ … unchanged … ]
+```
+
+Four `sources:` entries become two, `output:` and `args.testable` disappear (§4.6), and the remaining
+hand-written source entry is there because the author wants a *subset* of a directory — the one thing
+derivation must not decide. Dropping `testable` rather than leaving it explicit is deliberate: it
+puts D11's default on the full lane, where a change to the candidate rule shows up as a compile
+failure in the specs rather than as a passing test that no longer proves anything.
+
+`.Sourcery.TypeErase.yml`, beside the sources target — the zero-configuration case, since it scans
+only its own target and the closure is a superset of that:
+
+```yml
+templates:
+  - TypeErase
+args:
+  import: [RIBs, RxSwift, UIKit]
+  excludedSwiftLintRules: [ … unchanged … ]
+```
+
+Both files then read as *what to generate* and nothing else, which is the claim §2 makes.
+
+To also cover §4.7's multiplicity in something CI runs, the sources-side config additionally names
+`Component`, generating `Component.generated.swift` beside `TypeErase.generated.swift` from one
+config — the two-templates-one-config shape, which nothing exercises today.
+
+### 6.4 The cost to measure
+
+The derived closure is much bigger than what the example lists today: RxSwift, RxCocoa, RxRelay,
+RxBlocking, RxTest, Alamofire, Quick, Nimble and RIBs, in full. Sourcery parses all of it on a cold
+cache. **Record the example lane's wall time before and after** and put both numbers in the
+CHANGELOG entry. If the increase is material, the mitigations in order are: `sources.exclude` in the
+example config; a `${SOURCERY_SOURCES_LOCAL}` variant scoped to the root package (§11.1); leaving the
+external modules to explicit vars, which still works.
+
+This is the one place the spec's approach can fail on its merits rather than on its mechanics, so it
+is measured rather than argued.
+
+---
+
+## 7. Checks
+
+The plugin cannot be imported by a test target (§1.5), so every check is black-box over a fixture
+package.
+
+New lane, `Checks/run-plugin-checks.sh`, over `Checks/PluginFixture/` — a package with a three-level
+target chain (`Leaf` ← `Middle` ← `App`), an external-looking path dependency, and four configs, one
+per shape §4.1 and §4.6 define:
+
+| gate | what it proves |
+| --- | --- |
+| **splice** | after `swift build`, the synthesized config under `.build/plugins/…/.sourceryConfigs/` contains one quoted directory line per module in the closure, sorted, with `Leaf` present — the case no env var can express |
+| **passthrough** | every other line of the placeholder config, comments included, is byte-identical to the source file |
+| **defaults** | a config carrying only `templates:` comes out with a `sources:` block holding the closure and an `output:` holding the absolute output directory, and generates |
+| **no-defaults** | a config declaring both keys gets neither appended — and one declaring `package:` instead of `sources:` gets no `sources:` block (§1.4/G, the silent-override case of §1.4/I) |
+| **wrong output** | a config whose `output:` resolves anywhere but the plugin's directory fails the build with a `Diagnostics.error` naming both paths — the red control for D12 |
+| **testable** | the fixture's test target, with one direct root-package dependency, gets `testable: [<module>]` inserted at the existing `args:` indentation; a second fixture target with two gets nothing and a remark; a config that already has `testable` is untouched; a non-test target never gets it |
+| **bare name** | `- Mocks` resolves to the shipped template; a template file beside the config wins over the shipped one of the same name (§4.5 rule 2 before rule 3); an unknown name warns and fails |
+| **collision** | two configs of one target naming the same template is a `Diagnostics.error`, not a silent overwrite (§4.7) |
+| **determinism** | a second `swift build` with no source change leaves every synthesized config byte-identical (§1.5, cache stability) |
+| **no-placeholder** | a config with none of the above is copied verbatim and generates what it generates today |
+| **generation** | the generated mock for the `Leaf`-refining protocol carries the inherited requirement — the §6.1 failure, at fast-lane speed |
+
+`Checks/run-checks.sh` and `run-cli-checks.sh` are untouched: no template and no CLI behaviour
+changes here. CI gains the plugin lane beside `checks` and `cli` (it needs no simulator); the
+`example-project` lane keeps covering the real thing.
+
+The fixture also carries the **shared-cache measurement**. A target with two configs is the shape
+§4.7 encourages and nothing has ever run: both prebuild commands are handed the same
+`--cacheBasePath` and `--buildPath` (`:96-102`, `:147-150`). Build that target repeatedly, cold and
+warm, and record whether the two runs interfere — a corrupted cache, a "recovering with a full
+rebuild" line, or nothing at all. The answer decides whether each config needs its own cache
+subdirectory, which costs a cold cache per config; until it is measured the spec claims nothing about
+it.
+
+---
+
+## 8. Phasing
+
+Each step is a commit that stands on its own and leaves `master` green.
+
+1. **Template naming** (§4.5): the graph walk, `SOURCERY_TEMPLATES`, and bare-name resolution.
+   Independently useful, changes no existing config's meaning, and the fixture only needs one config.
+   Examples adopt the bare form in the same commit; `GIT_ROOT` stays exported.
+2. **Derivation, the placeholder and the defaults** (§3, §4.1-4.4, §4.6). The plugin change, the
+   fixture package and `Checks/run-plugin-checks.sh`, plus the CI lane. Carries the `output:`
+   verification (D12) and the `args.testable` default (D11) — both are §4.6 and both need the same
+   line machinery. No example config uses any of it yet, so the full lane must be unchanged: that is
+   the backward-compatibility gate.
+3. **The collision diagnostic and the cache measurement** (§4.7, §7). Small, and both want the
+   preceding steps: the diagnostic is stated in terms of resolved template names, and the measurement
+   needs a fixture target carrying two configs.
+4. **The example adopts it** (§6.1-6.3). New `ExampleProjectSpmCore` target, the refining protocol,
+   the dropped RIBs line, the two configs reduced to what they generate, the added `Component`
+   entry, the new spec assertions, and the before/after wall-time measurement.
+5. **Docs.** README's plugin section rewritten around the three config shapes; CONTRIBUTING's
+   "Sourcery only knows the declarations it parses" pitfall gains "on the plugin path,
+   `${SOURCERY_SOURCES}` closes this"; a CHANGELOG entry carrying both wall-time numbers.
+6. **The Xcode path** (§3.4) — degrade safely and say so in the README. The exploration of whether
+   it can do better is deferred (§11.2); what this step owes is that an Xcode consumer's build does
+   not break and the log says which features are SPM-only.
+
+Steps 1-3 are worth landing even if 4 measures badly (§6.4): everything before the example is opt-in,
+and a consumer with a small graph benefits regardless.
+
+---
+
+## 9. Decisions
+
+- **D1 — Line rules, not a YAML parser.** A plugin cannot depend on a library (§1.5, measured), so a
+  parser would have to be hand-written; a hand-written YAML parser deciding what a consumer's config
+  means is a much larger liability than a line-level substitution. Costs, all three real: the
+  placeholder and a bare template name must each be a whole list item; §4.3's relative-path contract
+  cannot be enforced properly; and a top-level key is detected by a column-0 line match, which a
+  flow-style or multi-document config defeats — silently, because a duplicate key is last-wins
+  (§1.4/I). That last one is why §4.2 rule 3 logs what it appended.
+- **D2 — Directories, not the file list of `2a2857c`.** §3.2. Smaller, cache-stable, and the shape
+  the entries being replaced already had.
+- **D3 — Absolute paths are a contract, and the check is a warning.** §4.3. Erroring on a heuristic
+  would block builds the plugin misread; the three configs in this repo already comply.
+- **D4 — The plugin supplies where, the config says what.** §5. `sources` and `output` have one
+  defensible answer each; `args.import`, the lint exclusions and the choice of template do not, and
+  stay authored. The test is not "can the plugin compute it" but "is there one right answer" —
+  applied per package, not per option, which is what D11 turns on.
+- **D8 — A template is named by name, not by path or by the config's filename.** §4.5. A path is
+  what a consumer cannot write portably, and the config's filename cannot carry a list — a config may
+  name several templates and Sourcery writes one file per entry (§1.4/F). Naming by basename also
+  matches what `mock-templates` records in the fingerprint (`Commands.swift:10-13`), so the plugin
+  path and the CLI path describe generation identically. A file beside the config still wins, which
+  is what keeps the rule backward compatible.
+- **D9 — The config's filename is never load-bearing.** The discovery regex (`:190`) accepts any
+  `*.sourcery*.yml`, and the CocoaPods-era configs used `.sourcery-mocks.yml`; giving the middle
+  segment meaning would reinterpret files that already exist, and would make a rename change what a
+  build generates. The filename names the file, and nothing else — not even as a fallback for a
+  config that omits `templates:`, which is simply an error. Only `templates:` entries are acted on.
+- **D10 — Defaults are appended, not merged.** §4.6. A missing `sources:` or `output:` is fatal today
+  (§1.4/G, §1.4/H), so supplying them cannot change an existing config; and appending a block is a
+  transform the plugin can perform correctly without understanding the document, which merging into
+  an existing key is not. `args.testable` is the single exception and pays for it with an explicit
+  indentation rule and three cases where it declines to act.
+- **D11 — `args.testable` defaults from the *direct* dependencies, not the closure.** §4.6. The
+  module a test target tests is the one it depends on; one it reaches only through that module is
+  not. The distinction is not academic — §6.1's new `ExampleProjectSpmCore` makes the closure
+  ambiguous and leaves the direct dependencies unambiguous, so a closure-based rule would stop
+  defaulting exactly when the example got more realistic.
+- **D12 — A wrong `output:` fails the build.** §4.6. Generating into a directory the build does not
+  collect from produces a target that compiles without the generated file; the error surfaces as a
+  missing type with nothing pointing at the config. The plugin knows the right answer, so it says so
+  rather than silently rewriting the author's value — a rewrite would make a deliberate-looking line
+  a lie.
+- **D5 — Every existing env var keeps its name and value.** A config with no placeholder is copied
+  verbatim. This spec adds capability and removes none, so no consumer has to change anything.
+- **D6 — `mock-templates` is unchanged.** Its doc comment (§1.2) commits it to policy-freedom, and a
+  caller who wants derivation has a shell. Making the CLI resolve a package graph would mean
+  shelling out to `swift package dump-package` from a tool whose whole value is that it needs no
+  toolchain at validation time.
+- **D7 — The placeholder is not an env var.** §4.1. An unexpanded `${SOURCERY_SOURCES}` fails loudly;
+  an unexported env var expands to nothing and silently scans less.
+
+---
+
+## 10. Non-goals
+
+- Fingerprinting on the plugin path. The plugin runs `sourcery` directly (`:143-144`); routing it
+  through `mock-templates generate` would give plugin-generated files a provenance block, and it is
+  a separate change with its own design (the output would land in DerivedData, where a fingerprint
+  proves nothing a rebuild does not).
+- Any template change. This spec moves no generated byte except by scanning more sources.
+- CocoaPods. Retired at `4b1d0bb`.
+- Teaching Sourcery about SPM. Its `package:` config key exists (both example configs carry it
+  commented out) and would need the engine to run SwiftPM itself — the thing the plugin sandbox is
+  there to prevent.
+
+---
+
+## 11. Open questions
+
+1. **Does the full closure cost too much?** §6.4. Measured in phase 4, and the answer decides whether
+   `${SOURCERY_SOURCES_LOCAL}` (root-package modules only) ships beside the full variant or not at
+   all. The only question here that can invalidate an approach rather than tune one.
+2. **The Xcode path.** Deferred, and worth exploring later rather than closing now. `XcodeTarget` has
+   no `recursiveTargetDependencies` and `XcodePluginContext` no package graph, so §3.4 degrades to
+   the target's own input directories plus the product modules already reachable — better than
+   today's `[]`, not a closure. Two threads when it is picked up: whether the checkouts directory can
+   be reached from the resolved artifact path well enough to export `SOURCERY_TEMPLATES`, and whether
+   a small committed `.xcodeproj` fixture is worth its maintenance — with the CocoaPods example gone
+   there is no coverage of `XcodeBuildToolPlugin` at all.
+3. **The object form of `output:`.** §4.6 checks a nested `path:` scalar and warns on any other
+   shape. Nothing in this repo has ever written one, so the shape is unmeasured; if a consumer turns
+   up using `link:` to add generated files to an Xcode target, the check needs revisiting rather than
+   extending.
+
+Resolved while drafting, and recorded where they belong rather than here: `args.testable` defaults
+when unambiguous (D11, §4.6); a config that names the wrong `output:` fails the build (D12, §4.6);
+the config's filename is never load-bearing and only `templates:` entries are acted on (D9, §4.5);
+the shared per-target cache and build directories are measured by the fixture rather than argued
+(§7).

--- a/specs/001-plugin-source-discovery/spec.md
+++ b/specs/001-plugin-source-discovery/spec.md
@@ -1,7 +1,10 @@
 # 001 — A self-sufficient build-tool plugin: a derived source closure, a synthesized config, and the options the author keeps
 
-**Status:** Draft, 2026-09-09. Nothing implemented. Every measurement in §1.4 and §1.5 was run
-against this checkout on 2026-09-09 with Sourcery 2.3.0 and the Xcode 26.5 toolchain.
+**Status:** Implemented, 2026-09-09, on `spec/001-plugin-source-discovery`. Every measurement in §1.4
+and §1.5 was run against this checkout on 2026-09-09 with Sourcery 2.3.0 and the Xcode 26.5 toolchain;
+§1.4/C, /G and /H were re-run on Xcode 26.6 while implementing. **§12 records what building it
+changed** — two of the mechanisms below do not survive contact with the plugin API, and one open
+question is now answered.
 **Scope:** `Plugins/SourcerySwiftCodegenPlugin/SourcerySwiftCodegenPlugin.swift`,
 `Examples/ExampleProjectSpm/`, `Checks/`, README and CONTRIBUTING. No template change. No change to
 `mock-templates` — the CLI stays policy-free (§9, D6).
@@ -792,9 +795,10 @@ and a consumer with a small graph benefits regardless.
 
 ## 11. Open questions
 
-1. **Does the full closure cost too much?** §6.4. Measured in phase 4, and the answer decides whether
-   `${SOURCERY_SOURCES_LOCAL}` (root-package modules only) ships beside the full variant or not at
-   all. The only question here that can invalidate an approach rather than tune one.
+1. ~~**Does the full closure cost too much?**~~ **Answered: no.** The example lane, cold, three
+   samples each: 32/29/30s before, 36/36/34s after — about +5s, and the "after" also carries a third
+   target, four new specs and a second template. `${SOURCERY_SOURCES_LOCAL}` does not ship; the other
+   mitigations in §6.4 stay unneeded. The numbers are in the CHANGELOG entry.
 2. **The Xcode path.** Deferred, and worth exploring later rather than closing now. `XcodeTarget` has
    no `recursiveTargetDependencies` and `XcodePluginContext` no package graph, so §3.4 degrades to
    the target's own input directories plus the product modules already reachable — better than
@@ -812,3 +816,63 @@ when unambiguous (D11, §4.6); a config that names the wrong `output:` fails the
 the config's filename is never load-bearing and only `templates:` entries are acted on (D9, §4.5);
 the shared per-target cache and build directories are measured by the fixture rather than argued
 (§7).
+
+---
+
+## 12. What building it changed
+
+Written after the fact. Everything above is left as it was drafted; this section is the diff between
+the plan and the code, so a reader who trusts §4 knows where not to.
+
+**A. A plugin target is not in `Package.targets`, so §4.5's graph match could never fire.**
+`PackagePlugin.Package.targets` exposes `SwiftSourceModuleTarget`, `ClangSourceModuleTarget`,
+`BinaryArtifactTarget` and `SystemLibraryTarget` — there is no plugin-target type in the API at all.
+Matching `$0.name == "SourcerySwiftCodegenPlugin"` therefore matches nothing, and the first fixture
+build failed with every bare template name unresolved.
+
+The property §4.5 wanted from the target name is that it lives in *this* repository rather than the
+consumer's, so vendoring under another directory name cannot break it. `Package.displayName` — the
+manifest's own `name:`, `SourcerySwiftCodegen` — has exactly that property; only the identity moves
+when a consumer vendors the package. The plugin matches `displayName` or the canonical identity
+`swift-sourcery-templates`, and requires the `templates/` directory to exist, so a consumer package
+that happens to share the name is not mistaken for this one. Everything §4.5 says about *resolution*
+(the four rules, rule 2 before rule 3, the `_` exclusion) is unchanged.
+
+**B. Two configs of one target cannot share an output directory — and the failure is louder than
+§4.7 expected.** §4.7 predicted that two configs naming the same template would have the second
+silently overwrite the first. What actually happens is worse and does not need the same template:
+SwiftPM collects a prebuild command's outputs by scanning the whole directory it declared, so two
+commands of one target declaring one directory makes it attribute every file to both and refuse the
+build outright —
+
+```
+error: couldn't build …/AppTests.build/Mocks.generated.swift.o because of multiple producers:
+       Compiling Swift Module 'AppTests' (5 sources), Compiling Swift Module 'AppTests' (5 sources)
+```
+
+— which means the "Mocks beside the test target, Component and TypeErase beside the sources" shape
+§4.7 calls the adopter shape did not work for *any* two configs of one target, whatever they named.
+
+Each config now owns `‹pluginWorkDirectory›/.generatedFiles/‹config name›/`, and `SOURCERY_OUTPUT_DIR`
+is exported per config. §4.6's `output:` check is unchanged in kind — it now compares against the
+config's own directory. §4.7's collision diagnostic survives and is still worth having: with separate
+directories the two files no longer overwrite each other, they land on one compile path declaring the
+same types, so the plan-time error names the two configs instead of leaving a redeclaration error in
+generated code.
+
+**C. The shared cache and build directories are fine, measured.** §7 left this open. With B's split in
+place, `AppTests` carries two configs sharing one `--cacheBasePath` and one `--buildPath`; the lane
+drops the caches and rebuilds twice, and both configs produce byte-identical output with no
+cache-recovery line in the log. They stay shared, so two configs over one closure still share the
+parse cache.
+
+**D. `Diagnostics.remark` reaches the build log only under `swift build -v`.** Warnings and errors
+surface in a normal build; remarks do not. §4.2 rests on the log always distinguishing what the plugin
+supplied from what the author wrote, and it still does — but the reader has to ask for it. The plugin
+check lane builds with `-v` for exactly this reason, and the README says so.
+
+**E. Phasing.** The six phases of §8 were implemented as one change rather than six commits. The
+reason is B: phase 1 (template naming) and phase 2 (derivation) are independent on paper, but the
+fixture that proves either of them needs a target with two configs, which does not build until B is
+fixed — and B is a phase 3 concern. Splitting the commit afterwards would have produced two commits
+neither of which had ever been green.


### PR DESCRIPTION
A working branch for [specs/001-plugin-source-discovery/spec.md](https://github.com/modaal-agent/swift-sourcery-templates/blob/spec/001-plugin-source-discovery/specs/001-plugin-source-discovery/spec.md). The spec is the only new file; the implementation will land on this branch.

## What it plans

The plugin exports **one level** of the package graph as env vars, and the config hand-lists each one — so a module reachable only transitively has no var and cannot be named at all. `2a2857c` on branch `tt` tried to close this in Feb 2024 and was abandoned; its resolution half was right (`Target.recursiveTargetDependencies` is the closure) and its injection half bet that Sourcery expands `${}` before parsing the YAML. It does not.

So the plugin **synthesizes a config**: the author's file copied byte for byte into `pluginWorkDirectory`, with one placeholder line — `- ${SOURCERY_SOURCES}` — expanded into one directory per module in the closure. Directories, not the per-file list `2a2857c` built: ~30 lines instead of thousands, and stable when a file is added, which keeps Sourcery's cache warm.

Four other things follow from having the graph:

- **`SOURCERY_TEMPLATES` and bare template names.** `- Mocks` resolves to the shipped template, so a consumer stops hard-coding `.build/checkouts/…`. A file beside the config still wins, which is what keeps it backward compatible.
- **Defaults for what a config omits.** `sources:` and `output:` are appended when absent — free, because Sourcery rejects a config missing either one today.
- **`args.testable` where only one module can be meant** — from the test target's *direct* root-package dependencies, not its closure.
- **A wrong `output:` fails the build** instead of generating into a directory nothing reads.

## What was measured

Nine measurements against Sourcery 2.3.0 and the Xcode 26.5 plugin API are in §1.4/§1.5, each with the command that produced it. The three that shaped the design:

| measured | consequence |
| --- | --- |
| a config missing `sources:` or `output:` is fatal | supplying them cannot change anything that works today |
| a duplicate top-level key is silent, last-wins | the one rule that appends has to log what it appended |
| a build-tool plugin cannot depend on a library target | no YAML parser, no shared code with the CLI, every check black-box |

## Reviewing

§0 is the summary; §5 answers "why doesn't the plugin also supply the imports and the lint rules"; §8 is the phasing; §9 the decisions with their costs; §11 what is still open — chiefly whether parsing the full closure costs too much, which is measured in phase 4 and is the only question that can invalidate the approach rather than tune it.

Base note: this branch also carries `4b1d0bb` (retire CocoaPods) and `791d565` (specs/ doc map), which are on local `master` but not yet pushed. The diff narrows to the spec alone once `master` is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)