### PR TITLE
Run the by-URL example after a release and weekly

### DIFF
--- a/.github/workflows/published-example.yml
+++ b/.github/workflows/published-example.yml
@@ -1,0 +1,77 @@
+name: Published example
+
+# Builds Tests/Examples/ExampleProjectXcode — the only thing here that resolves
+# this package from its published URL at a version, which is what an adopter
+# writes. Every check lane reaches this repository by path, so nothing on a
+# branch exercises resolution at all.
+#
+# One job, three ways in:
+#
+#   workflow_call      release.yml calls it after publishing a bare X.Y.Z tag,
+#                      with expect-version set, so a release run reports whether
+#                      what it just published resolves and builds. It cannot
+#                      gate the publish — the asset has to exist before anything
+#                      can resolve it — so it reports rather than blocks.
+#   schedule           weekly, as the canary for what a release-time run cannot
+#                      see. `Package.swift`'s binaryTarget URL names an asset on
+#                      the `templates-X.Y.Z` *prerelease*; deleting that
+#                      prerelease breaks resolution for every consumer at that
+#                      version while every branch stays green.
+#   workflow_dispatch  on demand, optionally against a named version.
+#
+# Deliberately not a lane in ci.yml (followup-xcode-lane.md F9): a branch lane
+# here would make every push depend on the last published artifact, which is the
+# coupling that spec's §16 exists to avoid. This fails a release run or a
+# scheduled run instead of a branch.
+#
+# What it does not check: the plugin resolving templates out of the artifact
+# bundle. A URL-resolved package is a full source checkout carrying
+# `templates/`, so `#filePath` answers first — measured 2026-09-10, see
+# CONTRIBUTING's note beside the example.
+#
+# GitHub disables a scheduled workflow after 60 days with no repository
+# activity, and re-enabling it is a button in the Actions tab.
+on:
+  workflow_call:
+    inputs:
+      expect-version:
+        description: The version the example must resolve, e.g. 0.8.0.
+        type: string
+        required: false
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+    inputs:
+      expect-version:
+        description: Version the example must resolve. Empty accepts whatever `from:` picks.
+        type: string
+        required: false
+
+permissions:
+  contents: read
+
+# Same pin, same reason, as ci.yml.
+env:
+  XCODE_VERSION: '26.3'
+
+jobs:
+  build:
+    name: Build the by-URL example
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Build the example against the published package
+        # No cache. Resolving from the network is the thing under test, and a
+        # cached SourcePackages directory would hide exactly the failure the
+        # weekly run exists to catch.
+        env:
+          EXPECT_VERSION: ${{ inputs.expect-version }}
+        run: Tests/Examples/ExampleProjectXcode/build.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,8 @@ name: Release
 #   X.Y.Z             the release. Before anything is published, the pinned
 #                     bundle's templates/ is compared with the commit's — the
 #                     gate that keeps the plugin's third resolution route from
-#                     serving templates nobody reviewed.
+#                     serving templates nobody reviewed. After it publishes,
+#                     the by-URL example is built against the tag just cut.
 #
 # `*.*.*` matches `templates-0.8.0` as well (`templates-0` `.` `8` `.` `0`), so
 # the pattern is not what tells the two apart; the jobs' `if:` conditions are.
