### PR TITLE
One set of rules, in two files CI keeps identical

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,78 @@ env:
   SOURCERY_VERSION: '2.3.0'
 
 jobs:
+  # ── Rules lane ───────────────────────────────────────────────────
+  # AGENTS.md and CLAUDE.md are one file kept in two places, so that an agent
+  # reading either gets the same rules. This repository once carried different
+  # material in each and the copies drifted. The only lane that reads markdown
+  # and nothing else: no Swift toolchain, no Xcode, no macOS runner, so it runs
+  # on ubuntu in seconds and reports before the others have finished booting.
+  rules:
+    name: Rules files (AGENTS.md == CLAUDE.md)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: AGENTS.md and CLAUDE.md are byte-identical
+        # Fix a failure with `cp AGENTS.md CLAUDE.md`.
+        run: cmp AGENTS.md CLAUDE.md
+
+  # ── Change filter ────────────────────────────────────────────────
+  # Reports whether the push touched anything a build can read. Markdown cannot
+  # break a Swift build, so a docs-only push skips the four macOS lanes rather
+  # than spending about six minutes and a simulator boot to confirm a README is
+  # still a README. The `rules` job is deliberately not gated on this: it reads
+  # markdown, which is exactly what a docs-only push changes.
+  #
+  # It fails open. When the range cannot be computed — a branch's first push,
+  # where `event.before` is all zeros; a force push whose old tip is gone; a
+  # manual dispatch, which sets no range at all — it reports `true` and every
+  # lane runs. A filter that is wrong must be wrong in the direction of running
+  # the lane, because the other direction lands a change nothing checked.
+  changes:
+    name: Change filter
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # The default depth of 1 cannot diff against the previous tip.
+          fetch-depth: 0
+
+      - id: filter
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BEFORE:-}" ] \
+             || [ "$BEFORE" = "0000000000000000000000000000000000000000" ] \
+             || ! git cat-file -e "${BEFORE}^{commit}" 2>/dev/null; then
+            echo "no usable range (before='${BEFORE:-}') — running every lane"
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          changed="$(git diff --name-only "$BEFORE" "$AFTER")"
+          if [ -z "$changed" ]; then
+            echo "empty diff — running every lane"
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "changed files:"
+          printf '%s\n' "$changed" | sed 's/^/  /'
+          # Tested on the file list, not on grep's exit status: `grep -q -v`
+          # is not portable between grep implementations.
+          code_files="$(printf '%s\n' "$changed" | grep -vE '\.md$' || true)"
+          if [ -n "$code_files" ]; then
+            echo "outside **.md, so every lane runs:"
+            printf '%s\n' "$code_files" | sed 's/^/  /'
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "markdown only — skipping the four macOS lanes"
+            echo "code=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # ── Fast lane ────────────────────────────────────────────────────
   # Runs first, and alone, because it catches most template regressions in
   # about a minute: it is the only lane that diffs the generated output against
@@ -43,6 +115,8 @@ jobs:
   # language mode. It needs no simulator and no third-party package.
   checks:
     name: Checks (snapshot, both language modes, behaviour)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v5
@@ -73,6 +147,8 @@ jobs:
   # a minute.
   cli:
     name: CLI (mock-templates build + checks)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v5
@@ -99,6 +175,8 @@ jobs:
   # through one package shape).
   plugin:
     name: Plugin (source closure, synthesized config, red controls)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v5
@@ -129,7 +207,8 @@ jobs:
   # resolutions.
   example-project:
     name: Example project (RxSwift, RIBs, type erasure, SPM plugin)
-    needs: checks
+    needs: [changes, checks]
+    if: needs.changes.outputs.code == 'true'
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,11 @@
 # Agent rules
 
-Rules for working in this repository. They are the additions to
-[CONTRIBUTING.md](CONTRIBUTING.md), not a summary of it.
+Rules for working in this repository. They are the additions to [CONTRIBUTING.md](CONTRIBUTING.md),
+not a summary of it.
+
+`AGENTS.md` and `CLAUDE.md` are one file kept in two places, byte for byte. Edit `AGENTS.md`, then
+`cp AGENTS.md CLAUDE.md`; CI fails if they differ. This repository once carried different material
+in each and the copies drifted.
 
 **Read first, by question:**
 
@@ -11,14 +15,94 @@ Rules for working in this repository. They are the additions to
 | how the templates are built, where to change what, the pitfalls already hit | [CONTRIBUTING.md](CONTRIBUTING.md) |
 | what changed in a release and what it breaks | [CHANGELOG.md](CHANGELOG.md) |
 | which fixture covers which construct | [Tests/Checks/README.md](Tests/Checks/README.md) |
