### PR TITLE
[002-annotation-registry-and-agent-skill] The cross-repository comparison with kotlin-ksp-mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,8 +655,10 @@ npx skills add modaal-agent/swift-sourcery-templates
 
 ```bash
 git clone https://github.com/modaal-agent/swift-sourcery-templates
-cp -r swift-sourcery-templates/skills/* ~/.claude/skills/     # or .claude/skills/ per project
+cp -r swift-sourcery-templates/skills/* ~/.claude/skills/
 ```
+
+`.claude/skills/` inside a project installs it for that project alone.
 
 **4. claude.ai and the Skills API.** The frontmatter carries only the Agent Skills standard's keys,
 so `skills/swift-sourcery-mocks/` packages and uploads unedited.

--- a/skills/swift-sourcery-mocks/SKILL.md
+++ b/skills/swift-sourcery-mocks/SKILL.md
@@ -222,6 +222,29 @@ The generated file compiles at zero diagnostics under `-swift-version 5
 -strict-concurrency=complete` and under `-swift-version 6`: the protocol's global actor lands on the
 mock class, `nonisolated` is carried through, and a `Sendable` protocol gets `@unchecked Sendable`.
 
+The emitted Swift for each shape — the argument tuple, what an unset handler returns, the
+initializer-seeded bag, the overload names — is
+[references/generated-api.md](references/generated-api.md).
+
+## Publishers are subject-backed
+
+An `AnyPublisher` requirement, on a property or a method, is generated with a subject the test sends
+into, named `<var>Subject` or `<method>Subject`:
+
+```swift
+let repo = MemoryRepositoryMock()
+var received: [[MemoryDrop]] = []
+let token = repo.ownMemories.sink { received.append($0) }   // subscribe first
+repo.ownMemoriesSubject.send([drop])                        // then send
+```
+
+The default is a `PassthroughSubject`, which delivers nothing to a subscriber that arrives after the
+value was sent — a test that seeds in `setUp` and subscribes in the test body sees nothing and waits.
+Two ways to make the member replay: annotate the requirement `subject = "CurrentValue"`, which backs
+it with a `CurrentValueSubject` seeded with the `Output`'s default value, or return a publisher of
+your own from `<var>GetHandler`. A test that collects to the end also has to finish the stream —
+`send(completion: .finished)`.
+
 ## When it goes wrong
 
 | symptom | cause | action |
@@ -246,3 +269,5 @@ Each of these in full, with the diagnostic text to match against, is in
 - [references/writing-testable-protocols.md](references/writing-testable-protocols.md) — what to
   annotate, and how to shape a protocol so its mock is usable.
 - [references/troubleshooting.md](references/troubleshooting.md) — one section per symptom.
+- [references/generated-api.md](references/generated-api.md) — the emitted Swift, shape by shape,
+  and the member map to the Kotlin twin.