@@ -123,3 +124,17 @@ jobs:
             --notes-file .build/release-assets/notes.md \
             .build/release-assets/*.zip \
             .build/release-assets/*.sha256
+
+  # ── What an adopter gets ─────────────────────────────────────────
+  # Resolves the tag just published, from its URL, and builds against it. It
+  # runs after the publish because nothing can resolve an asset that is not
+  # there yet, so it reports on the release rather than gating it — a failure
+  # here means the published release does not work for an adopter, and the fix
+  # is another release, not a retry.
+  example:
+    name: The by-URL example, against what was just published
+    needs: release
+    if: ${{ !startsWith(github.ref_name, 'templates-') }}
+    uses: ./.github/workflows/published-example.yml
+    with:
+      expect-version: ${{ github.ref_name }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,9 +277,17 @@ protocol work. `Variable.isAsync` and `Variable.throws` carry effectful property
 | xcode | `Tests/Checks/run-xcode-checks.sh` | Xcode, `xcodegen` and, once, the network; ~35s |
 | full | `cd Tests/Examples/ExampleProjectSpm && ./test-ios.sh` | an iOS Simulator; minutes |
 
-`Tests/Examples/ExampleProjectXcode/build.sh` is not a lane. It resolves this package from its
-published URL at a tag, so it lags one release and belongs to the release procedure, not to a
-branch; see step 7 of Cutting a release.
+`Tests/Examples/ExampleProjectXcode/build.sh` is not a *branch* lane. It resolves this package from
+its published URL at a version, so making it one would put every push at the mercy of the last
+published artifact. `.github/workflows/published-example.yml` runs it where a published artifact is
+the right dependency: called by `release.yml` after a release publishes, weekly on a schedule, and
+on demand. `EXPECT_VERSION=<version>` makes it require a particular resolved version, which is what
+the release-time run passes.
+
+It resolves the package into a full source checkout that carries `templates/`, so the plugin's
+`#filePath` route answers and the artifact-bundle route does not — measured 2026-09-10 against
+0.8.0, correcting what `followup-xcode-lane.md` §17 expected of this project. That route is reached
+only where `#filePath` fails, which is what it was built for, and nothing here exercises it.
 
 Both check lanes provision Sourcery through `Tests/Checks/ensure-sourcery.sh`, which reads the pin
 from `Scripts/engine-pin.sh`; `SOURCERY=/path/to/sourcery` overrides it in either lane.
@@ -344,6 +352,12 @@ been measured to hold on Swift 6.3.3 (Xcode 26.6) and Swift 6.4 (Xcode 27 beta 4
 reproducibility rather than fragility. Bumping it means re-running the lanes locally on the new
 version first.
 
+`.github/workflows/published-example.yml` builds the by-URL example. `release.yml` calls it after a
+release publishes, a weekly `schedule:` runs it as a canary — `Package.swift` names an asset on the
+`templates-X.Y.Z` prerelease, so deleting that prerelease breaks resolution for every consumer at
+that version while every branch stays green — and `workflow_dispatch` runs it on demand. It caches
+nothing: resolving from the network is the thing under test.
+
 `.github/workflows/release.yml` runs on tag pushes only (which ci.yml deliberately skips), and
 routes two tag shapes to two jobs. A `templates-X.Y.Z` tag publishes the artifact bundle a
 `Package.swift` pin can name, as a prerelease. A bare `X.Y.Z` tag runs
@@ -380,13 +394,12 @@ the assets to the tag's GitHub release.
    `swift-sourcery-templates-<tag>.artifactbundle.zip`, `mock-templates-<tag>-macos.zip`, a
    `.sha256` beside each, and the release-notes body. Rehearse it locally with
    `Scripts/assemble-release.sh <version>` — everything lands in `.build/release-assets/`
-7. Build `Tests/Examples/ExampleProjectXcode` and record the version it printed. It is the only
-   thing here that resolves this package from its published URL at a tag, and the only thing that
-   reads `templates/` out of the pinned artifact bundle — every lane reaches this repository by
-   path, so neither is checked on a branch. It is not a CI lane on purpose: a lane over it would
-   make every branch depend on the last published artifact. One command,
-   `Tests/Examples/ExampleProjectXcode/build.sh`, which prints
-   `BUILT against swift-sourcery-templates <version>` on success
+7. Check the release run's **The by-URL example** job. It resolves the tag just published, from its
+   URL, and builds `Tests/Examples/ExampleProjectXcode` against it — the only check that an adopter
+   can resolve this package at all, since every lane reaches the repository by path. It runs after
+   the publish, because nothing can resolve an asset that is not there yet, so a failure means the
+   published release does not work and the fix is another release. Reproduce it locally with
+   `EXPECT_VERSION=<tag> Tests/Examples/ExampleProjectXcode/build.sh`
 
 ## Dependencies
 

--- a/Tests/Examples/ExampleProjectXcode/build.sh
+++ b/Tests/Examples/ExampleProjectXcode/build.sh
@@ -5,16 +5,23 @@
 # names this step (specs/001-plugin-source-discovery/followup-xcode-lane.md,
 # F9) — and record the version it prints in the release's notes.
 #
-# It is not a CI lane on purpose: it resolves the package from its published URL
+# Not a branch lane on purpose: it resolves the package from its published URL
 # at a tag, so wiring it into ci.yml would make every branch depend on the last
 # published artifact. Everything under Tests/Checks reaches this repository by
 # path instead, and that is what keeps a branch's lanes gating the working tree.
+# `.github/workflows/published-example.yml` runs it where a published artifact
+# is the right thing to depend on: after a release publishes, and weekly.
 #
 # Needs Xcode, `xcodegen` (`brew install xcodegen`) and the network. No
 # simulator. The `.xcodeproj` is generated and not committed.
 #
+# Set EXPECT_VERSION to require a particular resolved version — the release
+# workflow sets it to the tag it just published. Unset, any version `from:`
+# resolves is accepted.
+#
 # Usage:
 #   Tests/Examples/ExampleProjectXcode/build.sh
+#   EXPECT_VERSION=0.8.0 Tests/Examples/ExampleProjectXcode/build.sh
 
 set -eo pipefail
 
@@ -63,6 +70,14 @@ for pin in state.get("pins", []):
         print(pin["state"].get("version") or pin["state"].get("revision", "?"))
         break
 ' "$RESOLVED" 2>/dev/null || echo "?")"
+
+if [ -n "${EXPECT_VERSION:-}" ] && [ "$VERSION" != "$EXPECT_VERSION" ]; then
+  echo "FAIL: expected swift-sourcery-templates $EXPECT_VERSION, resolved $VERSION"
+  echo "      The spec pins with 'from:', so it takes the newest published"
+  echo "      version. A mismatch means that tag published no release, or a"
+  echo "      newer one exists."
+  exit 1
+fi
 
 MOCK="$(find "$DD/Build/Intermediates.noindex/BuildToolPluginIntermediates" \
   -path "*/Example/*/.generatedFiles/*/Mocks.generated.swift" -type f 2>/dev/null | head -1)"

