### PR TITLE
Pin the templates-0.8.0 artifact bundle

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,8 +30,8 @@ let package = Package(
     // templates/ is not the commit's.
     .binaryTarget(
       name: "sourcery",
-      url: "https://github.com/modaal-agent/swift-sourcery-templates/releases/download/0.7.0/swift-sourcery-templates-0.7.0.artifactbundle.zip",
-      checksum: "bcb47a7a1a19d195b18cbedbc76fce2d29d6102a9c478f0e534cf9764a72764f"
+      url: "https://github.com/modaal-agent/swift-sourcery-templates/releases/download/templates-0.8.0/swift-sourcery-templates-0.8.0.artifactbundle.zip",
+      checksum: "b2dc387daba5ed9d56cf21d752e79522a8486f14b8beea34169130c634d09860"
     ),
     .plugin(
       name: "SourcerySwiftCodegenPlugin",


### PR DESCRIPTION
The second of the two commits a release needs when `templates/` has changed
(followup-xcode-lane.md §15). `templates-0.8.0` published the bundle on
2026-09-10; this points the `sourcery` binaryTarget at it.

| | |
| --- | --- |
| url | `.../releases/download/templates-0.8.0/swift-sourcery-templates-0.8.0.artifactbundle.zip` |
| checksum | `b2dc387daba5ed9d56cf21d752e79522a8486f14b8beea34169130c634d09860` |
| size | 22,672,047 bytes |

Two lines change and nothing else, which is the invariant
`Scripts/check-pinned-templates.sh` enforces on the release tag.

## Checked before pushing

```
Scripts/check-pinned-templates.sh
── ok ── the pinned bundle's templates/ is this commit's templates/
```

and with `.build/xcode-checks/SourcePackages` deleted first, so the bundle
downloaded cold: `Tests/Checks/run-xcode-checks.sh` passed, and the engine at
`SourcePackages/artifacts/.../swift-sourcery-templates-0.8.0.artifactbundle/sourcery/bin/sourcery`
reports 2.3.0. CI here re-resolves it on clean runners, which is the point of
this PR having one.

## After merging

Tag `0.8.0` on `master`. The release job runs the gate above and then publishes.

**Do not delete the `templates-0.8.0` prerelease.** The URL in `Package.swift`
names its asset, not the `0.8.0` release's. Deleting it breaks package
resolution for every consumer at 0.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)