+| the plan for a change too big to carry in a commit message | [specs/](specs/) |
 
-## The generated output is the product — review it as a diff
+Run from the repository root:
+
+```bash
+Tests/Checks/run-checks.sh              # ~10s — snapshot, both language modes, behaviour
+Tests/Checks/run-checks.sh --record     # only after reading the diff the line above printed
+```
+
+## Writing style: state facts and actions, no aphorisms
+
+**Scope: every character of prose you produce for this project.** Specs, docs, code comments, commit
+messages, PR bodies, review findings, and **your replies in chat**. There is no "informal" channel
+where this relaxes.
+
+**The test, applied to each sentence:** does it give the reader **a fact they can verify** or **an
+action they can take**, with the referent named — the file, the line, the setting, the command, the
+number? If it does neither, delete it. A sentence that only characterizes the work, dramatizes a
+finding, or summarizes how significant something is carries no information the reader can act on.
+
+Habits to avoid (common LLM-isms):
+
+- **Mannered prose** substitutes metaphor and flourish for direct statement. Instead of "a parameter
+  worth varying," the mannered writer produces "a dial worth turning." Instead of "this point still
+  matters," they write "this point earns its keep." The phrases exist to display the writer, not to
+  convey the idea, and readers can tell. That is why mannered prose irritates: it makes the reader
+  work harder so the writer can perform. It is also imprecise — metaphors drag in connotations the
+  writer did not choose and cannot control. **The fix is to say what you mean. When a literal phrase
+  is available, use it.**
+- **Aphoristic juxtapositions** ("Free now, a second migration later"). State the trade-off
+  explicitly: what it costs now, what it costs later, which option you recommend.
+- **Dramatic reversals and punchlines** ("that direction has reversed"; "upgraded those steps from
+  redundant to breaking"). Give the before value, the after value, and the date measured.
+- **Negative-space phrasing** ("checked by nobody"; "not cosmetic"; "not the thing to move"). Say
+  which check is missing, in which file, what it costs, and when to add it. If the point is that X
+  is wrong, name what to do instead — "keep the Xcode pin and change `runs-on`", not "the Xcode pin
+  is not the thing to move".
+- **Metaphor or personification as the load-bearing content** ("a fresh package has no code to
+  fight"; "the gate now has teeth"; "what the spec still owes"). A metaphor may decorate a point
+  already stated literally; it may not be the only statement of that point. Documents do not owe,
+  want, or know things — name who does the work, in which file, by when.
+- **Rhetorical contrast standing in for content** ("verified, not merely committed"; "it is not that
+  X, it is that Y"). State both facts separately and drop the contrast.
+- **The closing paragraph that generalizes the lesson.** This is where aphorisms concentrate: a
+  section ends, and the urge is to extract a portable moral. Either write a concrete rule with a
+  named home — the gate to add, the file to add it to — or write nothing.
+
+## Git state — confirm every commit
+
+- **Never commit, amend, push or rewrite history without confirmation in the current turn.**
+  "Implement X", or approval of a *previous* commit, is not authorization for the next one. When
+  work is ready: stop, summarize what changed, ask.
+- **Never touch the index or restore the tree.** `git add`, `git reset`, `git stash`,
+  `git checkout -- <path>`: off-limits unless asked for in this turn. Staged versus unstaged is the
+  reviewer's record of how far they have read, and reverting your own edits to "recover" discards
+  work they have not seen. If a commit is authorized and the index is partly staged, ask which scope
+  before running anything.
+- **Subject line:** imperative, naming the change — "Retire the CocoaPods distribution". Work backed
+  by a spec carries the slug: `[001-plugin-source-discovery] Derive the source closure`. No spec in
+  play, no prefix — do not invent one.
+
+## Changes reach `master` through a pull request
+
+- Code goes on a branch and through a PR, so [`ci.yml`](.github/workflows/ci.yml)'s four lanes run
+  before it lands. They trigger on push, not on PR open.
+- Any merge strategy — merge, rebase or squash — chosen for the nature of the PR.
+- A change touching no code may go straight to `master`: a spec, a note, README or CHANGELOG
+  wording. `templates/`, `Sources/`, `Plugins/`, `Tests/`, `Scripts/` and `.github/` are code.
+- Branch when the work starts. If code is ready and the checkout is `master`, ask which branch.
+- Pushing, opening a PR and merging one each need their own go-ahead.
+
+## Specs are a read-only decision ledger
+
+- **A merged spec is never edited** — not to fix a path a later change moved, not to correct a
+  decision since superseded, not to tidy. Editing it destroys the record.
+- **A new spec names what it obsoletes**, by number and section ("obsoletes 001 §4.6").
+- **Writing a spec is not authorization to implement it.** When the task is a spec, produce only the
+  spec document — no code, config, template or workflow edit, not even the one line that looks
+  ready. When it is written, stop and ask.
+
+## Review generated output as a snapshot diff
 
 - **Run `Tests/Checks/run-checks.sh` before and after every template edit.** It is ~10s and it is
   the only place generated output is visible. A change that looks local to one shape routinely moves
   another.
-- **`--record` is a deliberate act.** Run the gates first, read the snapshot diff, and only then
-  `Tests/Checks/run-checks.sh --record`. Recording before reading turns the gate into a rubber stamp.
+- **Read the snapshot diff before you run `--record`.** Run the gates, read the diff they print,
+  and only then `Tests/Checks/run-checks.sh --record`. Recording first overwrites the snapshot with
+  whatever the template now emits, so nothing is left to compare against.
 - **Never hand-edit anything in `Tests/Checks/Snapshots/`.** Those files are build products; the
   only supported way to change one is to change a template and re-record.
 - **Run the full lane (`Tests/Examples/ExampleProjectSpm/test-ios.sh`) before cutting a tag**, and
@@ -27,35 +111,35 @@ Rules for working in this repository. They are the additions to
 
 ## State a rule once
 
-- A rule about isolation lives in `templates/Mocks/SourceryRuntimeExtensions.swift`; a rule about
-  parameter declarations lives in `MethodParameter.parametersDecl` /
-  `closureAttributesDecl`. Both templates read them. Restating a rule at a call site is how the mock
-  and the Component start disagreeing about the same protocol.
-- Both language modes are the gate, not one: `-swift-version 5 -strict-concurrency=complete` **and**
-  `-swift-version 6`, at zero *diagnostics*. A construct can be a warning under the first and an error
-  under the second.
-- A construct the template cannot handle gets a diagnostic naming the member and what to do about it,
-  not a partial emission that fails at the consumer's conformance.
+- The isolation rules are in `templates/Mocks/SourceryRuntimeExtensions.swift`, the
+  parameter-declaration rules in `MethodParameter.parametersDecl` / `closureAttributesDecl`. Both
+  templates read them. Restating a rule at a call site is how the mock and the Component come to
+  emit different isolation for the same protocol.
+- Both language modes are the gate: `-swift-version 5 -strict-concurrency=complete` **and**
+  `-swift-version 6`, at zero *diagnostics*. A construct can be a warning under the first and an
+  error under the second.
+- A construct the template cannot handle gets a diagnostic naming the member and what to do about
+  it, not a partial emission that fails at the consumer's conformance.
 
 ## Do not tag without measuring the consumer
 
-Follow [CONTRIBUTING.md](CONTRIBUTING.md#cutting-a-release) in order. The step that gets skipped and
-must not be: regenerate `modaal-firebase-wrappers` against `master` and record the size and shape of
-its diff in the `CHANGELOG.md` entry. A release whose consumer impact was not measured is not ready to
-tag. Write the entry **before** tagging, for a consumer deciding whether to bump.
+Follow [CONTRIBUTING.md](CONTRIBUTING.md#cutting-a-release) in order. Its most-skipped step:
+regenerate `modaal-firebase-wrappers` against `master` and record the size and shape of its diff in
+the `CHANGELOG.md` entry. Write that entry **before** tagging — a consumer reads it to decide
+whether to bump.
 
-## Keep the documents in their lanes
+## What goes in which document
 
 - **README.md** — what the templates do and how to use them. A new annotation adds a row to its
   reference table.
 - **CONTRIBUTING.md** — how the templates are built, where to change what, decided design rules,
   pitfalls, testing, release procedure, open items.
-- **AGENTS.md / CLAUDE.md** — rules only. If you are about to write a paragraph explaining what
-  something *is*, it belongs in one of the other two.
+- **AGENTS.md / CLAUDE.md** — rules only, and one file in two places. If you are about to write a
+  paragraph explaining what something *is*, it belongs in one of the other two.
 - **specs/`NNN-slug`/spec.md** — the plan for a change too big to carry in a commit message: what is
   true now (measured, with file and line references), what the rule becomes, the phasing, the
-  decisions and what stays open. A spec is written before the change and left in place after it, as
-  the record of why. It never becomes the place a *rule* lives — that is still AGENTS.md.
+  decisions and what stays open. Written before the change and left in place after it, as the record
+  of why. It never becomes the place a *rule* is stated — that is here.
 
 ## Scope
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,13 @@
-# Claude Code Instructions
+# Agent rules
 
-The rules for working in this repository are in [AGENTS.md](AGENTS.md). Read it before editing
-anything under `templates/`.
+Rules for working in this repository. They are the additions to [CONTRIBUTING.md](CONTRIBUTING.md),
+not a summary of it.
 
-They are deliberately in one file rather than two: this repository previously carried the same
-material in `AGENTS.md` and `CLAUDE.md`, and the copies drifted.
+`AGENTS.md` and `CLAUDE.md` are one file kept in two places, byte for byte. Edit `AGENTS.md`, then
+`cp AGENTS.md CLAUDE.md`; CI fails if they differ. This repository once carried different material
+in each and the copies drifted.
 
-Where the rest lives:
+**Read first, by question:**
 
 | you need | read |
 | --- | --- |
@@ -16,9 +17,131 @@ Where the rest lives:
 | which fixture covers which construct | [Tests/Checks/README.md](Tests/Checks/README.md) |
 | the plan for a change too big to carry in a commit message | [specs/](specs/) |
 
-The two commands worth memorising:
+Run from the repository root:
 
 ```bash
 Tests/Checks/run-checks.sh              # ~10s — snapshot, both language modes, behaviour
 Tests/Checks/run-checks.sh --record     # only after reading the diff the line above printed
 ```
+
+## Writing style: state facts and actions, no aphorisms
+
+**Scope: every character of prose you produce for this project.** Specs, docs, code comments, commit
+messages, PR bodies, review findings, and **your replies in chat**. There is no "informal" channel
+where this relaxes.
+
+**The test, applied to each sentence:** does it give the reader **a fact they can verify** or **an
+action they can take**, with the referent named — the file, the line, the setting, the command, the
+number? If it does neither, delete it. A sentence that only characterizes the work, dramatizes a
+finding, or summarizes how significant something is carries no information the reader can act on.
+
+Habits to avoid (common LLM-isms):
+
+- **Mannered prose** substitutes metaphor and flourish for direct statement. Instead of "a parameter
+  worth varying," the mannered writer produces "a dial worth turning." Instead of "this point still
+  matters," they write "this point earns its keep." The phrases exist to display the writer, not to
+  convey the idea, and readers can tell. That is why mannered prose irritates: it makes the reader
+  work harder so the writer can perform. It is also imprecise — metaphors drag in connotations the
+  writer did not choose and cannot control. **The fix is to say what you mean. When a literal phrase
+  is available, use it.**
+- **Aphoristic juxtapositions** ("Free now, a second migration later"). State the trade-off
+  explicitly: what it costs now, what it costs later, which option you recommend.
+- **Dramatic reversals and punchlines** ("that direction has reversed"; "upgraded those steps from
+  redundant to breaking"). Give the before value, the after value, and the date measured.
+- **Negative-space phrasing** ("checked by nobody"; "not cosmetic"; "not the thing to move"). Say
+  which check is missing, in which file, what it costs, and when to add it. If the point is that X
+  is wrong, name what to do instead — "keep the Xcode pin and change `runs-on`", not "the Xcode pin
+  is not the thing to move".
+- **Metaphor or personification as the load-bearing content** ("a fresh package has no code to
+  fight"; "the gate now has teeth"; "what the spec still owes"). A metaphor may decorate a point
+  already stated literally; it may not be the only statement of that point. Documents do not owe,
+  want, or know things — name who does the work, in which file, by when.
+- **Rhetorical contrast standing in for content** ("verified, not merely committed"; "it is not that
+  X, it is that Y"). State both facts separately and drop the contrast.
+- **The closing paragraph that generalizes the lesson.** This is where aphorisms concentrate: a
+  section ends, and the urge is to extract a portable moral. Either write a concrete rule with a
+  named home — the gate to add, the file to add it to — or write nothing.
+
+## Git state — confirm every commit
+
+- **Never commit, amend, push or rewrite history without confirmation in the current turn.**
+  "Implement X", or approval of a *previous* commit, is not authorization for the next one. When
+  work is ready: stop, summarize what changed, ask.
+- **Never touch the index or restore the tree.** `git add`, `git reset`, `git stash`,
+  `git checkout -- <path>`: off-limits unless asked for in this turn. Staged versus unstaged is the
+  reviewer's record of how far they have read, and reverting your own edits to "recover" discards
+  work they have not seen. If a commit is authorized and the index is partly staged, ask which scope
+  before running anything.
+- **Subject line:** imperative, naming the change — "Retire the CocoaPods distribution". Work backed
+  by a spec carries the slug: `[001-plugin-source-discovery] Derive the source closure`. No spec in
+  play, no prefix — do not invent one.
+
+## Changes reach `master` through a pull request
+
+- Code goes on a branch and through a PR, so [`ci.yml`](.github/workflows/ci.yml)'s four lanes run
+  before it lands. They trigger on push, not on PR open.
+- Any merge strategy — merge, rebase or squash — chosen for the nature of the PR.
+- A change touching no code may go straight to `master`: a spec, a note, README or CHANGELOG
+  wording. `templates/`, `Sources/`, `Plugins/`, `Tests/`, `Scripts/` and `.github/` are code.
+- Branch when the work starts. If code is ready and the checkout is `master`, ask which branch.
+- Pushing, opening a PR and merging one each need their own go-ahead.
+
+## Specs are a read-only decision ledger
+
+- **A merged spec is never edited** — not to fix a path a later change moved, not to correct a
+  decision since superseded, not to tidy. Editing it destroys the record.
+- **A new spec names what it obsoletes**, by number and section ("obsoletes 001 §4.6").
+- **Writing a spec is not authorization to implement it.** When the task is a spec, produce only the
+  spec document — no code, config, template or workflow edit, not even the one line that looks
+  ready. When it is written, stop and ask.
+
+## Review generated output as a snapshot diff
+
+- **Run `Tests/Checks/run-checks.sh` before and after every template edit.** It is ~10s and it is
+  the only place generated output is visible. A change that looks local to one shape routinely moves
+  another.
+- **Read the snapshot diff before you run `--record`.** Run the gates, read the diff they print,
+  and only then `Tests/Checks/run-checks.sh --record`. Recording first overwrites the snapshot with
+  whatever the template now emits, so nothing is left to compare against.
+- **Never hand-edit anything in `Tests/Checks/Snapshots/`.** Those files are build products; the
+  only supported way to change one is to change a template and re-record.
+- **Run the full lane (`Tests/Examples/ExampleProjectSpm/test-ios.sh`) before cutting a tag**, and
+  whenever a change touches RxSwift smart defaults, type erasure, or the SPM plugin — the fast lane
+  covers none of those.
+
+## State a rule once
+
+- The isolation rules are in `templates/Mocks/SourceryRuntimeExtensions.swift`, the
+  parameter-declaration rules in `MethodParameter.parametersDecl` / `closureAttributesDecl`. Both
+  templates read them. Restating a rule at a call site is how the mock and the Component come to
+  emit different isolation for the same protocol.
+- Both language modes are the gate: `-swift-version 5 -strict-concurrency=complete` **and**
+  `-swift-version 6`, at zero *diagnostics*. A construct can be a warning under the first and an
+  error under the second.
+- A construct the template cannot handle gets a diagnostic naming the member and what to do about
+  it, not a partial emission that fails at the consumer's conformance.
+
+## Do not tag without measuring the consumer
+
+Follow [CONTRIBUTING.md](CONTRIBUTING.md#cutting-a-release) in order. Its most-skipped step:
+regenerate `modaal-firebase-wrappers` against `master` and record the size and shape of its diff in
+the `CHANGELOG.md` entry. Write that entry **before** tagging — a consumer reads it to decide
+whether to bump.
+
+## What goes in which document
+
+- **README.md** — what the templates do and how to use them. A new annotation adds a row to its
+  reference table.
+- **CONTRIBUTING.md** — how the templates are built, where to change what, decided design rules,
+  pitfalls, testing, release procedure, open items.
+- **AGENTS.md / CLAUDE.md** — rules only, and one file in two places. If you are about to write a
+  paragraph explaining what something *is*, it belongs in one of the other two.
+- **specs/`NNN-slug`/spec.md** — the plan for a change too big to carry in a commit message: what is
+  true now (measured, with file and line references), what the rule becomes, the phasing, the
+  decisions and what stays open. Written before the change and left in place after it, as the record
+  of why. It never becomes the place a *rule* is stated — that is here.
+
+## Scope
+
+- Generated output in a consumer repo is that repo's build product. Do not hand-edit a consumer's
+  generated file to work around a template gap — fix the template and regenerate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Tests/                              # everything that verifies the product — s
     PluginFixtureRed/               # four packages that must FAIL, one per red control
   Examples/ExampleProjectSpm/       # full lane — RxSwift, RIBs, type erasure, the plugin
 Scripts/assemble-release.sh         # builds the release assets — see Cutting a release
-specs/                              # design specs, NNN-slug/spec.md — see Keep the documents in their lanes
+specs/                              # design specs, NNN-slug/spec.md — see What goes in which document
 ```
 
 An `includeFile` in a `.swifttemplate` inlines that file into one compilation unit, so `private` at


### PR DESCRIPTION
Two commits: the rules merge, then the CI jobs that enforce and exploit it.

## AGENTS.md and CLAUDE.md become one file

They carried different material — AGENTS.md the craft rules, CLAUDE.md a pointer to it. An agent
reading only AGENTS.md (Codex, Cursor, Copilot) got "run the checks, don't hand-edit snapshots" and
missed everything about when it may commit. That is the more expensive half to miss, so the split
is gone: one file kept in two places, byte for byte. Edit `AGENTS.md`, then `cp AGENTS.md CLAUDE.md`.

Nothing added is Claude-specific:

| rule | what it says |
| --- | --- |
| Git state | no commit, amend or push without confirmation in the current turn; never touch the index or restore the tree; ask when the index is partly staged |
| Commit subjects | imperative, no scope prefix; spec-backed work carries the slug — `[001-plugin-source-discovery] …` |
| Specs | a read-only decision ledger: a merged spec is never edited, a new spec names what it obsoletes by number and section, and writing one is not authorization to implement it |
| Pull requests | code reaches `master` through a PR under any merge strategy; a change touching no code may go direct |
| Writing style | state facts and actions, no aphorisms |

The style rule applies to the file itself, so the craft sections lost the metaphors they were
carrying: "turns the gate into a rubber stamp" now says what recording first does to the snapshot,
"a rule lives in" is "the rules are in", and two headings that stated an aphorism now name an
action. Renaming one of them moved a cross-reference in CONTRIBUTING.md.

The style rule came from a private sibling repository whose worked examples name internal projects.
This tree is public, so the examples are rebuilt from this repository's own history — the
`Collision` red control, and the `tags-ignore` trigger that could never fire.

## Two ubuntu jobs front the workflow

**`rules`** runs `cmp AGENTS.md CLAUDE.md` — what keeps the two copies from drifting as they did
before. No Swift toolchain, no Xcode, so it answers in seconds instead of reporting from behind a
`setup-xcode` install, and drift no longer turns `checks` red for a reason unrelated to templates.

**`changes`** reports whether the push touched anything outside `**.md`; the four macOS lanes gate
on it. They measured 1:19, 1:10, 2:27 and 4:11 on the last run, so a markdown-only push currently
spends about six minutes and a simulator boot to confirm a README is still a README. `rules` is
deliberately **not** gated — it reads markdown, which is exactly what a docs-only push changes.

Per-subtree filtering was considered and rejected: three of the four lanes are already off the
critical path, and the coupling is not directory-shaped (the plugin resolves bare template names
against `templates/`, and the CLI's transparency gate diffs against the fast lane's snapshot).

### The filter fails open

`event.before` all zeros (a branch's first push), a force push whose old tip is gone, a manual
dispatch with no range, and an empty diff all report `true`. Exercised against real commits here:

| case | result |
| --- | --- |
| `4d2b132` — code + docs | `true` |
| `791d565` — AGENTS/CLAUDE/CONTRIBUTING only | `false` |
| zeros / empty / missing commit / empty diff | `true` |

It tests the file list rather than grep's exit status. The first version used `grep -qv`, which
reported "markdown only" for a commit that moved 61 Swift and shell files — under that grep it
would have skipped every lane on a refactor.

Job-level `if:` rather than workflow-level `paths-ignore`: `master` has no required checks today,
but a job skipped by `if:` still reports and would satisfy them, where `paths-ignore` produces no
check at all and would leave a docs-only PR unsatisfiable.

## Note on this PR's own CI

The first push of a new branch sets `event.before` to all zeros, so the filter fails open and every
lane runs here. The skip path is not exercised by this PR — a later markdown-only push to `master`
is what will show it working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)