--- a/skills/swift-sourcery-mocks/references/generated-api.md
+++ b/skills/swift-sourcery-mocks/references/generated-api.md
@@ -1,0 +1,224 @@
+# The generated API, shape by shape
+
+Every snippet below is the Swift the templates emit, copied from a generated file. It is what a test
+writes against, so the names and the fallbacks here are the ones to assert on.
+
+## The file
+
+A generated file opens with a `// Generated using Sourcery` banner and `// DO NOT EDIT`, then the
+imports the parsed sources needed, then one class per annotated protocol:
+
+```swift
+final class DataServiceMock: DataService {
+```
+
+The class is `final` and `internal`, named `<Protocol>Mock`, and it conforms to the protocol and
+nothing else. Three variations: a `Sendable` protocol gets `, @unchecked Sendable`; a protocol
+refining `NSObjectProtocol`, or one annotated `ObjcProtocolMock`, gets an `NSObject` superclass; a
+`@MainActor` protocol puts `@MainActor` on the class.
+
+Methods and properties are emitted name-sorted, whatever order the protocol declares them in, so
+adding a requirement moves no other member in the diff.
+
+## A method with one recordable parameter
+
+```swift
+func identify(uid: String) {
+    identifyCallCount += 1
+    identifyArgs.append(uid)
+    if let __identifyHandler = self.identifyHandler {
+        __identifyHandler(uid)
+    }
+}
+var identifyCallCount: Int = 0
+var identifyArgs: [String] = []
+var identifyHandler: ((_ uid: String) -> ())? = nil
+```
+
+The count and the argument are recorded **before** the handler runs, so a handler that throws does
+not un-make the call.
+
+## A method with several recordable parameters
+
+Two or more recorded parameters give one labelled tuple per call, labelled with the parameter names:
+
+```swift
+func report(_ code: String, detail: String?) {
+    reportCallCount += 1
+    reportArgs.append((code: code, detail: detail))
+    …
+}
+var reportArgs: [(code: String, detail: String?)] = []
+var reportHandler: ((_ code: String, _ detail: String?) -> ())? = nil
+```
+
+A test reads a field by name rather than correlating two arrays by index:
+
+```swift
+XCTAssertEqual(mock.reportArgs.last?.detail, "disk full")
+```
+
+An `inout` parameter keeps `inout` in the method and in the handler, and the recorded element type
+drops it — what the mock records is the value it was handed on entry.
+
+## `async`, `throws`, and what an unset handler returns
+
+```swift
+func upload(fileName: String) async throws -> URL {
+    uploadCallCount += 1
+    uploadArgs.append(fileName)
+    if let __uploadHandler = self.uploadHandler {
+        return try await __uploadHandler(fileName)
+    }
+    fatalError("uploadHandler expected to be set.")
+}
+var uploadHandler: ((_ fileName: String) async throws -> (URL))? = nil
+```
+
+`async` and `throws` are carried into the handler's type. What happens with no handler set:
+
+| the return type | what an unset handler returns |
+| --- | --- |
+| `Void` | nothing; the handler is invoked if set and the method returns |
+| any `Optional` | `nil` |
+| `Array`, `Dictionary`, `Set`, a tuple of defaultable types | `[]`, `[:]`, `Set()`, the element-wise default |
+| `String`, `Bool`, the integer and floating-point types, `TimeInterval`, `CGFloat`, `CGPoint`, `CGSize`, `CGRect` | `""`, `false`, `0`, `0.0`, `CGFloat(0)`, `.zero` |
+| `AnyPublisher<Output, Failure>`, and the RxSwift stream types | the member's own subject, erased — see below |
+| `AnyCancellable` or `Disposable` | a token that counts its own cancellation |
+| anything else | `fatalError("<method>Handler expected to be set.")` |
+
+A method whose return type is in the last row is the one to seed before the call. `<method>CallCount`
+and `<method>Args` are recorded first, so the arguments of the call that trapped are readable in the
+debugger.
+
+## Publisher members
+
+An `AnyPublisher` requirement is backed by a subject the test sends into. On a property:
+
+```swift
+var ownMemories: AnyPublisher<[MemoryDrop], Never> {
+    ownMemoriesGetCount += 1
+    if let handler = ownMemoriesGetHandler {
+        return handler()
+    }
+    return ownMemoriesSubject.eraseToAnyPublisher()
+}
+var ownMemoriesGetCount: Int = 0
+var ownMemoriesGetHandler: (() -> AnyPublisher<[MemoryDrop], Never>)? = nil
+lazy var ownMemoriesSubject = PassthroughSubject<[MemoryDrop], Never>()
+```
+
+On a method the same subject sits behind `<method>Handler`, as `<method>Subject`. The default is a
+`PassthroughSubject`, which delivers nothing to a subscriber that arrives after the value was sent,
+and the erased publisher finishes only when the test sends a completion:
+
+```swift
+mock.ownMemoriesSubject.send([drop])
+mock.ownMemoriesSubject.send(completion: .finished)
+```
+
+`/// sourcery: subject = "CurrentValue"` on the requirement makes it a `CurrentValueSubject` seeded
+with the `Output`'s default value, which replays that value to a late subscriber. An `Output` with no
+default value fails generation naming the member, because a `CurrentValueSubject` has to be seeded;
+set `<name>GetHandler` to a stream that replays instead.
+
+An RxSwift `Observable`, `Single` or `AnyObserver` member takes the same shape, backed by a
+`PublishSubject` under the same `<name>Subject` name.
+
+## Properties
+
+```swift
+// var requirement: stored, and writes are counted. Construction does not count.
+var draft: String = "" {
+    didSet {
+        draftSetCount += 1
+    }
+}
+var draftSetCount: Int = 0
+
+// read-only requirement with a default value: a var a test can re-seed.
+var identifier: String = ""
+
+// read-only requirement without one: a stored property and an initializer parameter.
+var analytics: AnalyticsTracking
+init(analytics: AnalyticsTracking, memoryRepository: MemoryRepositoryProtocol) { … }
+```
+
+There is no `<var>GetCount` for a stored property — a read of a stored `var` is not counted; the
+counted form is the computed one publisher members and effectful requirements take. A protocol of
+properties alone therefore generates an initializer-seeded bag, and adding a requirement without a
+default value to it breaks every construction of the mock at compile time.
+
+Under a `@MainActor` protocol, a `nonisolated` member's storage is declared `nonisolated(unsafe)`,
+because a nonisolated member cannot mutate main-actor isolated storage.
+
+## Cancellation tokens
+
+A method returning `AnyCancellable` or an RxSwift `Disposable` records the cancellation as well as
+the call:
+
+```swift
+func registerURLHandler(_ tag: String, priority: Int) -> AnyCancellable {
+    …
+    return AnyCancellable { [weak self] in
+        self?.registerURLHandlerCancelCallCount += 1
+        self?.registerURLHandlerCancelHandler?()
+    }
+}
+var registerURLHandlerCancelCallCount: Int = 0
+var registerURLHandlerCancelHandler: (() -> ())? = nil
+```
+
+A test asserts that the caller released the registration by reading `<method>CancelCallCount`. The
+count belongs to the mock, not to the token, so it survives the token going out of scope.
+
+## Overloads
+
+Overloads would collide on the shared bookkeeping names. The overload with the fewest parameters
+keeps the plain name; each other overload appends its parameter labels and names, capitalized:
+
+```swift
+func update(id: String)                → updateCallCount, updateArgs, updateHandler
+func update(id: String, force: Bool)   → updateIdForceCallCount, updateIdForceArgs, updateIdForceHandler
+```
+
+Adding a wider overload later therefore does not rename the members an existing test already uses.
+Two overloads with the same number of parameters take the long form on both sides, and overloads
+differing only in return type get a suffix derived from that type. `methodName = "customName"` on a
+method names its members outright.
+
+## What is not recorded
+
+`<method>Args` is absent, and the call count and the handler are the whole record, when:
+
+- every parameter is function-typed — a closure reaches the handler and stays out of the record;
+- the method is generic — a stored property can only name the class's generic parameters;
+- `skipArgumentRecording` is on the method, or on the protocol, which applies it to every method.
+
+A method with no parameters gets no `<method>Args` either. Symptoms and fixes are in
+[troubleshooting.md](troubleshooting.md).
+
+## The same vocabulary in the Kotlin twin
+
+A codebase that tests the same logic on both platforms gets one dialect. The Kotlin side is generated
+by [kotlin-ksp-mocks](https://github.com/modaal-agent/kotlin-ksp-mocks), whose skill carries this
+table with the columns the other way round.
+
+| Swift | Kotlin |
+| --- | --- |
+| `<method>CallCount` | `<fn>CallCount` |
+| `<method>Args` | `<fn>Args`, elements of a nested `<Fn>Args` data class rather than a tuple |
+| `<method>Handler` | `<fn>Handler` |
+| `<var>GetCount`, `<var>GetHandler` | `<prop>GetCount`, `<prop>GetHandler` |
+| `<var>SetCount` | `<prop>SetCount` |
+| `<method>Subject` for an `AnyPublisher` member | `<fn>Channel` for a `Flow` member |
+| `fatalError("<method>Handler expected to be set.")` | the same string, thrown as `IllegalStateException` |
+| the initializer-seeded bag | the constructor-seeded bag |
+
+Members with no counterpart there: `<method>CancelCallCount`, and the per-declaration annotations of
+this generator, which that processor has no equivalent for because it selects targets in the build
+script. The property getter that traps is spelled differently on this side — `` `<var>GetHandler`
+must be set! `` — where the method form matches Kotlin's string exactly.
+
+The names, the subject-backed stream shape and the handler-expected string are shared deliberately.
+Renaming one of them is a change to both generators, not a local refactor.

--- a/specs/002-annotation-registry-and-agent-skill/spec.md
+++ b/specs/002-annotation-registry-and-agent-skill/spec.md
@@ -758,6 +758,8 @@ Body, budgeted at **under 400 lines** against the documented 500:
 | failure modes | the table in §5.4 | ~45 lines |
 | links to `references/` | one line each | ~10 lines |
 
+A ninth section, "Publishers are subject-backed", was added later — §14.3.
+
 ### 5.3 `references/` — loaded per lane
 
 | file | what it holds | budget |
@@ -766,6 +768,8 @@ Body, budgeted at **under 400 lines** against the documented 500:
 | `references/cli-lane.md` | every `mock-templates` flag, what `validate` fails on, `imprint`, the artifact-bundle download and checksum, and the `generate-mocks.sh` shape from `modaal-firebase-wrappers` | ≤250 lines |
 | `references/writing-testable-protocols.md` | what to annotate and how to shape a protocol so its mock is usable, plus the rendered table grouped by `kind` | ≤200 lines |
 | `references/troubleshooting.md` | the long form of §5.4, one section per symptom | ≤200 lines |
+
+A fifth file, `references/generated-api.md`, was added later — §14.2.
 
 ### 5.4 The failure modes the body names
 
@@ -1464,6 +1468,8 @@ than taken: `--args` is repeatable (`Sources/mock-templates/Commands.swift:27`, 
 `args: { testable: Payments }` as a scalar is read by `_header.swifttemplate:18-25`, which accepts a
 `String` or a `[String]`.
 
+The model those runs used and the Claude Code version they ran under are in §14.4.
+
 The two diagnostic prompts are where the skill adds least: without it, both answers name the cause
 correctly from general Swift knowledge and miss only this repository's vocabulary — the member names
 in one, the lane-specific `sources:` fix in the other. The three setup prompts are where it decides
@@ -1487,3 +1493,160 @@ costs model calls and no CI job runs it.
   prompt carries the package's shape in its text, because a scaffold does not run without
   `--scaffold` and a case that needs one grades against an empty directory by default.
 - **Phase A5** — §10.4, unchanged by anything here.
+
+---
+
+## 14. Amendment — the cross-repository comparison of 2026-09-10
+
+Written after §13, from a fourteen-row table comparing this repository with
+[kotlin-ksp-mocks](https://github.com/modaal-agent/kotlin-ksp-mocks), the processor that generates
+the same test vocabulary for Kotlin. The twin's half of the table is implemented and recorded in its
+001 §16, written the same day; this section is the half that names files here. Two rows ask for
+nothing and are flagged: §14.6 and §14.7.
+
+### 14.1 What this repository changed
+
+| row | what it asked | what landed |
+| --- | --- | --- |
+| 2, 6 | a `references/generated-api.md` — the emitted Swift per shape, plus the member map to the twin | `skills/swift-sourcery-mocks/references/generated-api.md`, 224 lines against SC5's 250, ten sections. §14.2 |
+| 4 | a section on publisher members in the body, about 12 lines | `SKILL.md:229-246`, "Publishers are subject-backed". §14.3 |
+| 9 | the model and the Claude Code version appended to §13's run record | §14.4 |
+| 10 | read the graders for the `not_contains`-on-a-tool-name shape the twin deleted one for | §14.5 — 18 graders read, none changed |
+| 11 | one form of the manual-copy line in both READMEs | `README.md:656-661` takes the twin's form: the command alone, then the sentence about `.claude/skills/` |
+| 13 | the writing-style section into `AGENTS.md` | it is already there, `AGENTS.md:29-65`. §14.7 |
+
+`SKILL.md` went 248 → 273 lines against SC5's 400. SC5, SC8 and SC9 are the checks a new reference
+file moves, and all three are green (§14.9).
+
+### 14.2 `references/generated-api.md` — a fifth reference file
+
+Adds a row to §5.3's table. What it holds, in the order it holds it: the file and class shape and the
+three variations of the class line; a method with one recorded parameter; a method with several,
+which records a labelled tuple; `async`/`throws` and the table of what an unset handler returns; the
+publisher members; the properties, including the initializer-seeded bag; the cancellation token
+members; the overload naming rule; what is not recorded; and the member map to the Kotlin twin.
+
+Three reasons it is a reference and not body text:
+
+- **It is per-shape lookup, not instruction.** A session that has already written the config opens it
+  once to answer "what is the member called and what does it return unseeded". §5.2's budget table
+  gives "what the generated mock gives a test" ~50 lines, and the member table there is the summary
+  this file is the long form of.
+- **The snippets are the emitted Swift**, copied from the generated file the fast lane snapshots, and
+  the defaults table is the one `TypeName.defaultValue()` implements. Neither is derivable from the
+  member names alone.
+- **The member map has to live beside them.** The map is only readable next to the Swift it maps
+  from; splitting it into a sixth file would put two halves of one table in two files.
+
+The map (`generated-api.md:201-224`) is the twin's D12 table with the columns the other way round,
+plus the two rows where the platforms differ rather than match: `<method>CancelCallCount` has no
+Kotlin counterpart, and the trapping *property* getter is spelled `` `<var>GetHandler` must be set! ``
+here (`templates/Mocks/MockVar.swift:91`) where the method form matches Kotlin's
+`<fn>Handler expected to be set.` exactly (`templates/Mocks/MockMethod.swift:146`). Neither CI can
+diff the two copies of the table, so each names the other repository and states that renaming a
+member is a change to both generators.
+
+### 14.3 "Publishers are subject-backed" — a ninth body section
+
+Adds a row to §5.2's table, between "what the generated mock gives a test" and the failure modes. It
+is 18 lines: the subject names, a four-line test that subscribes before it sends, the
+`PassthroughSubject` default and what it drops, and the two ways to make a member replay —
+`subject = "CurrentValue"` on the requirement, or a publisher of the test's own from
+`<var>GetHandler`.
+
+§5.4's symptom table already carries the hang, and `references/troubleshooting.md` carries the long
+form. The difference is when each is read: the symptom row is reached by an agent holding a failing
+test, and this section is reached by one about to write it. The `publisher-hangs` eval case measures
+the first path and not the second, which §14.8 leaves open.
+
+### 14.4 The model and the CLI version of §13.4's ten runs
+
+§13.4 records the date, the count and the cost, and names neither. Both, measured:
+
+- **Claude Code 2.1.267.** §13.2 and §13.3 already name it for the binary read and for the
+  early-access refusal; it is the same CLI that ran the ten arms.
+- **`claude-opus-5`.** No `--model` was passed to any arm — §13.3's command line has no such flag —
+  and `~/.claude/settings.json` carries no `model` key, so each arm took the CLI default. Measured
+  after the fact on the same version and the same account, from a fresh directory:
+  `claude -p --output-format json "…"` reports `canonicalModel: claude-opus-5` for the main agent and
+  `claude-haiku-4-5` for the side call the session makes.
+
+One version to record for the run that has not happened yet: `claude plugin eval --judge-model`
+defaults to haiku, so the `llm` graders of §13.6's first open item will be graded by a smaller model
+than the one that produced the answers.
+
+### 14.5 The grader audit — no `not_contains` here
+
+The twin deleted `evals/wire-a-jvm-module/graders/no-mocking-library.md` after a without-arm named
+MockK while refusing to use it: a `not_contains` on a tool name cannot tell "recommends X" from
+"declines X", and it redded an answer that was right. The eighteen graders of `Tests/Evals/` were
+read against that shape:
+
+| type | count | shape |
+| --- | --- | --- |
+| `regex` | 8 | every one `match: contains`, on a token the correct answer has to produce — `\$\{SOURCERY_SOURCES\}`, `--sources`, `mock-templates.{0,40}generate`, `subject = "CurrentValue"\|CurrentValueSubject` |
+| `tool_used` | 5 | `tool: Skill`, `arm: with-only`, the plugin-fired indicator |
+| `llm` | 5 | criteria plus an "It fails if …" clause |
+
+Nothing is changed. No grader excludes a string, so no answer can be redded for naming a tool it goes
+on to reject. The exclusions this suite does carry are the "It fails if …" clauses of the five `llm`
+graders — "It fails if it recommends adding the build-tool plugin to this package as well" — which a
+judge model reads as a judgement about the recommendation, not as a substring test. That is the
+property the twin's deleted grader lacked, and it is why the same row costs nothing here.
+
+### 14.6 Row 7 is not a defect in either spec — flagged
+
+The row reads: "One spec records the runner wrongly. Measure once with the installed runner and
+append the answer to both specs. Move nothing until then." Both specs are right, and the measurement
+needs the help text rather than a run. `claude plugin eval --help` at 2.1.267, read here:
+
+```
+--eval-dir <dir>   Directory name (below the plugin) that holds the eval cases; results go to
+                   <plugin>/<dir>/results/ … (default dir: the manifest's experimental.evals
+                   value, else evals/)
+```
+
+The default is the manifest's value **or** `evals/`. A plugin whose cases sit in `evals/` therefore
+needs no key — the twin, its 001 §8 D11 — and a plugin whose cases sit in `Tests/Evals` needs one,
+which is what §13.2 says and what `.claude-plugin/plugin.json` carries. The two records are about two
+directory names and do not contradict each other. Nothing moves: `Tests/Evals` stays where §13.2 put
+it, beside `Tests/Checks`. The twin's 001 §16.3 reaches the same reading from its own copy of the
+help text.
+
+### 14.7 Row 13 asks for what is already here — flagged
+
+The row's Swift column says `AGENTS.md` holds "rules for the skill and the gate" and asks for the
+writing-style section to be added. `AGENTS.md:29-65` is "## Writing style: state facts and actions,
+no aphorisms", six bullets and the sentence-level test, and it has been there since the file was
+written. The row's second clause — "CLAUDE.md there is a pointer, so one edit" — is wrong for both
+repositories: `AGENTS.md` and `CLAUDE.md` are byte-identical copies, `cp AGENTS.md CLAUDE.md`, and
+`ci.yml`'s `rules` job runs `cmp` on them. Editing one is always two files, never one. No edit.
+
+### 14.8 The rows that name the twin, and what stays open here
+
+Rows 1, 3 and 8 name `kotlin-ksp-mocks` and are implemented in its 001 §16.1: the decision table
+moved above the wiring block, the shaping heading renamed to this repository's first line, and an
+`evals/README.md`. Rows 5, 12 and 14 ask for nothing in either repository — the symptom-row counts
+and the marketplace descriptions are each right as they stand, and the wiring-shape counts differ
+because the build systems do.
+
+Open, unchanged by this section:
+
+- **No eval case reads a reference file.** §13.3's third condition means the with-arms answered from
+  `SKILL.md` alone, and `references/generated-api.md` joins the four files no case has exercised. A
+  case that asks what an unset handler returns, run with
+  `--add-dir <repo>/skills/swift-sourcery-mocks`, is what would measure it.
+- **§13.6's two items and phase A5**, unchanged.
+
+### 14.9 The gate
+
+| command | result |
+| --- | --- |
+| `Tests/Checks/run-skill-checks.sh` | twelve green, SC5 at 273 lines and 224 |
+| `Tests/Checks/run-skill-checks.sh --self-test` | twelve red against their seeded violations, then twelve green |
+| `Tests/Checks/run-annotation-checks.sh` | nine green |
+| `Tests/Checks/run-checks.sh` | snapshot, both language modes and the behaviour checks, all green |
+| `cmp AGENTS.md CLAUDE.md` | identical |
+
+No template, `Sources/`, `Plugins/` or `.github/` file is touched, so the five macOS lanes have
+nothing new to run; §6.2's change filter skips them for a push of `.md` files and `README.md`.

--- a/specs/002-annotation-registry-and-agent-skill/spec.md
+++ b/specs/002-annotation-registry-and-agent-skill/spec.md
@@ -1650,3 +1650,10 @@ Open, unchanged by this section:
 
 No template, `Sources/`, `Plugins/` or `.github/` file is touched, so the five macOS lanes have
 nothing new to run; §6.2's change filter skips them for a push of `.md` files and `README.md`.
+
+**Corrected against the run.** The branch's first push ran all nine jobs and all nine passed (run
+`34531716017`, head `01efee2`). The paragraph above is right about the files and wrong about this
+push: a branch-creating push carries `before=0000000000000000000000000000000000000000`, and the
+filter's fallback — *no usable range (before='000…') — running every lane* — sets `code=true`
+before any path is examined. §6.2's path filter decides the second and later pushes of a branch,
+where a range exists; it never decides the first.


### PR DESCRIPTION
Six rows of a fourteen-row table comparing this repository with
[kotlin-ksp-mocks](https://github.com/modaal-agent/kotlin-ksp-mocks) name a file here. The twin's
half landed in its 001 §16 the same day; this is the other half, recorded in spec 002 §14.

## What changed

| row | what landed |
| --- | --- |
| 2, 6 | `skills/swift-sourcery-mocks/references/generated-api.md` — the emitted Swift per shape (the recorded-argument tuple, the unset-handler fallback table, the subject behind a publisher member, the initializer-seeded bag, the cancellation-token members, the overload names) and the member map to the Kotlin twin. 224 lines against SC5's 250 |
| 4 | `SKILL.md` §"Publishers are subject-backed", 18 lines: the subject names, subscribe before send, and the two ways to make a member replay. 248 → 273 lines against SC5's 400 |
| 11 | `README.md` takes the twin's manual-copy form — the command alone, then a sentence saying what `.claude/skills/` does |
| 9 | spec §14.4: the ten runs of §13.4 ran on Claude Code 2.1.267 with no `--model` flag and no `model` key in settings, so on the CLI default, measured as `claude-opus-5` |
| 10 | spec §14.5: eighteen graders read for the `not_contains`-on-a-tool-name shape the twin deleted one for. There is none here — the eight `regex` graders are all `match: contains`, and the five `llm` graders' exclusions are judged, not substring-matched. No grader changed |

Two rows are flagged as asking for nothing:

- **Row 7** — "one spec records the runner wrongly". `claude plugin eval --help` at 2.1.267 makes the
  eval directory default "the manifest's `experimental.evals` value, else `evals/`", so a suite in
  `evals/` needs no key (the twin) and one in `Tests/Evals` needs one (here, §13.2). Both records are
  right; nothing moves. §14.6.
- **Row 13** — "add the writing-style section to `AGENTS.md`". `AGENTS.md:29-65` is that section
  already, and `CLAUDE.md` here is a byte-identical copy rather than a pointer, so an edit to the
  rules is always two files. §14.7.

Rows 1, 3 and 8 name the twin and landed there. Rows 5, 12 and 14 ask for nothing in either
repository.

## The gate

| command | result |
| --- | --- |
| `Tests/Checks/run-skill-checks.sh` | twelve green, SC5 at 273 lines and 224 |
| `Tests/Checks/run-skill-checks.sh --self-test` | twelve red against their seeded violations, then twelve green |
| `Tests/Checks/run-annotation-checks.sh` | nine green |
| `Tests/Checks/run-checks.sh` | snapshot, both language modes and the behaviour checks, all green |
| `cmp AGENTS.md CLAUDE.md` | identical |

No file under `templates/`, `Sources/`, `Plugins/` or `.github/` is touched. The branch's first push
ran all nine jobs anyway and all nine passed — a branch-creating push carries `before=000…0` and the
filter falls back to running every lane before it looks at a path. The path filter decides the second
push onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