--- a/Tests/Examples/ExampleProjectXcode/xcodegen.yml
+++ b/Tests/Examples/ExampleProjectXcode/xcodegen.yml
@@ -1,26 +1,31 @@
 # The adopter's shape, as documentation rather than as a gate.
 #
 # Every fixture in Tests/Checks reaches this repository by path, because that is
-# what a fixture in this repository can do. Two things therefore go unchecked by
-# any lane, and this project is both of them: SwiftPM resolving this package
-# from its published URL at a version, which is what an adopter writes, and the
-# plugin reading `templates/` out of the artifact bundle `Package.swift` pins —
-# route 3 of specs/001-plugin-source-discovery/followup-xcode-lane.md §12, which
-# routes 1 and 2 win over on every branch of this repository.
+# what a fixture in this repository can do. This project is the one thing that
+# resolves the package from its published URL at a version, which is what an
+# adopter writes, and it is the only check that resolution works at all.
 #
-# Not wired into ci.yml (F9): a lane over this project would make every branch
-# depend on the last published artifact, which is the coupling §16 exists to
-# avoid. CONTRIBUTING's release procedure names the step that builds it after a
-# release publishes, and `build.sh` beside this file is that step.
+# It does NOT exercise route 3 of
+# specs/001-plugin-source-discovery/followup-xcode-lane.md §12, which that
+# spec's §17 expected it to. Measured 2026-09-10 against 0.8.0: a URL-resolved
+# package is a full source checkout that carries `templates/`, so `#filePath`
+# answers and the log reads "shipped templates come from the plugin's own source
+# location, .../SourcePackages/checkouts/swift-sourcery-templates/templates".
+# Route 3 answers only where route 2 fails, which is what F6 built it for.
 #
