### PR TITLE
Gate the artifact-bundle template route, and fix the install snippet

### DIFF
--- a/.github/workflows/published-example.yml
+++ b/.github/workflows/published-example.yml
@@ -26,8 +26,9 @@ name: Published example
 #
 # What it does not check: the plugin resolving templates out of the artifact
 # bundle. A URL-resolved package is a full source checkout carrying
-# `templates/`, so `#filePath` answers first — measured 2026-09-10, see
-# CONTRIBUTING's note beside the example.
+# `templates/`, so `#filePath` answers first — measured 2026-09-10.
+# Tests/Checks/PluginFixtureBundleRoute is what runs that route, on every push,
+# by depending on a copy of this repository with `templates/` left out.
 #
 # GitHub disables a scheduled workflow after 60 days with no repository
 # activity, and re-enabling it is a button in the Actions tab.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ Tests/                              # everything that verifies the product — s
   Checks/                           # fast lane + CLI lane + plugin lane + Xcode lane
     PluginFixture/                  # the plugin lane's green package: one target per config shape
     PluginFixtureRed/               # four packages that must FAIL, one per red control
+    PluginFixtureBundleRoute/       # the only fixture that runs the artifact-bundle template route
     XcodeFixture/                   # the Xcode lane's green project — an xcodegen.yml, no .xcodeproj
     XcodeFixtureRed/                # one project per red control — each must FAIL
   Examples/
@@ -286,8 +287,9 @@ the release-time run passes.
 
 It resolves the package into a full source checkout that carries `templates/`, so the plugin's
 `#filePath` route answers and the artifact-bundle route does not — measured 2026-09-10 against
-0.8.0, correcting what `followup-xcode-lane.md` §17 expected of this project. That route is reached
-only where `#filePath` fails, which is what it was built for, and nothing here exercises it.
+0.8.0, correcting what `followup-xcode-lane.md` §17 expected of this project. The bundle route is
+reached only where `#filePath` fails, which is what it was built for;
+`Tests/Checks/PluginFixtureBundleRoute` is what runs it.
 
 Both check lanes provision Sourcery through `Tests/Checks/ensure-sourcery.sh`, which reads the pin
 from `Scripts/engine-pin.sh`; `SOURCERY=/path/to/sourcery` overrides it in either lane.
@@ -308,6 +310,12 @@ configs, the generated code, and the build's own outcome. Its four red controls 
 `Tests/Checks/PluginFixtureRed/`, one package each, because build planning runs *every* target's
 plugin: a plan-time error in one target fails the build for all of them, so no `--target` can
 isolate a red control that shares a package with a green one. See `Tests/Checks/README.md`.
+
+`Tests/Checks/PluginFixtureBundleRoute` is the one fixture that runs the third template-resolution
+route, the artifact bundle. Every other fixture reaches this repository directly, so the plugin's
+own source file sits beside a `templates/` directory and `#filePath` answers first; this one depends
+on a generated copy of the repository with `templates/` left out, so the two routes ahead of the
+bundle cannot answer.
 
 The Xcode lane covers the other half of the same plugin. `XcodeBuildToolPlugin` is handed no package
 graph, no dependency edges and no shipped templates, so almost nothing the plugin lane asserts
@@ -334,6 +342,7 @@ external-annotation pattern, type erasure, and the plugin itself.
 | fast | `Tests/Checks/Behaviour/Main.swift` | call counting, handlers, async suspension, nonisolated access off the main actor, subject-driven streams, cancellation counting, composites; for Components: forwarding identity, per-Component ownership, settable forwarding, parameter shapes, effectful getters |
 | CLI | `Tests/Checks/run-cli-checks.sh` | `generate` transparency against the fast lane's snapshot; determinism across runs; `validate` red on a mutated input, an unlisted file, a hand-edited body, a wrong bundle tag, a `--template`/`--args` pair the block does not record; `imprint` recovery |
 | plugin | `Tests/Checks/run-plugin-checks.sh` | the derived source closure (splice, sort, absolute paths); passthrough of everything else; the defaults the plugin supplies and the ones it must not; bare template-name resolution and the local file that outranks a shipped one; `args.testable` inserted, declined and left alone; determinism between builds; two configs on one target; and four red controls — a wrong `output:`, a template collision, an unknown template name, a `package:` the plugin must leave alone |
+| plugin | `Tests/Checks/PluginFixtureBundleRoute` | the artifact-bundle template route: a bare name resolving with no `templates/` in the consumed checkout, the route named in the log, the resolved path inside an `.artifactbundle`, and the mock the bundle's template generated |
 | xcode | `Tests/Checks/run-xcode-checks.sh` | the `XcodeBuildToolPlugin` path: config discovery through the target's own directory; the expansion being the target's own input directories and nothing else; a hand-listed `${SOURCERY_PROJECT}` entry that is scanned; passthrough; the defaults; determinism; a target depending on a sibling target; and one red control — a bare template name, which has no package graph to resolve against here |
 | full | `SwiftSourceryTemplatesMocksSpec.swift` | mock instantiation, call counting, handler execution |
 | full | `EscapingClosureMocksSpec.swift` | `@escaping` preservation — capture, async dispatch |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # swift-sourcery-templates
 
-[![CI](https://github.com/ivanmisuno/swift-sourcery-templates/actions/workflows/ci.yml/badge.svg)](https://github.com/ivanmisuno/swift-sourcery-templates/actions/workflows/ci.yml)
+[![CI](https://github.com/modaal-agent/swift-sourcery-templates/actions/workflows/ci.yml/badge.svg)](https://github.com/modaal-agent/swift-sourcery-templates/actions/workflows/ci.yml)
 
 Advanced Protocol Mock, Type Erasure and dependency-forwarding Code-generation templates for Swift (using [Sourcery](https://github.com/krzysztofzablocki/Sourcery)).
 
@@ -279,7 +279,7 @@ let package = Package(
   ],
   dependencies: [
     // ...
-    .package(url: "https://github.com/ivanmisuno/swift-sourcery-templates.git", from: "0.2.2"),
+    .package(url: "https://github.com/modaal-agent/swift-sourcery-templates.git", from: "0.8.0"),
   ],
   targets: [
     .target(

--- a/Tests/Checks/PluginFixtureBundleRoute/Package.resolved
+++ b/Tests/Checks/PluginFixtureBundleRoute/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Tests/Checks/PluginFixtureBundleRoute/Package.swift
+++ b/Tests/Checks/PluginFixtureBundleRoute/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// The fixture for route 3 of specs/001-plugin-source-discovery/followup-xcode-lane.md
+// §12: the plugin reading `templates/` out of the artifact bundle `Package.swift`
+// pins.
+//
+// Every other fixture reaches this repository directly, so the plugin's own
+// source file sits in a checkout that carries `templates/` and route 2
+// (`#filePath`, up three components) always answers first. Route 3 is the
+// fallback for the two undocumented behaviours route 2 rests on, so the only way
+// to run it is to make route 2 fail.
+//
+// `../../../.build/plugin-checks/engine-package` is that: a copy of this
+// repository holding Package.swift, Plugins/ and Sources/ and **no templates/**,
+// which `run-plugin-checks.sh` writes before building this package. So route 1
+// finds the package in the graph and no `templates/` under it, route 2 finds no
+// `templates/` beside the plugin source, and route 3 answers out of the
+// artifact bundle the copied manifest pins. Generated, not committed, because
+// what it is is "this repository minus one directory" and a second copy in the
+// tree would be a second thing to keep in step.
+let package = Package(
+  name: "PluginFixtureBundleRoute",
+  platforms: [
+    .macOS(.v13)
+  ],
+  dependencies: [
+    .package(name: "swift-sourcery-templates", path: "../../../.build/plugin-checks/engine-package"),
+  ],
+  targets: [
+    .target(
+      name: "BundleRoute",
+      plugins: [.plugin(name: "SourcerySwiftCodegenPlugin", package: "swift-sourcery-templates")]
+    ),
+  ]
+)

--- a/Tests/Checks/PluginFixtureBundleRoute/Sources/BundleRoute/.Sourcery.Mocks.yml
+++ b/Tests/Checks/PluginFixtureBundleRoute/Sources/BundleRoute/.Sourcery.Mocks.yml
@@ -1,0 +1,5 @@
+# A bare template name, with nothing in the checkout to resolve it against. It
+# has to come out of the pinned artifact bundle, and the lane asserts that the
+# path it resolved to is inside the bundle rather than in this working tree.
+templates:
+  - Mocks

--- a/Tests/Checks/PluginFixtureBundleRoute/Sources/BundleRoute/Protocols.swift
+++ b/Tests/Checks/PluginFixtureBundleRoute/Sources/BundleRoute/Protocols.swift
@@ -1,0 +1,13 @@
+/// The subject of the bundle-route gate. `ferry` has to appear in the generated
+/// mock, so the gate reports on the template that ran rather than on the build
+/// merely succeeding.
+// sourcery: CreateMock
+protocol Ferrying {
+  func ferry(_ item: String) -> String
+}
+
+/// The generated mock has to satisfy this, so a template that resolved to
+/// nothing fails the compile instead of leaving an empty file behind.
+func acceptFerrying(_ value: any Ferrying) -> String {
+  value.ferry("manifest")
+}

--- a/Tests/Checks/README.md
+++ b/Tests/Checks/README.md
@@ -167,6 +167,30 @@ exactly the distance no `SOURCERY_TARGET_*` variable reaches.
 | **determinism** | a second build leaves every synthesized config byte-identical — the prebuild command re-runs every build, and a config that churns invalidates Sourcery's cache every time |
 | **shared cache** | a target with two configs, rebuilt with the caches dropped, produces the same output both times |
 
+## The artifact-bundle route
+
+[`PluginFixtureBundleRoute/`](PluginFixtureBundleRoute) is the only place route 3
+of the template-resolution order runs — the plugin reading `templates/` out of
+the artifact bundle `Package.swift` pins.
+
+Every other fixture reaches this repository directly, so the plugin's own source
+file sits beside a `templates/` directory and `#filePath` answers first. That is
+what a branch wants, and it leaves the bundle route covered by nothing. This
+fixture's dependency is therefore a copy of the repository with `templates/` left
+out, which `run-plugin-checks.sh` writes into `.build/plugin-checks/engine-package`
+before building: route 1 finds the package in the graph with no templates under
+it, route 2 finds none beside the plugin source, and route 3 answers.
+
+| gate | what it proves |
+| --- | --- |
+| **bundle route** | the build succeeds, the log names the pinned artifact bundle as the route, the resolved template path is inside an `.artifactbundle` rather than in this working tree, and the mock the bundle's template generated carries `func ferry` |
+
+The copy is generated rather than committed: it is this repository minus one
+directory, and a second copy in the tree would be a second thing to keep in step.
+Restoring `templates/` into it turns the route back to the package graph, which
+is the negative control — the log then reads `the package graph` and both path
+assertions fail.
+
 ## The red controls
 
 [`PluginFixtureRed/`](PluginFixtureRed) holds four packages that must **fail**,

--- a/Tests/Checks/run-plugin-checks.sh
+++ b/Tests/Checks/run-plugin-checks.sh
@@ -17,6 +17,10 @@
 #                FAIL, for a reason this script matches on. One package per
 #                control: build planning runs every target's plugin, so a
 #                plan-time error in one target fails the build for all of them.
+#   bundle route Checks/PluginFixtureBundleRoute — a package whose dependency is
+#                a copy of this repository with no `templates/`, so the two
+#                routes ahead of the artifact bundle cannot answer and the third
+#                one runs. The only place it does.
 #
 # Usage:
 #   Checks/run-plugin-checks.sh            # run the gates
@@ -39,6 +43,8 @@ CACHE_DIR="$WORK_DIR/cache"
 FIXTURE_DIR="$SCRIPT_DIR/PluginFixture"
 FIXTURE_SCRATCH="$WORK_DIR/fixture"
 RED_DIR="$SCRIPT_DIR/PluginFixtureRed"
+BUNDLE_ROUTE_DIR="$SCRIPT_DIR/PluginFixtureBundleRoute"
+ENGINE_PACKAGE="$WORK_DIR/engine-package"
 
 KEEP=0
 [ "$1" = "--keep" ] && KEEP=1
@@ -454,6 +460,57 @@ elif [ -z "$PACKAGEKEY_CONFIG" ]; then
   fail "PackageKey wrote no synthesized config to inspect"
 else
   fail "a sources: block was appended over a config that declares package:"
+fi
+
+# ── 12. The artifact-bundle template route ────────────────────────
+# Route 3 of followup-xcode-lane.md §12, and the only gate that runs it. Every
+# other fixture reaches this repository directly, so the plugin's own source file
+# sits beside a `templates/` directory and route 2 answers first — which is what
+# §16 wants on a branch, and what leaves route 3 covered by nothing.
+#
+# So the dependency here is a copy of this repository with `templates/` left out:
+# route 1 finds the package in the graph with no templates under it, route 2
+# finds none beside the plugin source, and the plugin falls through to the
+# artifact bundle its manifest pins. `-v` because a remark reaches the SwiftPM
+# log only in verbose mode.
+echo ""
+echo "── artifact-bundle route ──"
+rm -rf "$ENGINE_PACKAGE"
+mkdir -p "$ENGINE_PACKAGE"
+cp "$GIT_ROOT/Package.swift" "$ENGINE_PACKAGE/"
+cp -R "$GIT_ROOT/Plugins" "$GIT_ROOT/Sources" "$ENGINE_PACKAGE/"
+if [ -e "$ENGINE_PACKAGE/templates" ]; then
+  fail "the engine-package copy carries templates/, so this gate would test route 2 again"
+fi
+
+BUNDLE_ROUTE_SCRATCH="$WORK_DIR/bundle-route"
+BUNDLE_ROUTE_LOG="$WORK_DIR/bundle-route.log"
+if ! swift build --package-path "$BUNDLE_ROUTE_DIR" --scratch-path "$BUNDLE_ROUTE_SCRATCH" \
+     "${SWIFT_FLAGS[@]}" -v > "$BUNDLE_ROUTE_LOG" 2>&1; then
+  grep -E "error:" "$BUNDLE_ROUTE_LOG" | head -10
+  fail "the bundle-route fixture did not build — a bare name did not resolve without a templates/ in the checkout"
+else
+  pass "a bare template name resolves with no templates/ in the consumed checkout"
+  if grep -qF "shipped templates come from the pinned artifact bundle" "$BUNDLE_ROUTE_LOG"; then
+    pass "and the log names the artifact bundle as the route"
+  else
+    grep -o "shipped templates come from [^\"]*" "$BUNDLE_ROUTE_LOG" | head -1
+    fail "the log does not name the pinned artifact bundle as the route"
+  fi
+  BUNDLE_ROUTE_CONFIG="$(find "$BUNDLE_ROUTE_SCRATCH/plugins/outputs" -path "*/.sourceryConfigs/*" -type f 2>/dev/null | head -1)"
+  BUNDLE_ROUTE_TEMPLATE="$(block_paths "$BUNDLE_ROUTE_CONFIG" templates)"
+  case "$BUNDLE_ROUTE_TEMPLATE" in
+    */artifacts/*.artifactbundle/templates/Mocks.swifttemplate)
+      pass "'- Mocks' resolved inside the artifact bundle, not in this working tree" ;;
+    *)
+      fail "expected a path inside an .artifactbundle, got: $BUNDLE_ROUTE_TEMPLATE" ;;
+  esac
+  BUNDLE_ROUTE_MOCK="$(find "$BUNDLE_ROUTE_SCRATCH/plugins/outputs" -path "*/.generatedFiles/*/Mocks.generated.swift" -type f 2>/dev/null | head -1)"
+  if [ -n "$BUNDLE_ROUTE_MOCK" ] && grep -q 'func ferry' "$BUNDLE_ROUTE_MOCK"; then
+    pass "and the bundle's template generated the requirement the fixture declares"
+  else
+    fail "no mock, or one missing 'func ferry', from the bundle's template"
+  fi
 fi
 
 # ── Result ────────────────────────────────────────────────────────

--- a/Tests/Examples/ExampleProjectXcode/xcodegen.yml
+++ b/Tests/Examples/ExampleProjectXcode/xcodegen.yml
@@ -11,7 +11,8 @@
 # package is a full source checkout that carries `templates/`, so `#filePath`
 # answers and the log reads "shipped templates come from the plugin's own source
 # location, .../SourcePackages/checkouts/swift-sourcery-templates/templates".
-# Route 3 answers only where route 2 fails, which is what F6 built it for.
+# Route 3 answers only where route 2 fails, which is what F6 built it for, and
+# Tests/Checks/PluginFixtureBundleRoute is the fixture that makes it fail.
 #
 # Not a lane in ci.yml (F9): a branch lane here would make every push depend on
 # the last published artifact, which is the coupling §16 exists to avoid.


### PR DESCRIPTION
Two independent items from the end-of-round review.

## 1. The artifact-bundle template route now has a gate

Route 3 of `followup-xcode-lane.md` §12 was exercised by nothing. Every fixture
reaches this repository directly, so the plugin's own source file sits beside a
`templates/` directory and `#filePath` answers first — which is what §16 wants
on a branch, and also why the route had no coverage. §17 expected the by-URL
example to cover it; measurement showed it does not, because a URL-resolved
package is a full source checkout carrying `templates/` too.

The only way to run the route is to make the ones ahead of it fail.
`Tests/Checks/PluginFixtureBundleRoute` depends on a copy of this repository
with `templates/` left out, which `run-plugin-checks.sh` writes into
`.build/plugin-checks/engine-package` before building. Route 1 finds the package
in the graph with no templates under it, route 2 finds none beside the plugin
source, route 3 answers.

The copy is generated, not committed: it is this repository minus one directory,
and a second copy in the tree would be a second thing to keep in step.

Four assertions, so the gate reports on the route rather than on the build
succeeding:

```
ok: a bare template name resolves with no templates/ in the consumed checkout
ok: and the log names the artifact bundle as the route
ok: '- Mocks' resolved inside the artifact bundle, not in this working tree
ok: and the bundle's template generated the requirement the fixture declares
```

**Negative control.** With `templates/` copied back into `engine-package`, the
log reads `shipped templates come from the package graph,
.../engine-package/templates` — both path assertions would fail. The gate
discriminates rather than passing on any successful build.

Lane time is unchanged: `ALL PLUGIN CHECKS PASSED  (cold 48s, warm 1s)`.

## 2. The install snippet named the old org

[README.md:282](README.md#L282) said
`github.com/ivanmisuno/swift-sourcery-templates.git`, `from: "0.2.2"`, and the
CI badge said the same org. Everything else here says `modaal-agent`. GitHub
redirects, so nothing was broken — but a consumer whose graph reaches this
package under both names fails to resolve on duplicate identity. `from:` becomes
`0.8.0`, the first release supporting what the page below it documents.

## Checked locally

All five lanes, with `.build/plugin-checks` deleted first so the plugin lane ran
cold: fast, CLI, plugin (48s cold), xcode, and the SPM example (19 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)