-# It needs the first release after 0.7.0, and lags by one until that publishes —
-# which is the state §17 records rather than a fault in the project. Measured
-# against 0.7.0 on 2026-09-10: that plugin does not synthesize a config at all,
-# so it runs `Sources/.Sourcery.Mocks.yml` as written and Sourcery rejects it —
-# "Invalid sources. 'sources', 'project' or 'package' key are missing." A config
-# this short needs the plugin to supply `sources:` and `output:`, and a bare
-# `- Mocks` needs the two template routes that read no package graph. Both land
-# in the same release.
+# Not a lane in ci.yml (F9): a branch lane here would make every push depend on
+# the last published artifact, which is the coupling §16 exists to avoid.
+# `.github/workflows/published-example.yml` runs `build.sh` where a published
+# artifact is the right thing to depend on — after a release, and weekly.
+#
+# `from:` rather than an exact version, so the project follows releases without
+# an edit; 0.8.0 is the first that builds it, and it printed
+# "BUILT against swift-sourcery-templates 0.8.0" on 2026-09-10. Against 0.7.0 it
+# failed, and the earliest reason was not the bare template name: that plugin
+# does not synthesize a config at all, so it ran `Sources/.Sourcery.Mocks.yml`
+# as written and Sourcery rejected it — "Invalid sources. 'sources', 'project'
+# or 'package' key are missing." A config this short needs the plugin to supply
+# `sources:` and `output:` as well.
 name: ExampleProjectXcode
 options:
   createIntermediateGroups: true


### PR DESCRIPTION
`Tests/Examples/ExampleProjectXcode` was built by nothing but a person following
step 7 of the release procedure. It is the only check that an adopter can
resolve this package at all — every lane reaches the repository by path — so it
had no owner but a checklist line. F9 accepted that; §20 question 3 left the
alternative open. This is that alternative.

## The workflow

`.github/workflows/published-example.yml`, one job, three ways in:

| trigger | why |
| --- | --- |
| `workflow_call` | `release.yml` calls it after publishing a bare `X.Y.Z` tag, with `expect-version` set to that tag |
| `schedule` | weekly, as the canary for what a release-time run cannot see |
| `workflow_dispatch` | on demand, optionally against a named version |

Still not a lane in `ci.yml`: a branch lane here would make every push depend on
the last published artifact, which is the coupling §16 exists to avoid. This
fails a release run or a scheduled run instead of a branch.

The release-time job runs **after** the publish — nothing can resolve an asset
that is not there yet — so it reports on the release rather than gating it. A
failure means the published release does not work for an adopter, and the fix is
another release.

The weekly run covers what the release-time one cannot. `Package.swift` names an
asset on the `templates-X.Y.Z` **prerelease**; deleting that prerelease breaks
resolution for every consumer at that version while every branch stays green.
It caches nothing, because resolving from the network is the thing under test.

## `EXPECT_VERSION`

`build.sh` gains it. Verified both ways against the published 0.8.0:

```
EXPECT_VERSION=0.8.0  → BUILT against swift-sourcery-templates 0.8.0   exit 0
EXPECT_VERSION=9.9.9  → FAIL: expected 9.9.9, resolved 0.8.0           exit 1
```

## A correction this PR also carries

`followup-xcode-lane.md` §17 expected this project to exercise the
artifact-bundle template route. Measured against 0.8.0 on 2026-09-10, it does
not. A URL-resolved package is a full source checkout carrying `templates/`, so
`#filePath` answers first:

```
shipped templates come from the plugin's own source location,
  .../SourcePackages/checkouts/swift-sourcery-templates/templates
```

The bundle route answers only where `#filePath` fails, which is what F6 built it
for — the mechanism is fine, the claim about what this project proves was not.
Nothing exercises that route today. A merged spec is a read-only ledger, so the
correction lives in the example's own spec comment and in CONTRIBUTING.

## Note on the triggers

Neither new trigger can run from this branch — `schedule:` only fires on the
default branch, and the `release.yml` call only on a tag. CI here checks the
rest; the first real exercise is the next release, and the weekly run after
that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)