### PR TITLE
One naming rule for every generated mock member

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,9 +92,14 @@ Habits to avoid (common LLM-isms):
 - Code goes on a branch and through a PR, so [`ci.yml`](.github/workflows/ci.yml)'s seven lanes run
   before it lands. They trigger on push, not on PR open.
 - Any merge strategy — merge, rebase or squash — chosen for the nature of the PR.
-- A change touching no code may go straight to `master`: a spec, a note, README or CHANGELOG
-  wording, the skill tree under `skills/` or a `.claude-plugin/` manifest. `templates/`, `Sources/`,
-  `Plugins/`, `Tests/`, `Scripts/` and `.github/` are code.
+- **A new spec starts its feature's branch, and the spec is that branch's first commit.** Offer the
+  branch when the spec is asked for and create it before writing, named `spec/NNN-slug` after the
+  spec directory. The feature's code then lands on the same branch. A follow-up file beside a closed
+  spec follows this rule too when it plans new work.
+- A change touching no code may go straight to `master`: a note, README or CHANGELOG wording, the
+  skill tree under `skills/` or a `.claude-plugin/` manifest, or an addition to a spec whose branch
+  has already merged. `templates/`, `Sources/`, `Plugins/`, `Tests/`, `Scripts/` and `.github/` are
+  code.
 - Branch when the work starts. If code is ready and the checkout is `master`, ask which branch.
 - Pushing, opening a PR and merging one each need their own go-ahead.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,10 @@ Habits to avoid (common LLM-isms):
   parameter-declaration rules in `MethodParameter.parametersDecl` / `closureAttributesDecl`. Both
   templates read them. Restating a rule at a call site is how the mock and the Component come to
   emit different isolation for the same protocol.
+- **Every generated mock member name is built in `templates/Mocks/MockNaming.swift`** — the prefix,
+  the overload chain, every suffix, the backing store's spelling, both `fatalError` strings and the
+  uniqueness check. Interpolating a suffix where a member is emitted is how the method trap string
+  and the property one came to differ by three words and a pair of backticks.
 - Both language modes are the gate: `-swift-version 5 -strict-concurrency=complete` **and**
   `-swift-version 6`, at zero *diagnostics*. A construct can be a warning under the first and an
   error under the second.
@@ -177,7 +181,7 @@ templates. `Tests/Checks/run-skill-checks.sh` gates every rule below that a scri
   for every turn after the skill is invoked; a reference costs nothing until the agent opens it.
 - **The skill's behavioural gate is `Tests/Evals/`, and it does not live under `skills/`** — the
   runner refuses a case directory inside a plugin's component directory, so
-  `.claude-plugin/plugin.json` names the suite in `experimental.evals`. Each of the five prompts is
+  `.claude-plugin/plugin.json` names the suite in `experimental.evals`. Each of the six prompts is
   run once with the plugin loaded and once without, in fresh sessions, and the two answers compared.
   A with-arm answer that is wrong is a defect in the skill's text: edit the skill and run that case
   again. It spends model calls and no CI job runs it; SC13 only checks that each case would parse.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ var draftSetCount: Int = 0
 var _draft: String = ""
 ```
 
+**A `{ get }` requirement's witness is get-only**, as the requirement is, and `mock._<var> = value`
+is how a test seeds one — the same expression `kotlin-ksp-mocks` writes. A read-only requirement was
+emitted as a settable stored property before, so `mock.draft = x` compiled and moved no counter.
+`<var>SetCount` is still emitted for a `{ get set }` requirement only.
+
 **A property requirement declared `{ get async }`, `{ get throws }` or `{ get async throws }`**
 generates the accessor it declares, with the same effects on `<var>GetHandler`. It generated a plain
 stored property before, which does not satisfy the requirement.
@@ -95,12 +100,18 @@ func end(at fieldValues: [String]) {
 Comments only: no member moves and no generated code changes. Search a generated file for either
 spelling, the declaration as written or the prefix its members carry.
 
-**Breaking.** Every test naming a renamed member stops compiling. Regenerate and fix what the
+**Breaking, twice.** Every test naming a renamed member stops compiling. Regenerate and fix what the
 compiler names — each error names the member and the type, which is why no deprecated aliases are
 emitted: keeping them would mean keeping both naming rules in the generator.
 
+Every assignment to a `{ get }` requirement on a mock stops compiling too, with
+`cannot assign to property: … is a get-only property`. The fix at each site is `_<var>`:
+`mock.documentID = "d1"` becomes `mock._documentID = "d1"`. No deprecation window is available —
+`@available(*, deprecated)` marks a property, not one accessor. Nothing assigns such a requirement
+through the protocol, so every site is code holding the concrete `<Type>Mock`.
+
 Measured against `modaal-firebase-wrappers`, regenerated against `master` from its pinned 0.2.15:
-**7 files, 1706 lines → 3148**, 274 generated members → 515.
+**7 files, 1706 lines → 2803**, 274 generated members → 515.
 
 | category | count |
 | --- | --- |
@@ -109,6 +120,8 @@ Measured against `modaal-firebase-wrappers`, regenerated against `master` from i
 | property members added | 168, over 56 requirements: `GetCount`, `GetHandler` and `_<var>` each |
 | `<method>Args` added | 73 — from the version bump itself, not from this change; that repository is pinned before argument recording |
 | naming comments | 214 lines — 5 per file, 2 per class, and 47 members carrying one above the witness and one in their class's index, in 10 of its 34 classes |
+| witnesses that became get-only | 69, over 52 distinct names; 4 `{ get set }` witnesses keep their setter |
+| its own tests that stop compiling on an assignment | **12 sites in 5 files** — `FirebaseAuthCombineTests` (4), `DocumentReferenceCombineTests` (4), `QueryDocumentSnapshotProtocolTests` (2), `FirestoreCombineTests` (1), `QueryCombineTests` (1); each becomes `_<var>` |
 | its own tests that stop compiling | **9 references in 2 files**, all naming `setDataDataForDocumentDocumentMerge*`, `setDataDataForDocumentDocumentMergeFields*` or `signInWithEmailEmailPasswordCompletionHandler` |
 
 The remaining renames land only in the committed generated files and in whatever repository imports
@@ -125,7 +138,9 @@ declaration.
    block changes with the body.
 3. **A property read starts counting.** An assertion that reads `mock.draft` moves `draftGetCount`
    itself. Read and seed `mock._draft` to leave the counters where they are.
-4. **A publisher member gains six members and a handler.** Driving `<name>Subject` is unchanged, and
+4. **Seed a `{ get }` requirement through `_<var>`.** `mock.documentID = "d1"` no longer compiles;
+   `mock._documentID = "d1"` is the replacement, and it is the same expression on the Kotlin side.
+5. **A publisher member gains six members and a handler.** Driving `<name>Subject` is unchanged, and
    a value sent while nobody is subscribed still goes nowhere — `<name>OutputCount` is how a test
    sees that.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,12 +82,25 @@ A property getter with no handler set now traps with `<var>GetHandler expected t
 wording the method form already used and the one `kotlin-ksp-mocks` matches; it was
 `` `<var>GetHandler` must be set! ``.
 
+**Every generated file says how its members are named.** Five lines at the top state the rule, every
+`// MARK: - <Protocol>` restates it in two, and a member whose prefix is not its declared name
+carries a comment naming both spellings — above the witness, and in an index under that class's
+`MARK:`:
+
+```swift
+// `end(at:)` members are named `endAt*` — overload of `end`, argument labels appended
+func end(at fieldValues: [String]) {
+```
+
+Comments only: no member moves and no generated code changes. Search a generated file for either
+spelling, the declaration as written or the prefix its members carry.
+
 **Breaking.** Every test naming a renamed member stops compiling. Regenerate and fix what the
 compiler names — each error names the member and the type, which is why no deprecated aliases are
 emitted: keeping them would mean keeping both naming rules in the generator.
 
 Measured against `modaal-firebase-wrappers`, regenerated against `master` from its pinned 0.2.15:
-**7 files, 1706 lines → 2934**, 274 generated members → 515.
+**7 files, 1706 lines → 3148**, 274 generated members → 515.
 
 | category | count |
 | --- | --- |
@@ -95,6 +108,7 @@ Measured against `modaal-firebase-wrappers`, regenerated against `master` from i
 | members renamed by the prefix rule | 0 — no protocol there declares a method name carrying an underscore or leading capitals |
 | property members added | 168, over 56 requirements: `GetCount`, `GetHandler` and `_<var>` each |
 | `<method>Args` added | 73 — from the version bump itself, not from this change; that repository is pinned before argument recording |
+| naming comments | 214 lines — 5 per file, 2 per class, and 47 members carrying one above the witness and one in their class's index, in 10 of its 34 classes |
 | its own tests that stop compiling | **9 references in 2 files**, all naming `setDataDataForDocumentDocumentMerge*`, `setDataDataForDocumentDocumentMergeFields*` or `signInWithEmailEmailPasswordCompletionHandler` |
 
 The remaining renames land only in the committed generated files and in whatever repository imports
@@ -116,8 +130,8 @@ declaration.
    sees that.
 
 The rule is stated in `README.md` §"Generated Mock API", in the skill's
-`references/generated-api.md` and `references/stream-members.md`, and built in one place,
-`templates/Mocks/MockNaming.swift`. `specs/004-mock-member-naming/spec.md` is what measured it.
+`references/generated-api.md` and `references/stream-members.md`, in every generated file, and built
+in one place, `templates/Mocks/MockNaming.swift`. `specs/004-mock-member-naming/spec.md` is what measured it.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,109 @@ templates are distributed through SPM and through the assets a tag publishes on 
 
 ---
 
+## Unreleased — a mock member is the declared name plus a suffix
+
+Ships in the same release as the annotation-name entry below.
+
+**Generated output.** The bookkeeping prefix is now the member's declared name with backticks
+removed, and nothing else — no case change, no underscore removal, no first-word lowercasing. It was
+that for a property and a transform for a method, so one generated class carried two rules:
+
+```swift
+func perform1_0()              // perform10CallCount     → perform1_0CallCount
+func ID() -> String            // crashed generation     → IDCallCount
+var setting4_2: Int { get set }// setting4_2SetCount     → unchanged
+```
+
+An **overloaded** method's long form appends the capitalized argument label of each parameter, or the
+parameter name where the parameter has no label. It appended the label *and* the name before:
+
+```swift
+func end(atDocument document:)     // endAtDocumentDocument   → endAtDocument
+func end(at fieldValues:)          // endAtFieldValues        → endAt
+func reference(withPath path:)     // referenceWithPathPath   → referenceWithPath
+func update(id:force:)             // updateIdForce           → unchanged
+func putData(_ data:metadata:)     // putDataDataMetadata     → unchanged
+```
+
+**Every property requirement now counts its reads.** It generates `<var>GetCount`, `<var>GetHandler`
+and a store named `_<var>`, and the generated initializer seeds the store — construction still moves
+no counter, and `Mock(analytics:)` keeps its argument label. A stored property could not observe a
+read at all before, so `<var>GetCount` existed only on a stream member or one annotated `handler`.
+
+```swift
+var draft: String {
+    get { draftGetCount += 1; if let handler = draftGetHandler { return handler() }; return _draft }
+    set { draftSetCount += 1; _draft = newValue }
+}
+var draftGetCount: Int = 0
+var draftGetHandler: (() -> String)? = nil
+var draftSetCount: Int = 0
+var _draft: String = ""
+```
+
+**A property requirement declared `{ get async }`, `{ get throws }` or `{ get async throws }`**
+generates the accessor it declares, with the same effects on `<var>GetHandler`. It generated a plain
+stored property before, which does not satisfy the requirement.
+
+**An `AnyPublisher` member hands back a construct the mock owns** — a `Deferred` over the same
+subject — and counts what crossed it: `<name>SubscribeCount`, `<name>SubscribeCancelCount`,
+`<name>OutputCount`, `<name>CompletionCount`, with `<name>Outputs` recording the delivered values and
+`<name>OutputHandler` running after them. The subject, its default and `subject = "CurrentValue"` are
+unchanged. A property's `<var>GetHandler` is now read when the code under test **subscribes** rather
+than when it reads the member, so a handler seeded after the publisher was captured decides the
+stream. An `AnyObserver` member gains `<name>Events`, recording what was pushed in beside the count
+it already kept. `skipArgumentRecording` covers both recorders.
+
+**Two diagnostics replace two silent failures.** Two members of one mock that would carry the same
+name fail generation naming both — a protocol declaring `draft` and `draftGetCount` emitted
+`var draftGetCount` twice and only the consumer's compiler said so. A requirement declaring
+`throws(E)`, on a property or a method, fails generation naming the member: the templates write bare
+`throws`, and a witness throwing `any Error` does not satisfy it.
+
+A property getter with no handler set now traps with `<var>GetHandler expected to be set.`, the
+wording the method form already used and the one `kotlin-ksp-mocks` matches; it was
+`` `<var>GetHandler` must be set! ``.
+
+**Breaking.** Every test naming a renamed member stops compiling. Regenerate and fix what the
+compiler names — each error names the member and the type, which is why no deprecated aliases are
+emitted: keeping them would mean keeping both naming rules in the generator.
+
+Measured against `modaal-firebase-wrappers`, regenerated against `master` from its pinned 0.2.15:
+**7 files, 1706 lines → 2934**, 274 generated members → 515.
+
+| category | count |
+| --- | --- |
+| members renamed by the overload rule | 30, over 15 declarations (`endAtDocumentDocument*` → `endAtDocument*`, `referenceWithPathPath*` → `referenceWithPath*`, `signInWithEmailEmailPasswordCompletion*` → `signInWithEmailPasswordCompletion*`, …) |
+| members renamed by the prefix rule | 0 — no protocol there declares a method name carrying an underscore or leading capitals |
+| property members added | 168, over 56 requirements: `GetCount`, `GetHandler` and `_<var>` each |
+| `<method>Args` added | 73 — from the version bump itself, not from this change; that repository is pinned before argument recording |
+| its own tests that stop compiling | **9 references in 2 files**, all naming `setDataDataForDocumentDocumentMerge*`, `setDataDataForDocumentDocumentMergeFields*` or `signInWithEmailEmailPasswordCompletionHandler` |
+
+The remaining renames land only in the committed generated files and in whatever repository imports
+that mocks module.
+
+A member that must keep its old name takes `/// sourcery: methodName = "oldName"` on the
+declaration.
+
+**Adopting.**
+
+1. **Plugin lane** — rebuild. The mock regenerates and the compiler names every test that used a
+   renamed member.
+2. **CLI lane** — `mock-templates generate`, then `mock-templates validate` in CI. The fingerprint
+   block changes with the body.
+3. **A property read starts counting.** An assertion that reads `mock.draft` moves `draftGetCount`
+   itself. Read and seed `mock._draft` to leave the counters where they are.
+4. **A publisher member gains six members and a handler.** Driving `<name>Subject` is unchanged, and
+   a value sent while nobody is subscribed still goes nowhere — `<name>OutputCount` is how a test
+   sees that.
+
+The rule is stated in `README.md` §"Generated Mock API", in the skill's
+`references/generated-api.md` and `references/stream-members.md`, and built in one place,
+`templates/Mocks/MockNaming.swift`. `specs/004-mock-member-naming/spec.md` is what measured it.
+
+---
+
 ## Unreleased — annotation names are matched exactly, and the selectors are renamed
 
 **Generated output:** unchanged for a source that spells its annotations the way `README.md` spells

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,9 +92,14 @@ Habits to avoid (common LLM-isms):
 - Code goes on a branch and through a PR, so [`ci.yml`](.github/workflows/ci.yml)'s seven lanes run
   before it lands. They trigger on push, not on PR open.
 - Any merge strategy — merge, rebase or squash — chosen for the nature of the PR.
-- A change touching no code may go straight to `master`: a spec, a note, README or CHANGELOG
-  wording, the skill tree under `skills/` or a `.claude-plugin/` manifest. `templates/`, `Sources/`,
-  `Plugins/`, `Tests/`, `Scripts/` and `.github/` are code.
+- **A new spec starts its feature's branch, and the spec is that branch's first commit.** Offer the
+  branch when the spec is asked for and create it before writing, named `spec/NNN-slug` after the
+  spec directory. The feature's code then lands on the same branch. A follow-up file beside a closed
+  spec follows this rule too when it plans new work.
+- A change touching no code may go straight to `master`: a note, README or CHANGELOG wording, the
+  skill tree under `skills/` or a `.claude-plugin/` manifest, or an addition to a spec whose branch
+  has already merged. `templates/`, `Sources/`, `Plugins/`, `Tests/`, `Scripts/` and `.github/` are
+  code.
 - Branch when the work starts. If code is ready and the checkout is `master`, ask which branch.
 - Pushing, opening a PR and merging one each need their own go-ahead.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,10 @@ Habits to avoid (common LLM-isms):
   parameter-declaration rules in `MethodParameter.parametersDecl` / `closureAttributesDecl`. Both
   templates read them. Restating a rule at a call site is how the mock and the Component come to
   emit different isolation for the same protocol.
+- **Every generated mock member name is built in `templates/Mocks/MockNaming.swift`** — the prefix,
+  the overload chain, every suffix, the backing store's spelling, both `fatalError` strings and the
+  uniqueness check. Interpolating a suffix where a member is emitted is how the method trap string
+  and the property one came to differ by three words and a pair of backticks.
 - Both language modes are the gate: `-swift-version 5 -strict-concurrency=complete` **and**
   `-swift-version 6`, at zero *diagnostics*. A construct can be a warning under the first and an
   error under the second.
@@ -177,7 +181,7 @@ templates. `Tests/Checks/run-skill-checks.sh` gates every rule below that a scri
   for every turn after the skill is invoked; a reference costs nothing until the agent opens it.
 - **The skill's behavioural gate is `Tests/Evals/`, and it does not live under `skills/`** — the
   runner refuses a case directory inside a plugin's component directory, so
-  `.claude-plugin/plugin.json` names the suite in `experimental.evals`. Each of the five prompts is
+  `.claude-plugin/plugin.json` names the suite in `experimental.evals`. Each of the six prompts is
   run once with the plugin loaded and once without, in fresh sessions, and the two answers compared.
   A with-arm answer that is wrong is a defect in the skill's text: edit the skill and run that case
   again. It spends model calls and no CI job runs it; SC13 only checks that each case would parse.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Tests/                              # everything that verifies the product — s
   Examples/
     ExampleProjectSpm/              # full lane — RxSwift, RIBs, type erasure, the plugin
     ExampleProjectXcode/            # the adopter's shape, by URL at a tag — not a lane
-  Evals/                            # the skill's behavioural gate — five prompts, run with it and without
+  Evals/                            # the skill's behavioural gate — six prompts, run with it and without
 Scripts/
   assemble-release.sh               # builds the release assets — see Cutting a release
   engine-pin.sh                     # the upstream Sourcery pin: version, zip, SHA-256
@@ -102,6 +102,20 @@ its consumers need no Sourcery installation.
 3. Add the shape to `Tests/Checks/Fixtures/`, `--record`, read the diff
 4. If it needs RxSwift or RIBs to express, add a protocol to the example project's `Protocols.swift`
    and a Quick spec
+
+### A mock member's name
+
+`templates/Mocks/MockNaming.swift`. It holds the prefix derivation for a method and for a property,
+the overload chain, every suffix, the store's spelling, the two `fatalError` strings and the
+uniqueness check every emitted name goes through. `MockMethod`, `MockVar`, `MockGenerator` and
+`SourceryRuntimeExtensions` call it rather than interpolating a suffix where the member is emitted —
+that is how the method trap string and the property one came to differ by three words and a pair of
+backticks, each written at its own site
+(`specs/004-mock-member-naming/spec.md` §1.8, D5).
+
+Adding a member means adding its function there and calling it. The uniqueness check reads names
+back out of the declarations a class emits, so a new member is covered by it without being
+enumerated anywhere.
 
 ### A new smart default value
 
@@ -206,6 +220,26 @@ silence.
 
 ## Design rules already decided
 
+**A mock member is the declared name plus a suffix.** The name is taken verbatim, with backticks
+dropped and nothing else changed. An overloaded method is the one exception: the overload with the
+fewest parameters keeps the plain prefix and every other one appends the capitalized argument label
+of each parameter, or the parameter name where there is none; a group that still collides takes a
+return-type suffix, and one that still collides after that fails generation naming both members.
+The suffix set and the rule are in `specs/004-mock-member-naming/spec.md` §2, and
+`templates/Mocks/MockNaming.swift` is where they live.
+
+**Every property requirement is accessors over a `_<var>` store.** A stored property cannot observe
+a read, so `<var>GetCount` and `<var>GetHandler` are emitted for every requirement and the generated
+initializer seeds the store — construction moves no counter, and a test that does not want to move
+one reads and seeds `_<var>`. The witness stays settable wherever it was settable before that
+change; `const` and `handler` were not settable and are not now.
+
+**An effectful property requirement generates the accessor it declares.** `{ get async }`,
+`{ get throws }` and `{ get async throws }` carry through to the accessor and to
+`<var>GetHandler`'s type. Swift has no effectful setter, so such a requirement is get-only.
+A typed throw — `throws(E)` on a property or a method — is refused with a diagnostic: the templates
+write bare `throws`, which does not satisfy it.
+
 **Mock classes are `final`.** Subclassing a generated mock is not supported; setting a handler is the
 supported way to change behaviour.
 
@@ -246,6 +280,23 @@ traps. It cannot be opted out of at the call site either: assigning a `Passthrou
 `checkCombineStreams` asserts all four corners: the default does not replay, a get handler that
 returns a `CurrentValueSubject` does, `share(id:)` says nothing until the test sends, and the
 annotated `token()` answers on subscribe.
+
+**What is added around that subject is a construct the mock owns.** The member returns a `Deferred`
+whose closure runs once per subscription, wrapped in `handleEvents`, so the mock counts
+`<name>SubscribeCount`, `<name>OutputCount`, `<name>CompletionCount` and
+`<name>SubscribeCancelCount` and records `<name>Outputs` — it recorded only that the code under test
+*asked* for the stream before. The subject, its kind and what `subject = "CurrentValue"` does are
+unchanged. A property reads `<var>GetHandler` inside that closure, so a handler seeded after the
+publisher was captured decides the stream; a method keeps `<method>Handler` at call time, where its
+arguments are and where its `async` and `throws` apply. The closure captures the subject directly
+and the mock weakly — the stream still delivers after the mock is released and only the counting
+stops. A publisher requirement declared `{ get async }` or `{ get throws }` is refused: that closure
+is synchronous. `checkPublisherCounting` asserts each of these.
+
+**An `AnyObserver` member records what was pushed into it**, as `<name>Events`, beside the count it
+already kept — the RxSwift dual of `<name>Outputs`. Both sit under `skipArgumentRecording`, for the
+reason `<method>Args` does: a recorded value lives as long as the mock. `Event` declares no
+`Equatable` conformance, so a test reads `<name>Events` through `compactMap(\.element)`.
 
 **A Component refuses what it cannot forward** — `static`, `init` and `subscript` requirements, and
 associated types — with a diagnostic naming the member. Check `isInitializer` **before** `isStatic`:
@@ -322,7 +373,7 @@ protocol work. `Variable.isAsync` and `Variable.throws` carry effectful property
 | xcode | `Tests/Checks/run-xcode-checks.sh` | Xcode, `xcodegen` and, once, the network; ~35s |
 | full | `cd Tests/Examples/ExampleProjectSpm && ./test-ios.sh` | an iOS Simulator; minutes |
 
-`Tests/Evals/` is not a lane. It is the skill's behavioural gate: each of five prompts run once with
+`Tests/Evals/` is not a lane. It is the skill's behavioural gate: each of six prompts run once with
 the plugin loaded and once without, and the two answers compared — `claude plugin eval . --ablation
 with-without`, or the pair of `claude -p` invocations in `Tests/Evals/README.md`. It spends model
 calls and a few minutes, the runner is in early access, and no CI job runs it. Run it when the
@@ -503,11 +554,13 @@ the assets to the tag's GitHub release.
   `SetCount`). Decide whether it is the default or gated behind an annotation (`sourcery:
   publicMock`) or a template arg (`--args publicMocks`); `public` as the default is probably right,
   since mocks are always consumed from another module.
-- **Effectful property requirements in the mock template.** `var x: T { get async throws }` is
-  parsed by Sourcery (`Variable.isAsync`, `Variable.throws`) and ignored by `Mocks.swifttemplate`,
-  which emits a plain property that does not satisfy the requirement. Fixing it means always
-  emitting a computed property with a `get async throws { }` accessor plus a separate backing store
-  — a new naming convention, so it was left out of 0.2.15 rather than guessed at. No consumer uses
-  the shape. The Component template **does** forward it (`Tests/Checks/Fixtures/Forwarding.swift`,
-  `ProfileDependency`), because forwarding an effectful requirement is a pass-through and mocking
-  one is not.
+- **Typed throws.** `func f() throws(E)` and `var x: T { get throws(E) }` reach the templates as
+  `Method.throwsTypeName` and `Variable.throwsTypeName`, and both are refused with a diagnostic:
+  `MockMethod.throwingDecl` writes bare `throws`, and a witness throwing `any Error` does not
+  satisfy a requirement throwing `E`. Emitting the typed form means carrying the error type into the
+  method signature, the handler type and the accessor, and deciding what an unset handler throws. No
+  fixture and no consumer protocol in reach declares one.
+- **`AnySubscriber`.** Combine's dual of RxSwift's `AnyObserver` reaches no branch of
+  `smartDefaultValueImplementation` and falls through to `MockError.noDefaultValue`, so a
+  requirement returning one is constructor-seeded or traps for want of a handler. A coverage gap
+  rather than a naming one; no protocol in reach declares it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,6 +228,14 @@ return-type suffix, and one that still collides after that fails generation nami
 The suffix set and the rule are in `specs/004-mock-member-naming/spec.md` §2, and
 `templates/Mocks/MockNaming.swift` is where they live.
 
+**A prefix that is not the declared name is stated in the generated file.**
+`MockNaming.methodPrefix` returns the prefix and the comment recording it from one call, so a
+comment that disagrees with the member under it cannot be produced. `MockGenerator` emits the file
+header, the per-class header and the class's index of those members; `MockMethod` emits the line
+above the witness. `run-checks.sh`'s naming-comment gate reads them back out of the generated file
+and holds each to the `<prefix>CallCount` the witness increments, with a red control for a wrong
+prefix and one for an index missing a member.
+
 **Every property requirement is accessors over a `_<var>` store.** A stored property cannot observe
 a read, so `<var>GetCount` and `<var>GetHandler` are emitted for every requirement and the generated
 initializer seeds the store — construction moves no counter, and a test that does not want to move

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,8 +239,10 @@ prefix and one for an index missing a member.
 **Every property requirement is accessors over a `_<var>` store.** A stored property cannot observe
 a read, so `<var>GetCount` and `<var>GetHandler` are emitted for every requirement and the generated
 initializer seeds the store — construction moves no counter, and a test that does not want to move
-one reads and seeds `_<var>`. The witness stays settable wherever it was settable before that
-change; `const` and `handler` were not settable and are not now.
+one reads and seeds `_<var>`. **The witness declares what the requirement declares:** a `{ get }`
+requirement is get-only on the mock, so `mock._<var> = value` is the one way a test seeds it, and it
+is the expression `kotlin-ksp-mocks` writes for the same purpose (`spec.md` §12.2 item 2, D18). P5
+emitted an uncounted setter there; D18 retired it.
 
 **An effectful property requirement generates the accessor it declares.** `{ get async }`,
 `{ get throws }` and `{ get async throws }` carry through to the accessor and to

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ comment naming both spellings — above the witness, and in an index under that 
 | `Handler` | method | always |
 | `GetCount`, `GetHandler` | property | always |
 | `SetCount` | property | the requirement is `{ get set }` |
-| `_<var>` | property | the stored value, seeded and read without moving a counter |
+| `_<var>` | property | the stored value, seeded and read without moving a counter — and the only way to seed a `{ get }` requirement, whose witness is get-only |
 | `Subject` | both | `AnyPublisher`, `Observable`, `Single` |
 | `SubscribeCount`, `SubscribeCancelCount` | both | `AnyPublisher` — the code under test subscribed, and cancelled |
 | `OutputCount`, `Outputs`, `OutputHandler` | both | `AnyPublisher` — values the member delivered |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ first-word lowercasing. `func perform1_0()` gives `perform1_0CallCount`, `func I
 `IDCallCount`, ``func `do`()`` gives `doCallCount`, `var setting4_2: Int` gives `setting4_2GetCount`.
 An overload is the one case where the prefix is not the declared name: the overload with the fewest
 parameters keeps it, and every other one appends the capitalized argument label of each parameter,
-or the parameter name where there is none.
+or the parameter name where there is none. The generated file states the rule at its top and under
+every `// MARK: - <Protocol>`, and every member whose prefix is not its declared name carries a
+comment naming both spellings — above the witness, and in an index under that class's `MARK:`.
 
 | suffix | on | emitted when |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,35 @@ final class DataServiceMock: DataService {
 }
 ```
 
+**The naming rule: a mock member is the declared name plus a suffix.** The name is taken verbatim,
+with backticks dropped and nothing else changed — no case change, no underscore removal, no
+first-word lowercasing. `func perform1_0()` gives `perform1_0CallCount`, `func ID()` gives
+`IDCallCount`, ``func `do`()`` gives `doCallCount`, `var setting4_2: Int` gives `setting4_2GetCount`.
+An overload is the one case where the prefix is not the declared name: the overload with the fewest
+parameters keeps it, and every other one appends the capitalized argument label of each parameter,
+or the parameter name where there is none.
+
+| suffix | on | emitted when |
+| --- | --- | --- |
+| `CallCount` | method | always |
+| `Args` | method | at least one recordable parameter |
+| `Handler` | method | always |
+| `GetCount`, `GetHandler` | property | always |
+| `SetCount` | property | the requirement is `{ get set }` |
+| `_<var>` | property | the stored value, seeded and read without moving a counter |
+| `Subject` | both | `AnyPublisher`, `Observable`, `Single` |
+| `SubscribeCount`, `SubscribeCancelCount` | both | `AnyPublisher` — the code under test subscribed, and cancelled |
+| `OutputCount`, `Outputs`, `OutputHandler` | both | `AnyPublisher` — values the member delivered |
+| `CompletionCount` | both | `AnyPublisher` — the stream finished or failed |
+| `EventCallCount`, `Events`, `EventHandler` | both | `AnyObserver` — events pushed in |
+| `CancelCallCount`, `CancelHandler` | method | the return type is `AnyCancellable` |
+| `DisposeCallCount`, `DisposeHandler` | method | the return type is `Disposable` |
+
+A returned token's suffix is the call that token exposes: `cancel()` on `AnyCancellable`,
+`dispose()` on RxSwift's `Disposable`. Every name is built in
+[`templates/Mocks/MockNaming.swift`](templates/Mocks/MockNaming.swift), and two members of one mock
+that would carry the same name fail generation naming both.
+
 **Key features:**
 - **Call counting** — `methodCallCount` tracks invocation count
 - **Argument recording** — `methodArgs` holds what each call was passed, in order. See [Recorded arguments](#recorded-arguments)
@@ -54,6 +83,8 @@ final class DataServiceMock: DataService {
 - **`async` / `throws` preservation** — an `async` requirement generates an `async` method with an `async` handler, so a spec can control *when* the call returns, not only what it returns
 - **Smart defaults** — Optional returns `nil`, Void returns nothing, known types get sensible defaults, and RxSwift / Combine types get a subject the test drives
 - **Overload disambiguation** — overloaded methods get distinct handler names automatically
+- **Property read counting** — every property requirement generates `<var>GetCount`, `<var>GetHandler` and a `_<var>` store; `mock._draft` reads and seeds the value without moving a counter
+- **Effectful property requirements** — `{ get async }`, `{ get throws }` and `{ get async throws }` generate the accessor they declare, with the same effects on `<var>GetHandler`
 
 ## Recorded arguments
 
@@ -129,6 +160,28 @@ protocol UserRepositoryProtocol {
 mock.meStreamSubject.send(UserSummary(uid: "u1", displayName: "Ada"))   // state, replayed
 mock.bootstrapSubject.send(())                                          // event
 ```
+
+**The member hands back a construct the mock owns, not the erased subject**, so it records what the
+code under test did with the stream rather than only that it asked for one:
+
+| counter | what it answers |
+| --- | --- |
+| `<var>GetCount` / `<method>CallCount` | it asked for the stream |
+| `<name>SubscribeCount` | it subscribed |
+| `<name>OutputCount`, `<name>Outputs` | a value reached it — counted on **delivery**, so a value sent while nobody is subscribed counts nothing and one delivered to two subscribers counts twice |
+| `<name>CompletionCount` | the stream finished or failed |
+| `<name>SubscribeCancelCount` | it cancelled |
+
+`<name>OutputHandler` runs after the counter and the recorder and sees each value as it lands, which
+is how a test sends the next one from inside it. `/// sourcery: skipArgumentRecording` on the member
+or the protocol drops `<name>Outputs`, leaving the counters and the handler.
+
+A property's `<var>GetHandler` is read when the code under test **subscribes**, not when it reads the
+member, so a handler seeded after the publisher was captured still decides the stream. A method's
+`<method>Handler` stays at call time, where its arguments are and where its `async` and `throws`
+apply, and a method handler that answers bypasses the subject — `<method>SubscribeCount` then stays
+at zero. A publisher requirement declared `{ get async }` or `{ get throws }` fails generation: the
+closure that reads its handler is synchronous.
 
 The subject is a **`PassthroughSubject`**, for a variable and for a method alike — the same rule the
 RxSwift members follow with `PublishSubject`. The double emits what the test sends it and nothing

--- a/README.md
+++ b/README.md
@@ -709,7 +709,7 @@ Annotation names are matched exactly, including case.
 | `globalActor = "MyIsolation"` | Protocol | Declare the mock's global actor when the attribute name does not end in `Actor` |
 | `uncheckedSendable` | Protocol | Force `@unchecked Sendable` on the mock when the `Sendable` refinement is not visible to Sourcery |
 | `subject = "CurrentValue"` | Variable / method | Choose the subject backing an `AnyPublisher` member — `CurrentValue` or `Passthrough` |
-| `skipArgumentRecording` | Protocol / method | Do not generate `<method>Args`; call counting and the handler are unaffected |
+| `skipArgumentRecording` | Protocol / method / variable | Do not generate `<method>Args`, `<name>Outputs` or `<name>Events`; counting and the handlers are unaffected |
 | `owns` | Protocol | Emit `<X>ComponentBase` (non-final) for a hand-written subclass that holds what the level owns |
 | `componentName = "Foo"` | Protocol | Name the emitted Component `Foo` instead of deriving it from the protocol |
 | `componentAccess = "public"` | Protocol | Emit a `public` Component; the default is internal |

--- a/Tests/Checks/Behaviour/Main.swift
+++ b/Tests/Checks/Behaviour/Main.swift
@@ -42,8 +42,8 @@ func checkCallCountingAndHandlers() {
   mock.requestRecordPermission { captured.append($0) }
   expectEqual(captured, [true], "@escaping completion is captured and invoked")
 
-  mock.recordPermission = .granted
-  expect(mock.recordPermission == .granted, "a read-only requirement is settable on the mock")
+  mock._recordPermission = .granted
+  expect(mock.recordPermission == .granted, "a read-only requirement is seeded through its store")
 
   struct Boom: Error {}
   mock.activateRecordingHandler = { throw Boom() }
@@ -107,7 +107,7 @@ actor Gate {
 @MainActor
 func checkNonisolatedMembers() async {
   let mock = PushNotificationRepositoryProtocolMock(authorizationStatus: .granted)
-  mock.installationId = "install-1"
+  mock._installationId = "install-1"
 
   // The point of the `nonisolated` modifier surviving into the mock: this call
   // is legal from a context that is not the main actor.
@@ -527,7 +527,7 @@ func checkComponentMutationAndEffects() async {
   let parent = CaptureDependencyMock(
     analytics: AnalyticsTrackingMock(),
     memoryRepository: MemoryRepositoryProtocolMock())
-  parent.installationId = "install-7"
+  parent._installationId = "install-7"
 
   let component = CaptureComponent(dependency: parent)
 

--- a/Tests/Checks/Behaviour/Main.swift
+++ b/Tests/Checks/Behaviour/Main.swift
@@ -492,6 +492,42 @@ func checkSendableMock() {
   expect(sendable is AnalyticsTrackingMock, "a Sendable protocol produces a Sendable mock")
 }
 
+// MARK: - Property accessors
+
+/// Every property requirement generates `GetCount`, `GetHandler` and a `_<var>`
+/// store (`specs/004-mock-member-naming/spec.md` §2.5). What that has to get
+/// right is which access moves which counter.
+@MainActor
+func checkPropertyCounting() {
+  let mock = PropertyShapedMock(themeProvider: StubThemeProvider())
+
+  // Construction seeds the store, so it counts no write. This is what keeps
+  // `Mock(themeProvider:)` from arriving with `themeProviderSetCount == 1`.
+  expectEqual(mock.themeProviderGetCount, 0, "construction counts no read")
+
+  _ = mock.identifier
+  _ = mock.identifier
+  expectEqual(mock.identifierGetCount, 2, "a read of a stored requirement counts")
+
+  mock._identifier = "seeded"
+  expectEqual(mock.identifierGetCount, 2, "seeding through the store counts no read")
+  expectEqual(mock.identifier, "seeded", "the accessor returns what the store holds")
+
+  let draftMock = CaptureDependencyMock(analytics: AnalyticsTrackingMock(), memoryRepository: MemoryRepositoryProtocolMock())
+  draftMock.draft = "typed"
+  expectEqual(draftMock.draftSetCount, 1, "a write to a `{ get set }` requirement counts")
+  expectEqual(draftMock.draftGetCount, 0, "a write counts no read")
+  expectEqual(draftMock.draft, "typed", "the value written is the value read")
+  expectEqual(draftMock.draftGetCount, 1, "and that read counts")
+
+  draftMock._draft = "reseeded"
+  expectEqual(draftMock.draftSetCount, 1, "seeding through the store counts no write")
+
+  draftMock.draftGetHandler = { "from the handler" }
+  expectEqual(draftMock.draft, "from the handler", "the handler wins over the store")
+  expectEqual(draftMock._draft, "reseeded", "and leaves the store alone")
+}
+
 // MARK: - Entry point
 
 @main
@@ -499,6 +535,7 @@ enum BehaviourChecks {
   static func main() async {
     print("behaviour checks")
     checkCallCountingAndHandlers()
+    checkPropertyCounting()
     await checkAsync()
     await checkNonisolatedMembers()
     checkCombineStreams()

--- a/Tests/Checks/Behaviour/Main.swift
+++ b/Tests/Checks/Behaviour/Main.swift
@@ -528,6 +528,34 @@ func checkPropertyCounting() {
   expectEqual(draftMock._draft, "reseeded", "and leaves the store alone")
 }
 
+/// An effectful property requirement generates the accessor it declares
+/// (`spec.md` §2.6). A stored property could not satisfy `{ get async throws }`
+/// at all, so this is the first time the mock template witnesses one.
+func checkEffectfulProperties() async {
+  let mock = PropertyEffectfulMock(loader: StubThemeProvider())
+
+  mock._token = "seeded"
+  let token = await mock.token
+  expectEqual(token, "seeded", "an `{ get async }` accessor suspends and returns the store")
+  expectEqual(mock.tokenGetCount, 1, "and counts the read")
+
+  struct Boom: Error {}
+  mock.configGetHandler = { throw Boom() }
+  var threw = false
+  do { _ = try await mock.config } catch { threw = true }
+  expect(threw, "a `{ get async throws }` handler propagates out of the accessor")
+  expectEqual(mock.configGetCount, 1, "the read that threw is still counted")
+
+  mock._secret = "quiet"
+  let secret = try? mock.secret
+  expectEqual(secret, "quiet", "a `{ get throws }` accessor returns the store when no handler throws")
+
+  // The store is assignable even though the requirement is get-only, which is
+  // how a test seeds a type with no synthesizable default.
+  mock._loader = StubThemeProvider()
+  expectEqual(mock.loaderGetCount, 0, "seeding the store of an effectful requirement counts no read")
+}
+
 // MARK: - Entry point
 
 @main
@@ -536,6 +564,7 @@ enum BehaviourChecks {
     print("behaviour checks")
     checkCallCountingAndHandlers()
     checkPropertyCounting()
+    await checkEffectfulProperties()
     await checkAsync()
     await checkNonisolatedMembers()
     checkCombineStreams()

--- a/Tests/Checks/Behaviour/Main.swift
+++ b/Tests/Checks/Behaviour/Main.swift
@@ -196,6 +196,114 @@ func checkCombineStreams() {
   expectEqual(repository.isRefreshingGetCount, 1, "a variable get is counted")
 }
 
+/// What the construct a publisher member hands back records
+/// (`specs/004-mock-member-naming/spec.md` §2.7). The member returns a `Deferred`
+/// the mock owns, so it can tell "asked for the stream" from "subscribed" from
+/// "was actually sent something" — three facts that were one counter before.
+func checkPublisherCounting() {
+  var cancellables: Set<AnyCancellable> = []
+
+  let repository = MemoryRepositoryProtocolMock()
+  _ = repository.ownMemories
+  expectEqual(repository.ownMemoriesGetCount, 1, "reading the member counts a read")
+  expectEqual(repository.ownMemoriesSubscribeCount, 0, "and no subscription")
+
+  let held = repository.ownMemories
+  var seen: [[MemoryDrop]] = []
+  held.sink { seen.append($0) }.store(in: &cancellables)
+  expectEqual(repository.ownMemoriesSubscribeCount, 1, "subscribing counts a subscription")
+
+  // Delivery is counted, not sending: a `PassthroughSubject` drops a value that
+  // reaches no subscriber, and `<name>OutputCount` is how a test sees that.
+  let quiet = MemoryRepositoryProtocolMock()
+  quiet.ownMemoriesSubject.send([MemoryDrop(id: "unheard")])
+  expectEqual(quiet.ownMemoriesOutputCount, 0, "a send with nobody subscribed counts no output")
+
+  repository.ownMemoriesSubject.send([MemoryDrop(id: "a")])
+  expectEqual(repository.ownMemoriesOutputCount, 1, "a delivered value counts one output")
+  expectEqual(repository.ownMemoriesOutputs, [[MemoryDrop(id: "a")]], "and is recorded")
+
+  // A publisher records per subscription, so one send to two subscribers counts
+  // and records twice.
+  repository.ownMemories.sink { _ in }.store(in: &cancellables)
+  expectEqual(repository.ownMemoriesSubscribeCount, 2, "a second subscription counts")
+  repository.ownMemoriesSubject.send([MemoryDrop(id: "b")])
+  expectEqual(repository.ownMemoriesOutputCount, 3, "one send to two subscribers counts twice")
+
+  repository.ownMemoriesSubject.send(completion: .finished)
+  expectEqual(repository.ownMemoriesCompletionCount, 2, "a completion is counted per subscription")
+
+  // Cancellation, counted separately from the subscription that produced it.
+  let cancelling = MemoryRepositoryProtocolMock()
+  var token: AnyCancellable? = cancelling.ownMemories.sink { _ in }
+  expectEqual(cancelling.ownMemoriesSubscribeCancelCount, 0, "an open subscription counts no cancel")
+  token?.cancel()
+  token = nil
+  expectEqual(cancelling.ownMemoriesSubscribeCancelCount, 1, "cancelling counts a cancel")
+
+  // The handler is read when the code under test subscribes, not when it reads
+  // the member — so a handler seeded after the publisher was captured decides
+  // the stream. That is what the `Deferred` buys over erasing the subject.
+  let late = MemoryRepositoryProtocolMock()
+  let captured = late.ownMemories
+  late.ownMemoriesGetHandler = { Just([MemoryDrop(id: "late")]).eraseToAnyPublisher() }
+  var lateSeen: [[MemoryDrop]] = []
+  captured.sink { lateSeen.append($0) }.store(in: &cancellables)
+  expectEqual(lateSeen, [[MemoryDrop(id: "late")]], "a handler seeded after capture decides the stream")
+  expectEqual(late.ownMemoriesOutputCount, 1, "a handler-supplied stream's values are counted too")
+  expectEqual(late.ownMemoriesCompletionCount, 1, "and its completion")
+
+  // `<name>OutputHandler` runs after the counter and the recorder, and sees each
+  // value as it lands — which is how a test drives a chain from inside it.
+  let chained = MemoryRepositoryProtocolMock()
+  var observed: [String] = []
+  chained.shareOutputHandler = { value in
+    observed.append(value)
+    if value == "first" { chained.shareSubject.send("second") }
+  }
+  chained.share(id: "a").sink(receiveCompletion: { _ in }, receiveValue: { _ in }).store(in: &cancellables)
+  chained.shareSubject.send("first")
+  expectEqual(observed, ["first", "second"], "the output handler sees each value and can send the next")
+  expectEqual(chained.shareOutputs, ["first", "second"], "and the recorder holds both")
+
+  // A method keeps its handler at call time, where its arguments are.
+  let handled = MemoryRepositoryProtocolMock()
+  handled.shareHandler = { _ in Just("direct").setFailureType(to: Error.self).eraseToAnyPublisher() }
+  var direct: [String] = []
+  handled.share(id: "a").sink(receiveCompletion: { _ in }, receiveValue: { direct.append($0) })
+    .store(in: &cancellables)
+  expectEqual(direct, ["direct"], "a method handler still answers at call time")
+  expectEqual(handled.shareSubscribeCount, 0, "and bypasses the deferred subject entirely")
+
+  // The stream outlives the mock: the closure captures the subject directly and
+  // the mock weakly, so only the counting stops.
+  let subject: PassthroughSubject<[MemoryDrop], Never>
+  var survivor: AnyPublisher<[MemoryDrop], Never>
+  do {
+    let short = MemoryRepositoryProtocolMock()
+    subject = short.ownMemoriesSubject
+    survivor = short.ownMemories
+  }
+  var afterRelease: [[MemoryDrop]] = []
+  survivor.sink { afterRelease.append($0) }.store(in: &cancellables)
+  subject.send([MemoryDrop(id: "c")])
+  expectEqual(afterRelease, [[MemoryDrop(id: "c")]], "the stream still delivers after the mock is released")
+
+  // `skipArgumentRecording` suppresses the recorder and nothing else.
+  let frames = FrameStreamingMock()
+  frames.frames.sink { _ in }.store(in: &cancellables)
+  frames.rawFrames.sink { _ in }.store(in: &cancellables)
+  let player = FeedAudioPlayer(memoryRepository: MemoryRepositoryProtocolMock(), analytics: AnalyticsTrackingMock())
+  frames.framesSubject.send(player)
+  frames.rawFramesSubject.send(player)
+  expectEqual(frames.framesOutputs.count, 1, "an unannotated member records what it delivered")
+  expectEqual(frames.rawFramesOutputCount, 1, "an opted-out member still counts its outputs")
+  var raw: [FeedAudioPlayer] = []
+  frames.rawFramesOutputHandler = { raw.append($0) }
+  frames.rawFramesSubject.send(player)
+  expectEqual(raw.count, 1, "and still runs its output handler")
+}
+
 @MainActor
 func checkComposition() {
   // A Dependency mock takes its whole surface through the initializer, which is
@@ -568,6 +676,7 @@ enum BehaviourChecks {
     await checkAsync()
     await checkNonisolatedMembers()
     checkCombineStreams()
+    checkPublisherCounting()
     checkComposition()
     checkSendableClosureParameters()
     checkSendableMock()

--- a/Tests/Checks/Fixtures/Naming.swift
+++ b/Tests/Checks/Fixtures/Naming.swift
@@ -89,3 +89,18 @@ public protocol NamingReturnTypeBase: AnyObject {
 public protocol NamingReturnTypes: NamingReturnTypeBase {
   func data() -> [String: Any]
 }
+
+/// Two overloads with the same parameter count, one of them unlabelled. The
+/// tie-break inside an overload group — `areInAscendingOrder` in
+/// `MockMethod.swift` — prefers the one the caller writes with no label, so
+/// `send(_:)` keeps the plain prefix and `send(to:)` takes the long form.
+///
+/// It is here because `kotlin-ksp-mocks` breaks the same tie by the joined
+/// rendered parameter types (its §11.2 item 5), and neither repository had a
+/// declaration that shows which name its generator picks (`spec.md` §12.5, D21).
+///
+/// sourcery: ProtocolMock
+public protocol NamingUnlabelledOverload: AnyObject {
+  func send(_ value: String)
+  func send(to target: String)
+}

--- a/Tests/Checks/Fixtures/Naming.swift
+++ b/Tests/Checks/Fixtures/Naming.swift
@@ -1,0 +1,51 @@
+// The naming rule itself: what prefix a declared name produces.
+//
+// `specs/004-mock-member-naming/spec.md` §2.1 states it — the declared name with
+// backticks removed, and nothing else. Before that rule, methods went through a
+// transform properties did not: `perform1_0` became `perform10`, `load_data` and
+// `loadData` became the same name, and an all-uppercase name crashed generation.
+// Each protocol below is one of those cases, and the snapshot is where the
+// answer is visible.
+
+import Foundation
+
+/// An underscore in a method name beside an underscore in a property name. Under
+/// the old transform the first became `perform10` and the second stayed
+/// `setting4_2`, which is the two-transforms-in-one-class case (§1.1).
+///
+/// sourcery: ProtocolMock
+public protocol NamingUnderscores: AnyObject {
+  var setting4_2: Int { get set }
+  func perform1_0()
+  func perform2_0(value: Int)
+}
+
+/// Two names the old transform mapped onto one. `load_data` and `loadData` both
+/// produced `loadData`, and generation failed with "not all duplicates
+/// resolved"; they are distinct declarations and now carry distinct members.
+///
+/// sourcery: ProtocolMock
+public protocol NamingManyToOne: AnyObject {
+  func load_data()
+  func loadData()
+}
+
+/// An all-uppercase name. `lowerFirstWord` indexed past the end of the string on
+/// this input and crashed the run (§1.2); the prefix is now the name.
+///
+/// sourcery: ProtocolMock
+public protocol NamingUppercase: AnyObject {
+  func ID() -> String
+  func URLSession() -> String
+}
+
+/// Keyword-named requirements. The backticks escape the keyword where the member
+/// is declared and are not part of the name, so the witness keeps them and the
+/// bookkeeping members drop them.
+///
+/// sourcery: ProtocolMock
+public protocol NamingKeywords: AnyObject {
+  var `default`: Int { get set }
+  func `do`()
+  func `repeat`(times: Int)
+}

--- a/Tests/Checks/Fixtures/Naming.swift
+++ b/Tests/Checks/Fixtures/Naming.swift
@@ -65,3 +65,27 @@ public protocol NamingOverloads: AnyObject {
   func reference(withPath path: String)
   func reference(forURL url: String)
 }
+
+/// A requirement whose members are named outright. `methodName` replaces the
+/// derived prefix, so nothing in the declaration spells `reloadNow` — the third
+/// of the three causes §10.1 counts, and the one no rule can derive.
+///
+/// sourcery: ProtocolMock
+public protocol NamingAnnotated: AnyObject {
+  /// sourcery: methodName = "reloadNow"
+  func refresh()
+  func reset()
+}
+
+/// Two overloads a refining protocol leaves sharing their name, their parameter
+/// list and their labels, so only the return type separates them (§2.2 step 3).
+/// Neither prefix appears in either declaration, and the declaration a reader
+/// has in front of them does not show that the other one exists.
+public protocol NamingReturnTypeBase: AnyObject {
+  func data() -> [String: Any]?
+}
+
+/// sourcery: ProtocolMock
+public protocol NamingReturnTypes: NamingReturnTypeBase {
+  func data() -> [String: Any]
+}

--- a/Tests/Checks/Fixtures/Naming.swift
+++ b/Tests/Checks/Fixtures/Naming.swift
@@ -49,3 +49,19 @@ public protocol NamingKeywords: AnyObject {
   func `do`()
   func `repeat`(times: Int)
 }
+
+/// An overload group whose argument labels differ from their parameter names.
+/// The long form takes the label — what the caller writes — and not the label
+/// followed by the name (§2.2 step 2): `endAtDocumentDocument` was the old
+/// spelling of the first of these. `end()` has the fewest parameters and keeps
+/// the plain prefix, which is what stops an added overload renaming a member an
+/// existing test already uses (D3).
+///
+/// sourcery: ProtocolMock
+public protocol NamingOverloads: AnyObject {
+  func end()
+  func end(atDocument document: String)
+  func end(at fieldValues: [String])
+  func reference(withPath path: String)
+  func reference(forURL url: String)
+}

--- a/Tests/Checks/Fixtures/Properties.swift
+++ b/Tests/Checks/Fixtures/Properties.swift
@@ -39,3 +39,25 @@ public protocol PropertyShaped: AnyObject {
   /// sourcery: handler
   var cursor: Int { get set }
 }
+
+/// Effectful property requirements. `var x: T { get async throws }` is parsed —
+/// `SourceryRuntime.Variable.isAsync` and `Variable.throws` — and the mock
+/// template ignored it until §2.6, emitting a plain stored property that did not
+/// satisfy the requirement. The only effectful requirement anywhere under
+/// `Tests/` before this file is `Forwarding.swift`'s, which is `DuetComponent`
+/// alone, so the mock template had never seen one.
+///
+/// Swift has no effectful setter, so each of these is get-only and none carries a
+/// `<var>SetCount`. A test seeds `_<var>`.
+///
+/// sourcery: ProtocolMock
+public protocol PropertyEffectful: AnyObject {
+  var config: String { get async throws }
+  var token: String { get async }
+  var secret: String { get throws }
+  var plain: String { get }
+
+  /// No synthesizable default, so the initializer seeds the store and the
+  /// accessor still suspends.
+  var loader: ThemeProviding { get async }
+}

--- a/Tests/Checks/Fixtures/Properties.swift
+++ b/Tests/Checks/Fixtures/Properties.swift
@@ -1,0 +1,41 @@
+// What a property requirement generates, shape by shape.
+//
+// Every branch of `MockVar.mockImpl` is declared here once: a read-only
+// requirement whose type has a synthesizable default, a mutable one, one with no
+// default that the initializer seeds, `/// sourcery: const`, and
+// `/// sourcery: handler` in both its read-only and its mutable form.
+//
+// The `handler` pair is what puts the property trap string in the snapshot.
+// Before `specs/004-mock-member-naming/spec.md` §2.4 nothing under Tests/ carried
+// that annotation, so the wording that diverged from the method's was visible in
+// no generated file this repository holds.
+
+import Foundation
+
+/// sourcery: ProtocolMock
+public protocol PropertyShaped: AnyObject {
+  /// Read-only, synthesizable default: a `var` a test re-seeds.
+  var identifier: String { get }
+
+  /// Mutable, synthesizable default.
+  var draft: String { get set }
+
+  /// No synthesizable default: an initializer parameter.
+  var themeProvider: ThemeProviding { get }
+
+  /// The value is fixed at construction.
+  ///
+  /// sourcery: const
+  var buildNumber: Int { get }
+
+  /// Read-only, supplied by the test rather than stored. A read with no handler
+  /// set traps.
+  ///
+  /// sourcery: handler
+  var snapshot: [String: Int] { get }
+
+  /// The same, mutable: the getter traps and the setter counts.
+  ///
+  /// sourcery: handler
+  var cursor: Int { get set }
+}

--- a/Tests/Checks/Fixtures/Streams.swift
+++ b/Tests/Checks/Fixtures/Streams.swift
@@ -51,3 +51,36 @@ public protocol NotificationSignalling: AnyObject {
   /// sourcery: subject = "CurrentValue"
   var badgeCount: AnyPublisher<Int, Never> { get }
 }
+
+// MARK: - What a stream member records
+
+/// `<name>Outputs` on a publisher member and `<name>Events` on an `AnyObserver`
+/// one record what crossed the member, the way `<method>Args` records what a
+/// call carried (`specs/004-mock-member-naming/spec.md` D13). They sit under the
+/// same opt-out and for the same reason: a recorded value lives as long as the
+/// mock, and when the value is an object a churn or leak spec measures the
+/// deallocation of, that retain reads as a leak in the code under test.
+///
+/// `frames` records; `rawFrames` is annotated and does not. Both still count
+/// their outputs and run `<name>OutputHandler`.
+///
+/// sourcery: CreateMock
+public protocol FrameStreaming: AnyObject {
+  var frames: AnyPublisher<FeedAudioPlayer, Never> { get }
+
+  /// sourcery: skipArgumentRecording
+  var rawFrames: AnyPublisher<FeedAudioPlayer, Never> { get }
+
+  /// The same on a method.
+  /// sourcery: skipArgumentRecording
+  func replay(tag: String) -> AnyPublisher<FeedAudioPlayer, Never>
+}
+
+/// The opt-out on the type reaches every stream member of it, as it reaches
+/// every method's arguments.
+///
+/// sourcery: CreateMock, skipArgumentRecording
+public protocol FrameRetaining: AnyObject {
+  var frames: AnyPublisher<FeedAudioPlayer, Never> { get }
+  func replay(tag: String) -> AnyPublisher<FeedAudioPlayer, Never>
+}

--- a/Tests/Checks/PluginFixture/Tests/AppTests/AppTests.swift
+++ b/Tests/Checks/PluginFixture/Tests/AppTests/AppTests.swift
@@ -7,7 +7,7 @@ import XCTest
 final class AppTests: XCTestCase {
   func testMockCarriesEveryInheritedRequirement() throws {
     let mock = ProfilePersistingMock()
-    mock.profileID = "id"
+    mock._profileID = "id"
     try mock.save("value", key: "key")
     mock.report("message")
     XCTAssertEqual(mock.saveCallCount, 1)

--- a/Tests/Checks/README.md
+++ b/Tests/Checks/README.md
@@ -101,6 +101,7 @@ carry a naming comment, so they are what the naming-comment gate reads.
 | an overload group — argument labels appended, fewest parameters keeps the plain name | `NamingOverloads` |
 | `methodName` — a prefix that appears in no declaration | `NamingAnnotated` |
 | overloads the labels do not separate, so the return type does | `NamingReturnTypes` |
+| an overload group's tie-break — same parameter count, one of them unlabelled | `NamingUnlabelledOverload` |
 
 [`Properties.swift`](Fixtures/Properties.swift) declares every branch of
 `MockVar.mockImpl` once.

--- a/Tests/Checks/README.md
+++ b/Tests/Checks/README.md
@@ -8,7 +8,7 @@ generated Xcode project. The fast lane comes first.
 ## The fast lane
 
 `./run-checks.sh` runs every template in its `TEMPLATES` list over
-[`Fixtures/`](Fixtures) and holds the results to five gates. It needs no
+[`Fixtures/`](Fixtures) and holds the results to seven gates. It needs no
 simulator and no third-party package, so it runs in a few seconds and is the loop
 to use while editing `templates/`.
 
@@ -23,6 +23,8 @@ SOURCERY=/path/to/sourcery Tests/Checks/run-checks.sh
 | **snapshot** | each generated file matches its recording in [`Snapshots/`](Snapshots), so every template change shows up as a reviewable diff of real output |
 | **zero-match** | a scan with no matching annotation still writes the file — the generators emit a marker comment, because the engine skips whitespace-only renders and consumers commit + fingerprint the output — snapshotted as `ZeroMatch-*` |
 | **near-miss** | a selector whose spelling differs from the registry's only in case fails the run, naming the type, the spelling found and the canonical form; an option that does writes one `// sourcery-templates:` comment into the generated file and generation continues |
+| **refusal** | a construct the templates cannot emit fails generation naming the protocol and the member, instead of writing a file the consumer's compiler rejects: two members that would carry one name, a requirement declaring `throws(E)`, an `AnyPublisher` requirement declared `async` or `throws` |
+| **naming-comments** | every `` `X` members are named `Y*` `` comment in the generated file describes the member under it, and each class's index is exactly the set of members commented inside that class — with a red control for a comment naming the wrong prefix and one for an index missing a member |
 | **typecheck** | all of them compile **together** with **zero diagnostics** under `-swift-version 5 -strict-concurrency=complete` **and** under `-swift-version 6` |
 | **behaviour** | the mocks count calls, record arguments, run handlers, suspend where the protocol suspends and deliver values pushed into their subjects; the Components forward to the parent and hold what the level owns — [`Behaviour/Main.swift`](Behaviour/Main.swift), plain assertions in one executable |
 
@@ -84,6 +86,34 @@ The generic case is not here: a generic method records nothing, and the
 annotated-generic protocols that would prove it live in the example project (a
 mocked generic method needs `annotatedGenericTypes` to produce a usable double
 at all). The example lane is what covers it.
+
+[`Naming.swift`](Fixtures/Naming.swift) is the naming rule itself: which prefix a
+declared name produces, and which declarations produce a prefix that is not the
+declared name. The last three rows are the only members in the snapshot that
+carry a naming comment, so they are what the naming-comment gate reads.
+
+| construct | fixture |
+| --- | --- |
+| underscore in a method name beside one in a property name | `NamingUnderscores` |
+| two declarations the old transform mapped onto one name | `NamingManyToOne` |
+| an all-uppercase name | `NamingUppercase` |
+| keyword-named requirements, backticked at the witness | `NamingKeywords` |
+| an overload group — argument labels appended, fewest parameters keeps the plain name | `NamingOverloads` |
+| `methodName` — a prefix that appears in no declaration | `NamingAnnotated` |
+| overloads the labels do not separate, so the return type does | `NamingReturnTypes` |
+
+[`Properties.swift`](Fixtures/Properties.swift) declares every branch of
+`MockVar.mockImpl` once.
+
+| construct | fixture |
+| --- | --- |
+| read-only with a synthesizable default | `PropertyShaped.identifier` |
+| mutable with a synthesizable default | `PropertyShaped.draft` |
+| no synthesizable default — an initializer parameter | `PropertyShaped.themeProvider` |
+| `const` | `PropertyShaped.buildNumber` |
+| `handler`, read-only and mutable — the property trap string | `PropertyShaped.snapshot` / `.cursor` |
+| `{ get async throws }`, `{ get async }`, `{ get throws }` | `PropertyEffectful` |
+| an effectful requirement whose type has no default | `PropertyEffectful.loader` |
 
 [`Forwarding.swift`](Fixtures/Forwarding.swift) adds the shapes the Component
 template has to forward. Two of its protocols carry `DuetComponent` alone, each

--- a/Tests/Checks/Snapshots/Mocks.generated.swift
+++ b/Tests/Checks/Snapshots/Mocks.generated.swift
@@ -446,6 +446,116 @@ final class MemoryRepositoryProtocolMock: MemoryRepositoryProtocol {
     lazy var tokenSubject = CurrentValueSubject<String, Error>("")
 }
 
+// MARK: - NamingKeywords
+final class NamingKeywordsMock: NamingKeywords {
+
+    // MARK: - Variables
+    var `default`: Int = 0 {
+        didSet {
+            defaultSetCount += 1
+        }
+    }
+    var defaultSetCount: Int = 0
+
+    // MARK: - Methods
+    func `do`() {
+        doCallCount += 1
+        if let __doHandler = self.doHandler {
+            __doHandler()
+        }
+    }
+    var doCallCount: Int = 0
+    var doHandler: (() -> ())? = nil
+    func `repeat`(times: Int) {
+        repeatCallCount += 1
+        repeatArgs.append(times)
+        if let __repeatHandler = self.repeatHandler {
+            __repeatHandler(times)
+        }
+    }
+    var repeatCallCount: Int = 0
+    var repeatArgs: [Int] = []
+    var repeatHandler: ((_ times: Int) -> ())? = nil
+}
+
+// MARK: - NamingManyToOne
+final class NamingManyToOneMock: NamingManyToOne {
+
+    // MARK: - Methods
+    func loadData() {
+        loadDataCallCount += 1
+        if let __loadDataHandler = self.loadDataHandler {
+            __loadDataHandler()
+        }
+    }
+    var loadDataCallCount: Int = 0
+    var loadDataHandler: (() -> ())? = nil
+    func load_data() {
+        load_dataCallCount += 1
+        if let __load_dataHandler = self.load_dataHandler {
+            __load_dataHandler()
+        }
+    }
+    var load_dataCallCount: Int = 0
+    var load_dataHandler: (() -> ())? = nil
+}
+
+// MARK: - NamingUnderscores
+final class NamingUnderscoresMock: NamingUnderscores {
+
+    // MARK: - Variables
+    var setting4_2: Int = 0 {
+        didSet {
+            setting4_2SetCount += 1
+        }
+    }
+    var setting4_2SetCount: Int = 0
+
+    // MARK: - Methods
+    func perform1_0() {
+        perform1_0CallCount += 1
+        if let __perform1_0Handler = self.perform1_0Handler {
+            __perform1_0Handler()
+        }
+    }
+    var perform1_0CallCount: Int = 0
+    var perform1_0Handler: (() -> ())? = nil
+    func perform2_0(value: Int) {
+        perform2_0CallCount += 1
+        perform2_0Args.append(value)
+        if let __perform2_0Handler = self.perform2_0Handler {
+            __perform2_0Handler(value)
+        }
+    }
+    var perform2_0CallCount: Int = 0
+    var perform2_0Args: [Int] = []
+    var perform2_0Handler: ((_ value: Int) -> ())? = nil
+}
+
+// MARK: - NamingUppercase
+final class NamingUppercaseMock: NamingUppercase {
+
+    // MARK: - Methods
+    func ID() -> String {
+        IDCallCount += 1
+        if let __IDHandler = self.IDHandler {
+            return __IDHandler()
+        }
+        return ""
+    }
+    var IDCallCount: Int = 0
+    var IDHandler: (() -> (String))? = nil
+    func URLSession() -> String {
+        URLSessionCallCount += 1
+        if let __URLSessionHandler = self.URLSessionHandler {
+            return __URLSessionHandler()
+        }
+        return ""
+    }
+    var URLSessionCallCount: Int = 0
+    var URLSessionHandler: (() -> (String))? = nil
+}
+
 // MARK: - NotificationSignalling
 final class NotificationSignallingMock: NotificationSignalling {
 

--- a/Tests/Checks/Snapshots/Mocks.generated.swift
+++ b/Tests/Checks/Snapshots/Mocks.generated.swift
@@ -500,6 +500,60 @@ final class NamingManyToOneMock: NamingManyToOne {
     var load_dataHandler: (() -> ())? = nil
 }
 
+// MARK: - NamingOverloads
+final class NamingOverloadsMock: NamingOverloads {
+
+    // MARK: - Methods
+    func end() {
+        endCallCount += 1
+        if let __endHandler = self.endHandler {
+            __endHandler()
+        }
+    }
+    var endCallCount: Int = 0
+    var endHandler: (() -> ())? = nil
+    func end(at fieldValues: [String]) {
+        endAtCallCount += 1
+        endAtArgs.append(fieldValues)
+        if let __endAtHandler = self.endAtHandler {
+            __endAtHandler(fieldValues)
+        }
+    }
+    var endAtCallCount: Int = 0
+    var endAtArgs: [[String]] = []
+    var endAtHandler: ((_ fieldValues: [String]) -> ())? = nil
+    func end(atDocument document: String) {
+        endAtDocumentCallCount += 1
+        endAtDocumentArgs.append(document)
+        if let __endAtDocumentHandler = self.endAtDocumentHandler {
+            __endAtDocumentHandler(document)
+        }
+    }
+    var endAtDocumentCallCount: Int = 0
+    var endAtDocumentArgs: [String] = []
+    var endAtDocumentHandler: ((_ document: String) -> ())? = nil
+    func reference(forURL url: String) {
+        referenceForURLCallCount += 1
+        referenceForURLArgs.append(url)
+        if let __referenceForURLHandler = self.referenceForURLHandler {
+            __referenceForURLHandler(url)
+        }
+    }
+    var referenceForURLCallCount: Int = 0
+    var referenceForURLArgs: [String] = []
+    var referenceForURLHandler: ((_ url: String) -> ())? = nil
+    func reference(withPath path: String) {
+        referenceWithPathCallCount += 1
+        referenceWithPathArgs.append(path)
+        if let __referenceWithPathHandler = self.referenceWithPathHandler {
+            __referenceWithPathHandler(path)
+        }
+    }
+    var referenceWithPathCallCount: Int = 0
+    var referenceWithPathArgs: [String] = []
+    var referenceWithPathHandler: ((_ path: String) -> ())? = nil
+}
+
 // MARK: - NamingUnderscores
 final class NamingUnderscoresMock: NamingUnderscores {
 

--- a/Tests/Checks/Snapshots/Mocks.generated.swift
+++ b/Tests/Checks/Snapshots/Mocks.generated.swift
@@ -682,6 +682,50 @@ final class PlaybackRetainingMock: PlaybackRetaining {
     var retainHandler: ((_ player: FeedAudioPlayer) -> ())? = nil
 }
 
+// MARK: - PropertyShaped
+final class PropertyShapedMock: PropertyShaped {
+
+    // MARK: - Variables
+    let buildNumber: Int = 0
+    var cursor: Int {
+        get {
+            cursorGetCount += 1
+            if let handler = cursorGetHandler {
+                return handler()
+            }
+            fatalError("cursorGetHandler expected to be set.")
+        }
+        set {
+            cursorSetCount += 1
+        }
+    }
+    var cursorGetCount: Int = 0
+    var cursorGetHandler: (() -> Int)? = nil
+    var cursorSetCount: Int = 0
+    var draft: String = "" {
+        didSet {
+            draftSetCount += 1
+        }
+    }
+    var draftSetCount: Int = 0
+    var identifier: String = ""
+    var snapshot: [String: Int] {
+        snapshotGetCount += 1
+        if let handler = snapshotGetHandler {
+            return handler()
+        }
+        fatalError("snapshotGetHandler expected to be set.")
+    }
+    var snapshotGetCount: Int = 0
+    var snapshotGetHandler: (() -> [String: Int])? = nil
+    var themeProvider: ThemeProviding
+
+    // MARK: - Initializer
+    init(themeProvider: ThemeProviding) {
+        self.themeProvider = themeProvider
+    }
+}
+
 // MARK: - PushNotificationRepositoryProtocol
 @MainActor
 final class PushNotificationRepositoryProtocolMock: PushNotificationRepositoryProtocol {

--- a/Tests/Checks/Snapshots/Mocks.generated.swift
+++ b/Tests/Checks/Snapshots/Mocks.generated.swift
@@ -385,6 +385,139 @@ final class DiagnosticsReportingMock: DiagnosticsReporting {
     nonisolated(unsafe) var reportHandler: ((_ code: String, _ detail: String?) -> ())? = nil
 }
 
+// MARK: - FrameRetaining
+final class FrameRetainingMock: FrameRetaining {
+
+    // MARK: - Variables
+    var frames: AnyPublisher<FeedAudioPlayer, Never> {
+        framesGetCount += 1
+        return Deferred { [weak self, subject = framesSubject] () -> AnyPublisher<FeedAudioPlayer, Never> in
+            self?.framesSubscribeCount += 1
+            if let handler = self?.framesGetHandler {
+                return handler()
+            }
+            return subject.eraseToAnyPublisher()
+        }
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.framesOutputCount += 1
+            self?.framesOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.framesCompletionCount += 1 }, receiveCancel: { [weak self] in self?.framesSubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
+    }
+    var framesGetCount: Int = 0
+    var framesGetHandler: (() -> AnyPublisher<FeedAudioPlayer, Never>)? = nil
+    var framesSubscribeCount: Int = 0
+    var framesSubscribeCancelCount: Int = 0
+    var framesOutputCount: Int = 0
+    var framesOutputHandler: ((FeedAudioPlayer) -> Void)? = nil
+    var framesCompletionCount: Int = 0
+    lazy var framesSubject = PassthroughSubject<FeedAudioPlayer, Never>()
+
+    // MARK: - Methods
+    func replay(tag: String) -> AnyPublisher<FeedAudioPlayer, Never> {
+        replayCallCount += 1
+        if let __replayHandler = self.replayHandler {
+            return __replayHandler(tag)
+        }
+        return Deferred { [weak self, subject = replaySubject] () -> AnyPublisher<FeedAudioPlayer, Never> in
+            self?.replaySubscribeCount += 1
+            return subject.eraseToAnyPublisher()
+        }
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.replayOutputCount += 1
+            self?.replayOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.replayCompletionCount += 1 }, receiveCancel: { [weak self] in self?.replaySubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
+    }
+    var replayCallCount: Int = 0
+    var replayHandler: ((_ tag: String) -> (AnyPublisher<FeedAudioPlayer, Never>))? = nil
+    var replaySubscribeCount: Int = 0
+    var replaySubscribeCancelCount: Int = 0
+    var replayOutputCount: Int = 0
+    var replayOutputHandler: ((FeedAudioPlayer) -> Void)? = nil
+    var replayCompletionCount: Int = 0
+    lazy var replaySubject = PassthroughSubject<FeedAudioPlayer, Never>()
+}
+
+// MARK: - FrameStreaming
+final class FrameStreamingMock: FrameStreaming {
+
+    // MARK: - Variables
+    var frames: AnyPublisher<FeedAudioPlayer, Never> {
+        framesGetCount += 1
+        return Deferred { [weak self, subject = framesSubject] () -> AnyPublisher<FeedAudioPlayer, Never> in
+            self?.framesSubscribeCount += 1
+            if let handler = self?.framesGetHandler {
+                return handler()
+            }
+            return subject.eraseToAnyPublisher()
+        }
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.framesOutputCount += 1
+            self?.framesOutputs.append(value)
+            self?.framesOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.framesCompletionCount += 1 }, receiveCancel: { [weak self] in self?.framesSubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
+    }
+    var framesGetCount: Int = 0
+    var framesGetHandler: (() -> AnyPublisher<FeedAudioPlayer, Never>)? = nil
+    var framesSubscribeCount: Int = 0
+    var framesSubscribeCancelCount: Int = 0
+    var framesOutputCount: Int = 0
+    var framesOutputs: [FeedAudioPlayer] = []
+    var framesOutputHandler: ((FeedAudioPlayer) -> Void)? = nil
+    var framesCompletionCount: Int = 0
+    lazy var framesSubject = PassthroughSubject<FeedAudioPlayer, Never>()
+    var rawFrames: AnyPublisher<FeedAudioPlayer, Never> {
+        rawFramesGetCount += 1
+        return Deferred { [weak self, subject = rawFramesSubject] () -> AnyPublisher<FeedAudioPlayer, Never> in
+            self?.rawFramesSubscribeCount += 1
+            if let handler = self?.rawFramesGetHandler {
+                return handler()
+            }
+            return subject.eraseToAnyPublisher()
+        }
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.rawFramesOutputCount += 1
+            self?.rawFramesOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.rawFramesCompletionCount += 1 }, receiveCancel: { [weak self] in self?.rawFramesSubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
+    }
+    var rawFramesGetCount: Int = 0
+    var rawFramesGetHandler: (() -> AnyPublisher<FeedAudioPlayer, Never>)? = nil
+    var rawFramesSubscribeCount: Int = 0
+    var rawFramesSubscribeCancelCount: Int = 0
+    var rawFramesOutputCount: Int = 0
+    var rawFramesOutputHandler: ((FeedAudioPlayer) -> Void)? = nil
+    var rawFramesCompletionCount: Int = 0
+    lazy var rawFramesSubject = PassthroughSubject<FeedAudioPlayer, Never>()
+
+    // MARK: - Methods
+    func replay(tag: String) -> AnyPublisher<FeedAudioPlayer, Never> {
+        replayCallCount += 1
+        if let __replayHandler = self.replayHandler {
+            return __replayHandler(tag)
+        }
+        return Deferred { [weak self, subject = replaySubject] () -> AnyPublisher<FeedAudioPlayer, Never> in
+            self?.replaySubscribeCount += 1
+            return subject.eraseToAnyPublisher()
+        }
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.replayOutputCount += 1
+            self?.replayOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.replayCompletionCount += 1 }, receiveCancel: { [weak self] in self?.replaySubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
+    }
+    var replayCallCount: Int = 0
+    var replayHandler: ((_ tag: String) -> (AnyPublisher<FeedAudioPlayer, Never>))? = nil
+    var replaySubscribeCount: Int = 0
+    var replaySubscribeCancelCount: Int = 0
+    var replayOutputCount: Int = 0
+    var replayOutputHandler: ((FeedAudioPlayer) -> Void)? = nil
+    var replayCompletionCount: Int = 0
+    lazy var replaySubject = PassthroughSubject<FeedAudioPlayer, Never>()
+}
+
 // MARK: - MainDependency
 final class MainDependencyMock: MainDependency {
 
@@ -527,13 +660,28 @@ final class MemoryEventStreamingMock: MemoryEventStreaming {
     // MARK: - Variables
     var latestDrop: AnyPublisher<MemoryDrop, Never> {
         latestDropGetCount += 1
-        if let handler = latestDropGetHandler {
-            return handler()
+        return Deferred { [weak self, subject = latestDropSubject] () -> AnyPublisher<MemoryDrop, Never> in
+            self?.latestDropSubscribeCount += 1
+            if let handler = self?.latestDropGetHandler {
+                return handler()
+            }
+            return subject.eraseToAnyPublisher()
         }
-        return latestDropSubject.eraseToAnyPublisher()
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.latestDropOutputCount += 1
+            self?.latestDropOutputs.append(value)
+            self?.latestDropOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.latestDropCompletionCount += 1 }, receiveCancel: { [weak self] in self?.latestDropSubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
     }
     var latestDropGetCount: Int = 0
     var latestDropGetHandler: (() -> AnyPublisher<MemoryDrop, Never>)? = nil
+    var latestDropSubscribeCount: Int = 0
+    var latestDropSubscribeCancelCount: Int = 0
+    var latestDropOutputCount: Int = 0
+    var latestDropOutputs: [MemoryDrop] = []
+    var latestDropOutputHandler: ((MemoryDrop) -> Void)? = nil
+    var latestDropCompletionCount: Int = 0
     lazy var latestDropSubject = PassthroughSubject<MemoryDrop, Never>()
 }
 
@@ -543,23 +691,53 @@ final class MemoryRepositoryProtocolMock: MemoryRepositoryProtocol {
     // MARK: - Variables
     var isRefreshing: AnyPublisher<Bool, Never> {
         isRefreshingGetCount += 1
-        if let handler = isRefreshingGetHandler {
-            return handler()
+        return Deferred { [weak self, subject = isRefreshingSubject] () -> AnyPublisher<Bool, Never> in
+            self?.isRefreshingSubscribeCount += 1
+            if let handler = self?.isRefreshingGetHandler {
+                return handler()
+            }
+            return subject.eraseToAnyPublisher()
         }
-        return isRefreshingSubject.eraseToAnyPublisher()
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.isRefreshingOutputCount += 1
+            self?.isRefreshingOutputs.append(value)
+            self?.isRefreshingOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.isRefreshingCompletionCount += 1 }, receiveCancel: { [weak self] in self?.isRefreshingSubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
     }
     var isRefreshingGetCount: Int = 0
     var isRefreshingGetHandler: (() -> AnyPublisher<Bool, Never>)? = nil
+    var isRefreshingSubscribeCount: Int = 0
+    var isRefreshingSubscribeCancelCount: Int = 0
+    var isRefreshingOutputCount: Int = 0
+    var isRefreshingOutputs: [Bool] = []
+    var isRefreshingOutputHandler: ((Bool) -> Void)? = nil
+    var isRefreshingCompletionCount: Int = 0
     lazy var isRefreshingSubject = PassthroughSubject<Bool, Never>()
     var ownMemories: AnyPublisher<[MemoryDrop], Never> {
         ownMemoriesGetCount += 1
-        if let handler = ownMemoriesGetHandler {
-            return handler()
+        return Deferred { [weak self, subject = ownMemoriesSubject] () -> AnyPublisher<[MemoryDrop], Never> in
+            self?.ownMemoriesSubscribeCount += 1
+            if let handler = self?.ownMemoriesGetHandler {
+                return handler()
+            }
+            return subject.eraseToAnyPublisher()
         }
-        return ownMemoriesSubject.eraseToAnyPublisher()
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.ownMemoriesOutputCount += 1
+            self?.ownMemoriesOutputs.append(value)
+            self?.ownMemoriesOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.ownMemoriesCompletionCount += 1 }, receiveCancel: { [weak self] in self?.ownMemoriesSubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
     }
     var ownMemoriesGetCount: Int = 0
     var ownMemoriesGetHandler: (() -> AnyPublisher<[MemoryDrop], Never>)? = nil
+    var ownMemoriesSubscribeCount: Int = 0
+    var ownMemoriesSubscribeCancelCount: Int = 0
+    var ownMemoriesOutputCount: Int = 0
+    var ownMemoriesOutputs: [[MemoryDrop]] = []
+    var ownMemoriesOutputHandler: (([MemoryDrop]) -> Void)? = nil
+    var ownMemoriesCompletionCount: Int = 0
     lazy var ownMemoriesSubject = PassthroughSubject<[MemoryDrop], Never>()
 
     // MARK: - Methods
@@ -569,11 +747,26 @@ final class MemoryRepositoryProtocolMock: MemoryRepositoryProtocol {
         if let __deleteHandler = self.deleteHandler {
             return __deleteHandler(id)
         }
-        return deleteSubject.eraseToAnyPublisher()
+        return Deferred { [weak self, subject = deleteSubject] () -> AnyPublisher<(), Error> in
+            self?.deleteSubscribeCount += 1
+            return subject.eraseToAnyPublisher()
+        }
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.deleteOutputCount += 1
+            self?.deleteOutputs.append(value)
+            self?.deleteOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.deleteCompletionCount += 1 }, receiveCancel: { [weak self] in self?.deleteSubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
     }
     var deleteCallCount: Int = 0
     var deleteArgs: [String] = []
     var deleteHandler: ((_ id: String) -> (AnyPublisher<Void, Error>))? = nil
+    var deleteSubscribeCount: Int = 0
+    var deleteSubscribeCancelCount: Int = 0
+    var deleteOutputCount: Int = 0
+    var deleteOutputs: [()] = []
+    var deleteOutputHandler: ((()) -> Void)? = nil
+    var deleteCompletionCount: Int = 0
     lazy var deleteSubject = PassthroughSubject<(), Error>()
     func fetch(id: String) -> AnyPublisher<MemoryDrop?, Error> {
         fetchCallCount += 1
@@ -581,11 +774,26 @@ final class MemoryRepositoryProtocolMock: MemoryRepositoryProtocol {
         if let __fetchHandler = self.fetchHandler {
             return __fetchHandler(id)
         }
-        return fetchSubject.eraseToAnyPublisher()
+        return Deferred { [weak self, subject = fetchSubject] () -> AnyPublisher<MemoryDrop?, Error> in
+            self?.fetchSubscribeCount += 1
+            return subject.eraseToAnyPublisher()
+        }
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.fetchOutputCount += 1
+            self?.fetchOutputs.append(value)
+            self?.fetchOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.fetchCompletionCount += 1 }, receiveCancel: { [weak self] in self?.fetchSubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
     }
     var fetchCallCount: Int = 0
     var fetchArgs: [String] = []
     var fetchHandler: ((_ id: String) -> (AnyPublisher<MemoryDrop?, Error>))? = nil
+    var fetchSubscribeCount: Int = 0
+    var fetchSubscribeCancelCount: Int = 0
+    var fetchOutputCount: Int = 0
+    var fetchOutputs: [MemoryDrop?] = []
+    var fetchOutputHandler: ((MemoryDrop?) -> Void)? = nil
+    var fetchCompletionCount: Int = 0
     lazy var fetchSubject = PassthroughSubject<MemoryDrop?, Error>()
     func share(id: String) -> AnyPublisher<String, Error> {
         shareCallCount += 1
@@ -593,21 +801,51 @@ final class MemoryRepositoryProtocolMock: MemoryRepositoryProtocol {
         if let __shareHandler = self.shareHandler {
             return __shareHandler(id)
         }
-        return shareSubject.eraseToAnyPublisher()
+        return Deferred { [weak self, subject = shareSubject] () -> AnyPublisher<String, Error> in
+            self?.shareSubscribeCount += 1
+            return subject.eraseToAnyPublisher()
+        }
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.shareOutputCount += 1
+            self?.shareOutputs.append(value)
+            self?.shareOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.shareCompletionCount += 1 }, receiveCancel: { [weak self] in self?.shareSubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
     }
     var shareCallCount: Int = 0
     var shareArgs: [String] = []
     var shareHandler: ((_ id: String) -> (AnyPublisher<String, Error>))? = nil
+    var shareSubscribeCount: Int = 0
+    var shareSubscribeCancelCount: Int = 0
+    var shareOutputCount: Int = 0
+    var shareOutputs: [String] = []
+    var shareOutputHandler: ((String) -> Void)? = nil
+    var shareCompletionCount: Int = 0
     lazy var shareSubject = PassthroughSubject<String, Error>()
     func token() -> AnyPublisher<String, Error> {
         tokenCallCount += 1
         if let __tokenHandler = self.tokenHandler {
             return __tokenHandler()
         }
-        return tokenSubject.eraseToAnyPublisher()
+        return Deferred { [weak self, subject = tokenSubject] () -> AnyPublisher<String, Error> in
+            self?.tokenSubscribeCount += 1
+            return subject.eraseToAnyPublisher()
+        }
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.tokenOutputCount += 1
+            self?.tokenOutputs.append(value)
+            self?.tokenOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.tokenCompletionCount += 1 }, receiveCancel: { [weak self] in self?.tokenSubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
     }
     var tokenCallCount: Int = 0
     var tokenHandler: (() -> (AnyPublisher<String, Error>))? = nil
+    var tokenSubscribeCount: Int = 0
+    var tokenSubscribeCancelCount: Int = 0
+    var tokenOutputCount: Int = 0
+    var tokenOutputs: [String] = []
+    var tokenOutputHandler: ((String) -> Void)? = nil
+    var tokenCompletionCount: Int = 0
     lazy var tokenSubject = CurrentValueSubject<String, Error>("")
 }
 
@@ -803,23 +1041,53 @@ final class NotificationSignallingMock: NotificationSignalling {
     // MARK: - Variables
     var badgeCount: AnyPublisher<Int, Never> {
         badgeCountGetCount += 1
-        if let handler = badgeCountGetHandler {
-            return handler()
+        return Deferred { [weak self, subject = badgeCountSubject] () -> AnyPublisher<Int, Never> in
+            self?.badgeCountSubscribeCount += 1
+            if let handler = self?.badgeCountGetHandler {
+                return handler()
+            }
+            return subject.eraseToAnyPublisher()
         }
-        return badgeCountSubject.eraseToAnyPublisher()
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.badgeCountOutputCount += 1
+            self?.badgeCountOutputs.append(value)
+            self?.badgeCountOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.badgeCountCompletionCount += 1 }, receiveCancel: { [weak self] in self?.badgeCountSubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
     }
     var badgeCountGetCount: Int = 0
     var badgeCountGetHandler: (() -> AnyPublisher<Int, Never>)? = nil
+    var badgeCountSubscribeCount: Int = 0
+    var badgeCountSubscribeCancelCount: Int = 0
+    var badgeCountOutputCount: Int = 0
+    var badgeCountOutputs: [Int] = []
+    var badgeCountOutputHandler: ((Int) -> Void)? = nil
+    var badgeCountCompletionCount: Int = 0
     lazy var badgeCountSubject = CurrentValueSubject<Int, Never>(0)
     var friendGraphChanged: AnyPublisher<Void, Never> {
         friendGraphChangedGetCount += 1
-        if let handler = friendGraphChangedGetHandler {
-            return handler()
+        return Deferred { [weak self, subject = friendGraphChangedSubject] () -> AnyPublisher<(), Never> in
+            self?.friendGraphChangedSubscribeCount += 1
+            if let handler = self?.friendGraphChangedGetHandler {
+                return handler()
+            }
+            return subject.eraseToAnyPublisher()
         }
-        return friendGraphChangedSubject.eraseToAnyPublisher()
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.friendGraphChangedOutputCount += 1
+            self?.friendGraphChangedOutputs.append(value)
+            self?.friendGraphChangedOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.friendGraphChangedCompletionCount += 1 }, receiveCancel: { [weak self] in self?.friendGraphChangedSubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
     }
     var friendGraphChangedGetCount: Int = 0
     var friendGraphChangedGetHandler: (() -> AnyPublisher<Void, Never>)? = nil
+    var friendGraphChangedSubscribeCount: Int = 0
+    var friendGraphChangedSubscribeCancelCount: Int = 0
+    var friendGraphChangedOutputCount: Int = 0
+    var friendGraphChangedOutputs: [()] = []
+    var friendGraphChangedOutputHandler: ((()) -> Void)? = nil
+    var friendGraphChangedCompletionCount: Int = 0
     lazy var friendGraphChangedSubject = PassthroughSubject<(), Never>()
 }
 
@@ -1097,10 +1365,25 @@ final class PushNotificationRepositoryProtocolMock: PushNotificationRepositoryPr
         if let __deregisterCurrentDeviceHandler = self.deregisterCurrentDeviceHandler {
             return __deregisterCurrentDeviceHandler()
         }
-        return deregisterCurrentDeviceSubject.eraseToAnyPublisher()
+        return Deferred { [weak self, subject = deregisterCurrentDeviceSubject] () -> AnyPublisher<(), Error> in
+            self?.deregisterCurrentDeviceSubscribeCount += 1
+            return subject.eraseToAnyPublisher()
+        }
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.deregisterCurrentDeviceOutputCount += 1
+            self?.deregisterCurrentDeviceOutputs.append(value)
+            self?.deregisterCurrentDeviceOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.deregisterCurrentDeviceCompletionCount += 1 }, receiveCancel: { [weak self] in self?.deregisterCurrentDeviceSubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
     }
     var deregisterCurrentDeviceCallCount: Int = 0
     var deregisterCurrentDeviceHandler: (() -> (AnyPublisher<Void, Error>))? = nil
+    var deregisterCurrentDeviceSubscribeCount: Int = 0
+    var deregisterCurrentDeviceSubscribeCancelCount: Int = 0
+    var deregisterCurrentDeviceOutputCount: Int = 0
+    var deregisterCurrentDeviceOutputs: [()] = []
+    var deregisterCurrentDeviceOutputHandler: ((()) -> Void)? = nil
+    var deregisterCurrentDeviceCompletionCount: Int = 0
     lazy var deregisterCurrentDeviceSubject = PassthroughSubject<(), Error>()
     nonisolated func requestPermission() {
         requestPermissionCallCount += 1
@@ -1256,13 +1539,28 @@ final class UserRepositoryProtocolMock: UserRepositoryProtocol {
     // MARK: - Variables
     var meStream: AnyPublisher<UserSummary?, Never> {
         meStreamGetCount += 1
-        if let handler = meStreamGetHandler {
-            return handler()
+        return Deferred { [weak self, subject = meStreamSubject] () -> AnyPublisher<UserSummary?, Never> in
+            self?.meStreamSubscribeCount += 1
+            if let handler = self?.meStreamGetHandler {
+                return handler()
+            }
+            return subject.eraseToAnyPublisher()
         }
-        return meStreamSubject.eraseToAnyPublisher()
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.meStreamOutputCount += 1
+            self?.meStreamOutputs.append(value)
+            self?.meStreamOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.meStreamCompletionCount += 1 }, receiveCancel: { [weak self] in self?.meStreamSubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
     }
     var meStreamGetCount: Int = 0
     var meStreamGetHandler: (() -> AnyPublisher<UserSummary?, Never>)? = nil
+    var meStreamSubscribeCount: Int = 0
+    var meStreamSubscribeCancelCount: Int = 0
+    var meStreamOutputCount: Int = 0
+    var meStreamOutputs: [UserSummary?] = []
+    var meStreamOutputHandler: ((UserSummary?) -> Void)? = nil
+    var meStreamCompletionCount: Int = 0
     lazy var meStreamSubject = PassthroughSubject<UserSummary?, Never>()
 
     // MARK: - Methods
@@ -1272,11 +1570,26 @@ final class UserRepositoryProtocolMock: UserRepositoryProtocol {
         if let __bootstrapHandler = self.bootstrapHandler {
             return __bootstrapHandler(displayName)
         }
-        return bootstrapSubject.eraseToAnyPublisher()
+        return Deferred { [weak self, subject = bootstrapSubject] () -> AnyPublisher<(), Error> in
+            self?.bootstrapSubscribeCount += 1
+            return subject.eraseToAnyPublisher()
+        }
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.bootstrapOutputCount += 1
+            self?.bootstrapOutputs.append(value)
+            self?.bootstrapOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.bootstrapCompletionCount += 1 }, receiveCancel: { [weak self] in self?.bootstrapSubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
     }
     var bootstrapCallCount: Int = 0
     var bootstrapArgs: [String?] = []
     var bootstrapHandler: ((_ displayName: String?) -> (AnyPublisher<Void, Error>))? = nil
+    var bootstrapSubscribeCount: Int = 0
+    var bootstrapSubscribeCancelCount: Int = 0
+    var bootstrapOutputCount: Int = 0
+    var bootstrapOutputs: [()] = []
+    var bootstrapOutputHandler: ((()) -> Void)? = nil
+    var bootstrapCompletionCount: Int = 0
     lazy var bootstrapSubject = PassthroughSubject<(), Error>()
     func registerDevice(token: String, platform: String) -> AnyPublisher<Void, Error> {
         registerDeviceCallCount += 1
@@ -1284,11 +1597,26 @@ final class UserRepositoryProtocolMock: UserRepositoryProtocol {
         if let __registerDeviceHandler = self.registerDeviceHandler {
             return __registerDeviceHandler(token, platform)
         }
-        return registerDeviceSubject.eraseToAnyPublisher()
+        return Deferred { [weak self, subject = registerDeviceSubject] () -> AnyPublisher<(), Error> in
+            self?.registerDeviceSubscribeCount += 1
+            return subject.eraseToAnyPublisher()
+        }
+        .handleEvents(receiveOutput: { [weak self] value in
+            self?.registerDeviceOutputCount += 1
+            self?.registerDeviceOutputs.append(value)
+            self?.registerDeviceOutputHandler?(value)
+        }, receiveCompletion: { [weak self] _ in self?.registerDeviceCompletionCount += 1 }, receiveCancel: { [weak self] in self?.registerDeviceSubscribeCancelCount += 1 })
+        .eraseToAnyPublisher()
     }
     var registerDeviceCallCount: Int = 0
     var registerDeviceArgs: [(token: String, platform: String)] = []
     var registerDeviceHandler: ((_ token: String, _ platform: String) -> (AnyPublisher<Void, Error>))? = nil
+    var registerDeviceSubscribeCount: Int = 0
+    var registerDeviceSubscribeCancelCount: Int = 0
+    var registerDeviceOutputCount: Int = 0
+    var registerDeviceOutputs: [()] = []
+    var registerDeviceOutputHandler: ((()) -> Void)? = nil
+    var registerDeviceCompletionCount: Int = 0
     lazy var registerDeviceSubject = PassthroughSubject<(), Error>()
 }
 

--- a/Tests/Checks/Snapshots/Mocks.generated.swift
+++ b/Tests/Checks/Snapshots/Mocks.generated.swift
@@ -5,7 +5,15 @@
 import Combine
 import Foundation
 
+// Mock member names are the requirement's declared name plus a suffix: `func load()` gives
+// `loadCallCount`, `loadArgs` and `loadHandler`; `var name` gives `nameGetCount`, `nameSetCount`,
+// `nameGetHandler` and the store `_name`. Where a prefix is not the declared name — an overload,
+// a return-type discriminator, `sourcery: methodName` — a comment carrying both spellings
+// sits above the witness and in the index under that class's `// MARK:` line.
+
 // MARK: - AnalyticsTracking
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class AnalyticsTrackingMock: AnalyticsTracking, @unchecked Sendable {
 
     // MARK: - Methods
@@ -40,6 +48,8 @@ final class AnalyticsTrackingMock: AnalyticsTracking, @unchecked Sendable {
 }
 
 // MARK: - AppServicesAPNSHandlerRegistering
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 @MainActor
 final class AppServicesAPNSHandlerRegisteringMock: AppServicesAPNSHandlerRegistering {
 
@@ -63,6 +73,8 @@ final class AppServicesAPNSHandlerRegisteringMock: AppServicesAPNSHandlerRegiste
 }
 
 // MARK: - AppServicesRegistering
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 @MainActor
 final class AppServicesRegisteringMock: AppServicesRegistering {
 
@@ -110,6 +122,8 @@ final class AppServicesRegisteringMock: AppServicesRegistering {
 }
 
 // MARK: - AppServicesURLHandlerRegistering
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 @MainActor
 final class AppServicesURLHandlerRegisteringMock: AppServicesURLHandlerRegistering {
 
@@ -133,6 +147,8 @@ final class AppServicesURLHandlerRegisteringMock: AppServicesURLHandlerRegisteri
 }
 
 // MARK: - AudioSessionConfiguring
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class AudioSessionConfiguringMock: AudioSessionConfiguring {
 
     // MARK: - Variables
@@ -185,6 +201,8 @@ final class AudioSessionConfiguringMock: AudioSessionConfiguring {
 }
 
 // MARK: - CaptureDependency
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 @MainActor
 final class CaptureDependencyMock: CaptureDependency {
 
@@ -291,6 +309,8 @@ final class CaptureDependencyMock: CaptureDependency {
 }
 
 // MARK: - DetailPresenting
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class DetailPresentingMock: DetailPresenting {
 
     // MARK: - Variables
@@ -351,6 +371,8 @@ final class DetailPresentingMock: DetailPresenting {
 }
 
 // MARK: - DiagnosticsReporting
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 @MainActor
 final class DiagnosticsReportingMock: DiagnosticsReporting {
 
@@ -386,6 +408,8 @@ final class DiagnosticsReportingMock: DiagnosticsReporting {
 }
 
 // MARK: - FrameRetaining
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class FrameRetainingMock: FrameRetaining {
 
     // MARK: - Variables
@@ -440,6 +464,8 @@ final class FrameRetainingMock: FrameRetaining {
 }
 
 // MARK: - FrameStreaming
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class FrameStreamingMock: FrameStreaming {
 
     // MARK: - Variables
@@ -519,6 +545,8 @@ final class FrameStreamingMock: FrameStreaming {
 }
 
 // MARK: - MainDependency
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class MainDependencyMock: MainDependency {
 
     // MARK: - Variables
@@ -609,6 +637,8 @@ final class MainDependencyMock: MainDependency {
 }
 
 // MARK: - MediaStaging
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class MediaStagingMock: MediaStaging {
 
     // MARK: - Methods
@@ -655,6 +685,8 @@ final class MediaStagingMock: MediaStaging {
 }
 
 // MARK: - MemoryEventStreaming
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class MemoryEventStreamingMock: MemoryEventStreaming {
 
     // MARK: - Variables
@@ -686,6 +718,8 @@ final class MemoryEventStreamingMock: MemoryEventStreaming {
 }
 
 // MARK: - MemoryRepositoryProtocol
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class MemoryRepositoryProtocolMock: MemoryRepositoryProtocol {
 
     // MARK: - Variables
@@ -849,7 +883,36 @@ final class MemoryRepositoryProtocolMock: MemoryRepositoryProtocol {
     lazy var tokenSubject = CurrentValueSubject<String, Error>("")
 }
 
+// MARK: - NamingAnnotated
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
+// Not named after their declaration:
+//   `refresh()` members are named `reloadNow*` — `/// sourcery: methodName = "reloadNow"`
+final class NamingAnnotatedMock: NamingAnnotated {
+
+    // MARK: - Methods
+    // `refresh()` members are named `reloadNow*` — `/// sourcery: methodName = "reloadNow"`
+    func refresh() {
+        reloadNowCallCount += 1
+        if let __reloadNowHandler = self.reloadNowHandler {
+            __reloadNowHandler()
+        }
+    }
+    var reloadNowCallCount: Int = 0
+    var reloadNowHandler: (() -> ())? = nil
+    func reset() {
+        resetCallCount += 1
+        if let __resetHandler = self.resetHandler {
+            __resetHandler()
+        }
+    }
+    var resetCallCount: Int = 0
+    var resetHandler: (() -> ())? = nil
+}
+
 // MARK: - NamingKeywords
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class NamingKeywordsMock: NamingKeywords {
 
     // MARK: - Variables
@@ -893,6 +956,8 @@ final class NamingKeywordsMock: NamingKeywords {
 }
 
 // MARK: - NamingManyToOne
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class NamingManyToOneMock: NamingManyToOne {
 
     // MARK: - Methods
@@ -915,6 +980,13 @@ final class NamingManyToOneMock: NamingManyToOne {
 }
 
 // MARK: - NamingOverloads
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
+// Not named after their declaration:
+//   `end(at:)` members are named `endAt*` — overload of `end`, argument labels appended
+//   `end(atDocument:)` members are named `endAtDocument*` — overload of `end`, argument labels appended
+//   `reference(forURL:)` members are named `referenceForURL*` — overload of `reference`, argument labels appended
+//   `reference(withPath:)` members are named `referenceWithPath*` — overload of `reference`, argument labels appended
 final class NamingOverloadsMock: NamingOverloads {
 
     // MARK: - Methods
@@ -926,6 +998,7 @@ final class NamingOverloadsMock: NamingOverloads {
     }
     var endCallCount: Int = 0
     var endHandler: (() -> ())? = nil
+    // `end(at:)` members are named `endAt*` — overload of `end`, argument labels appended
     func end(at fieldValues: [String]) {
         endAtCallCount += 1
         endAtArgs.append(fieldValues)
@@ -936,6 +1009,7 @@ final class NamingOverloadsMock: NamingOverloads {
     var endAtCallCount: Int = 0
     var endAtArgs: [[String]] = []
     var endAtHandler: ((_ fieldValues: [String]) -> ())? = nil
+    // `end(atDocument:)` members are named `endAtDocument*` — overload of `end`, argument labels appended
     func end(atDocument document: String) {
         endAtDocumentCallCount += 1
         endAtDocumentArgs.append(document)
@@ -946,6 +1020,7 @@ final class NamingOverloadsMock: NamingOverloads {
     var endAtDocumentCallCount: Int = 0
     var endAtDocumentArgs: [String] = []
     var endAtDocumentHandler: ((_ document: String) -> ())? = nil
+    // `reference(forURL:)` members are named `referenceForURL*` — overload of `reference`, argument labels appended
     func reference(forURL url: String) {
         referenceForURLCallCount += 1
         referenceForURLArgs.append(url)
@@ -956,6 +1031,7 @@ final class NamingOverloadsMock: NamingOverloads {
     var referenceForURLCallCount: Int = 0
     var referenceForURLArgs: [String] = []
     var referenceForURLHandler: ((_ url: String) -> ())? = nil
+    // `reference(withPath:)` members are named `referenceWithPath*` — overload of `reference`, argument labels appended
     func reference(withPath path: String) {
         referenceWithPathCallCount += 1
         referenceWithPathArgs.append(path)
@@ -968,7 +1044,40 @@ final class NamingOverloadsMock: NamingOverloads {
     var referenceWithPathHandler: ((_ path: String) -> ())? = nil
 }
 
+// MARK: - NamingReturnTypes
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
+// Not named after their declaration:
+//   `data()` members are named `dataStringAny*` — overload of `data` returning `[String: Any]`
+//   `data()` members are named `dataStringAnyOptional*` — overload of `data` returning `[String: Any]?`
+final class NamingReturnTypesMock: NamingReturnTypes {
+
+    // MARK: - Methods
+    // `data()` members are named `dataStringAny*` — overload of `data` returning `[String: Any]`
+    func data() -> [String: Any] {
+        dataStringAnyCallCount += 1
+        if let __dataStringAnyHandler = self.dataStringAnyHandler {
+            return __dataStringAnyHandler()
+        }
+        return [:]
+    }
+    var dataStringAnyCallCount: Int = 0
+    var dataStringAnyHandler: (() -> ([String: Any]))? = nil
+    // `data()` members are named `dataStringAnyOptional*` — overload of `data` returning `[String: Any]?`
+    func data() -> [String: Any]? {
+        dataStringAnyOptionalCallCount += 1
+        if let __dataStringAnyOptionalHandler = self.dataStringAnyOptionalHandler {
+            return __dataStringAnyOptionalHandler()
+        }
+        return nil
+    }
+    var dataStringAnyOptionalCallCount: Int = 0
+    var dataStringAnyOptionalHandler: (() -> ([String: Any]?))? = nil
+}
+
 // MARK: - NamingUnderscores
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class NamingUnderscoresMock: NamingUnderscores {
 
     // MARK: - Variables
@@ -1012,6 +1121,8 @@ final class NamingUnderscoresMock: NamingUnderscores {
 }
 
 // MARK: - NamingUppercase
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class NamingUppercaseMock: NamingUppercase {
 
     // MARK: - Methods
@@ -1036,6 +1147,8 @@ final class NamingUppercaseMock: NamingUppercase {
 }
 
 // MARK: - NotificationSignalling
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class NotificationSignallingMock: NotificationSignalling {
 
     // MARK: - Variables
@@ -1092,6 +1205,8 @@ final class NotificationSignallingMock: NotificationSignalling {
 }
 
 // MARK: - PlaybackObserving
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class PlaybackObservingMock: PlaybackObserving {
 
     // MARK: - Methods
@@ -1116,6 +1231,8 @@ final class PlaybackObservingMock: PlaybackObserving {
 }
 
 // MARK: - PlaybackRetaining
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class PlaybackRetainingMock: PlaybackRetaining {
 
     // MARK: - Methods
@@ -1138,6 +1255,8 @@ final class PlaybackRetainingMock: PlaybackRetaining {
 }
 
 // MARK: - PropertyEffectful
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class PropertyEffectfulMock: PropertyEffectful {
 
     // MARK: - Variables
@@ -1212,6 +1331,8 @@ final class PropertyEffectfulMock: PropertyEffectful {
 }
 
 // MARK: - PropertyShaped
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class PropertyShapedMock: PropertyShaped {
 
     // MARK: - Variables
@@ -1304,6 +1425,8 @@ final class PropertyShapedMock: PropertyShaped {
 }
 
 // MARK: - PushNotificationRepositoryProtocol
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 @MainActor
 final class PushNotificationRepositoryProtocolMock: PushNotificationRepositoryProtocol {
 
@@ -1406,10 +1529,14 @@ final class PushNotificationRepositoryProtocolMock: PushNotificationRepositoryPr
 }
 
 // MARK: - RootDependency
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class RootDependencyMock: RootDependency {
 }
 
 // MARK: - TimelineBuildable
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class TimelineBuildableMock: TimelineBuildable {
 
     // MARK: - Methods
@@ -1427,6 +1554,8 @@ final class TimelineBuildableMock: TimelineBuildable {
 }
 
 // MARK: - TimelineDependency
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class TimelineDependencyMock: TimelineDependency {
 
     // MARK: - Variables
@@ -1517,6 +1646,8 @@ final class TimelineDependencyMock: TimelineDependency {
 }
 
 // MARK: - UploadScheduling
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class UploadSchedulingMock: UploadScheduling {
 
     // MARK: - Methods
@@ -1533,6 +1664,8 @@ final class UploadSchedulingMock: UploadScheduling {
 }
 
 // MARK: - UserRepositoryProtocol
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 @MainActor
 final class UserRepositoryProtocolMock: UserRepositoryProtocol {
 
@@ -1621,6 +1754,8 @@ final class UserRepositoryProtocolMock: UserRepositoryProtocol {
 }
 
 // MARK: - VocabularyCanonical
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class VocabularyCanonicalMock: VocabularyCanonical {
 
     // MARK: - Variables
@@ -1652,6 +1787,8 @@ final class VocabularyCanonicalMock: VocabularyCanonical {
 }
 
 // MARK: - VocabularyLegacyObjc
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class VocabularyLegacyObjcMock: NSObject, VocabularyLegacyObjc {
 
     // MARK: - Methods
@@ -1666,6 +1803,8 @@ final class VocabularyLegacyObjcMock: NSObject, VocabularyLegacyObjc {
 }
 
 // MARK: - VocabularyObjc
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
 final class VocabularyObjcMock: NSObject, VocabularyObjc {
 
     // MARK: - Methods

--- a/Tests/Checks/Snapshots/Mocks.generated.swift
+++ b/Tests/Checks/Snapshots/Mocks.generated.swift
@@ -136,11 +136,25 @@ final class AppServicesURLHandlerRegisteringMock: AppServicesURLHandlerRegisteri
 final class AudioSessionConfiguringMock: AudioSessionConfiguring {
 
     // MARK: - Variables
-    var recordPermission: RecordPermission
+    var recordPermission: RecordPermission {
+        get {
+            recordPermissionGetCount += 1
+            if let handler = recordPermissionGetHandler {
+                return handler()
+            }
+            return _recordPermission
+        }
+        set {
+            _recordPermission = newValue
+        }
+    }
+    var recordPermissionGetCount: Int = 0
+    var recordPermissionGetHandler: (() -> RecordPermission)? = nil
+    var _recordPermission: RecordPermission
 
     // MARK: - Initializer
     init(recordPermission: RecordPermission) {
-        self.recordPermission = recordPermission
+        self._recordPermission = recordPermission
     }
 
     // MARK: - Methods
@@ -175,20 +189,73 @@ final class AudioSessionConfiguringMock: AudioSessionConfiguring {
 final class CaptureDependencyMock: CaptureDependency {
 
     // MARK: - Variables
-    var analytics: AnalyticsTracking
-    var draft: String = "" {
-        didSet {
-            draftSetCount += 1
+    var analytics: AnalyticsTracking {
+        get {
+            analyticsGetCount += 1
+            if let handler = analyticsGetHandler {
+                return handler()
+            }
+            return _analytics
+        }
+        set {
+            _analytics = newValue
         }
     }
+    var analyticsGetCount: Int = 0
+    var analyticsGetHandler: (() -> AnalyticsTracking)? = nil
+    var _analytics: AnalyticsTracking
+    var draft: String {
+        get {
+            draftGetCount += 1
+            if let handler = draftGetHandler {
+                return handler()
+            }
+            return _draft
+        }
+        set {
+            draftSetCount += 1
+            _draft = newValue
+        }
+    }
+    var draftGetCount: Int = 0
+    var draftGetHandler: (() -> String)? = nil
     var draftSetCount: Int = 0
-    nonisolated(unsafe) var installationId: String = ""
-    var memoryRepository: MemoryRepositoryProtocol
+    var _draft: String = ""
+    nonisolated var installationId: String {
+        get {
+            installationIdGetCount += 1
+            if let handler = installationIdGetHandler {
+                return handler()
+            }
+            return _installationId
+        }
+        set {
+            _installationId = newValue
+        }
+    }
+    nonisolated(unsafe) var installationIdGetCount: Int = 0
+    nonisolated(unsafe) var installationIdGetHandler: (() -> String)? = nil
+    nonisolated(unsafe) var _installationId: String = ""
+    var memoryRepository: MemoryRepositoryProtocol {
+        get {
+            memoryRepositoryGetCount += 1
+            if let handler = memoryRepositoryGetHandler {
+                return handler()
+            }
+            return _memoryRepository
+        }
+        set {
+            _memoryRepository = newValue
+        }
+    }
+    var memoryRepositoryGetCount: Int = 0
+    var memoryRepositoryGetHandler: (() -> MemoryRepositoryProtocol)? = nil
+    var _memoryRepository: MemoryRepositoryProtocol
 
     // MARK: - Initializer
     init(analytics: AnalyticsTracking, memoryRepository: MemoryRepositoryProtocol) {
-        self.analytics = analytics
-        self.memoryRepository = memoryRepository
+        self._analytics = analytics
+        self._memoryRepository = memoryRepository
     }
 
     // MARK: - Methods
@@ -227,8 +294,36 @@ final class CaptureDependencyMock: CaptureDependency {
 final class DetailPresentingMock: DetailPresenting {
 
     // MARK: - Variables
-    var policy: (any DetailSheet & DetailPolicy)? = nil
-    var restoredSheet: (any DetailSheet)? = nil
+    var policy: (any DetailSheet & DetailPolicy)? {
+        get {
+            policyGetCount += 1
+            if let handler = policyGetHandler {
+                return handler()
+            }
+            return _policy
+        }
+        set {
+            _policy = newValue
+        }
+    }
+    var policyGetCount: Int = 0
+    var policyGetHandler: (() -> (any DetailSheet & DetailPolicy)?)? = nil
+    var _policy: (any DetailSheet & DetailPolicy)? = nil
+    var restoredSheet: (any DetailSheet)? {
+        get {
+            restoredSheetGetCount += 1
+            if let handler = restoredSheetGetHandler {
+                return handler()
+            }
+            return _restoredSheet
+        }
+        set {
+            _restoredSheet = newValue
+        }
+    }
+    var restoredSheetGetCount: Int = 0
+    var restoredSheetGetHandler: (() -> (any DetailSheet)?)? = nil
+    var _restoredSheet: (any DetailSheet)? = nil
 
     // MARK: - Methods
     func present(sheet: (any DetailSheet)?, onDismiss: @escaping ((any DetailSheet)?) -> Void) -> (any DetailSheet)? {
@@ -294,19 +389,89 @@ final class DiagnosticsReportingMock: DiagnosticsReporting {
 final class MainDependencyMock: MainDependency {
 
     // MARK: - Variables
-    var analytics: AnalyticsTracking
-    var memoryRepository: MemoryRepositoryProtocol
-    var pushNotificationRepository: PushNotificationRepositoryProtocol
-    var themeProvider: ThemeProviding
-    var userRepository: UserRepositoryProtocol
+    var analytics: AnalyticsTracking {
+        get {
+            analyticsGetCount += 1
+            if let handler = analyticsGetHandler {
+                return handler()
+            }
+            return _analytics
+        }
+        set {
+            _analytics = newValue
+        }
+    }
+    var analyticsGetCount: Int = 0
+    var analyticsGetHandler: (() -> AnalyticsTracking)? = nil
+    var _analytics: AnalyticsTracking
+    var memoryRepository: MemoryRepositoryProtocol {
+        get {
+            memoryRepositoryGetCount += 1
+            if let handler = memoryRepositoryGetHandler {
+                return handler()
+            }
+            return _memoryRepository
+        }
+        set {
+            _memoryRepository = newValue
+        }
+    }
+    var memoryRepositoryGetCount: Int = 0
+    var memoryRepositoryGetHandler: (() -> MemoryRepositoryProtocol)? = nil
+    var _memoryRepository: MemoryRepositoryProtocol
+    var pushNotificationRepository: PushNotificationRepositoryProtocol {
+        get {
+            pushNotificationRepositoryGetCount += 1
+            if let handler = pushNotificationRepositoryGetHandler {
+                return handler()
+            }
+            return _pushNotificationRepository
+        }
+        set {
+            _pushNotificationRepository = newValue
+        }
+    }
+    var pushNotificationRepositoryGetCount: Int = 0
+    var pushNotificationRepositoryGetHandler: (() -> PushNotificationRepositoryProtocol)? = nil
+    var _pushNotificationRepository: PushNotificationRepositoryProtocol
+    var themeProvider: ThemeProviding {
+        get {
+            themeProviderGetCount += 1
+            if let handler = themeProviderGetHandler {
+                return handler()
+            }
+            return _themeProvider
+        }
+        set {
+            _themeProvider = newValue
+        }
+    }
+    var themeProviderGetCount: Int = 0
+    var themeProviderGetHandler: (() -> ThemeProviding)? = nil
+    var _themeProvider: ThemeProviding
+    var userRepository: UserRepositoryProtocol {
+        get {
+            userRepositoryGetCount += 1
+            if let handler = userRepositoryGetHandler {
+                return handler()
+            }
+            return _userRepository
+        }
+        set {
+            _userRepository = newValue
+        }
+    }
+    var userRepositoryGetCount: Int = 0
+    var userRepositoryGetHandler: (() -> UserRepositoryProtocol)? = nil
+    var _userRepository: UserRepositoryProtocol
 
     // MARK: - Initializer
     init(analytics: AnalyticsTracking, memoryRepository: MemoryRepositoryProtocol, pushNotificationRepository: PushNotificationRepositoryProtocol, themeProvider: ThemeProviding, userRepository: UserRepositoryProtocol) {
-        self.analytics = analytics
-        self.memoryRepository = memoryRepository
-        self.pushNotificationRepository = pushNotificationRepository
-        self.themeProvider = themeProvider
-        self.userRepository = userRepository
+        self._analytics = analytics
+        self._memoryRepository = memoryRepository
+        self._pushNotificationRepository = pushNotificationRepository
+        self._themeProvider = themeProvider
+        self._userRepository = userRepository
     }
 }
 
@@ -450,12 +615,23 @@ final class MemoryRepositoryProtocolMock: MemoryRepositoryProtocol {
 final class NamingKeywordsMock: NamingKeywords {
 
     // MARK: - Variables
-    var `default`: Int = 0 {
-        didSet {
+    var `default`: Int {
+        get {
+            defaultGetCount += 1
+            if let handler = defaultGetHandler {
+                return handler()
+            }
+            return _default
+        }
+        set {
             defaultSetCount += 1
+            _default = newValue
         }
     }
+    var defaultGetCount: Int = 0
+    var defaultGetHandler: (() -> Int)? = nil
     var defaultSetCount: Int = 0
+    var _default: Int = 0
 
     // MARK: - Methods
     func `do`() {
@@ -558,12 +734,23 @@ final class NamingOverloadsMock: NamingOverloads {
 final class NamingUnderscoresMock: NamingUnderscores {
 
     // MARK: - Variables
-    var setting4_2: Int = 0 {
-        didSet {
+    var setting4_2: Int {
+        get {
+            setting4_2GetCount += 1
+            if let handler = setting4_2GetHandler {
+                return handler()
+            }
+            return _setting4_2
+        }
+        set {
             setting4_2SetCount += 1
+            _setting4_2 = newValue
         }
     }
+    var setting4_2GetCount: Int = 0
+    var setting4_2GetHandler: (() -> Int)? = nil
     var setting4_2SetCount: Int = 0
+    var _setting4_2: Int = 0
 
     // MARK: - Methods
     func perform1_0() {
@@ -686,7 +873,16 @@ final class PlaybackRetainingMock: PlaybackRetaining {
 final class PropertyShapedMock: PropertyShaped {
 
     // MARK: - Variables
-    let buildNumber: Int = 0
+    var buildNumber: Int {
+        buildNumberGetCount += 1
+        if let handler = buildNumberGetHandler {
+            return handler()
+        }
+        return _buildNumber
+    }
+    var buildNumberGetCount: Int = 0
+    var buildNumberGetHandler: (() -> Int)? = nil
+    let _buildNumber: Int = 0
     var cursor: Int {
         get {
             cursorGetCount += 1
@@ -702,13 +898,38 @@ final class PropertyShapedMock: PropertyShaped {
     var cursorGetCount: Int = 0
     var cursorGetHandler: (() -> Int)? = nil
     var cursorSetCount: Int = 0
-    var draft: String = "" {
-        didSet {
+    var draft: String {
+        get {
+            draftGetCount += 1
+            if let handler = draftGetHandler {
+                return handler()
+            }
+            return _draft
+        }
+        set {
             draftSetCount += 1
+            _draft = newValue
         }
     }
+    var draftGetCount: Int = 0
+    var draftGetHandler: (() -> String)? = nil
     var draftSetCount: Int = 0
-    var identifier: String = ""
+    var _draft: String = ""
+    var identifier: String {
+        get {
+            identifierGetCount += 1
+            if let handler = identifierGetHandler {
+                return handler()
+            }
+            return _identifier
+        }
+        set {
+            _identifier = newValue
+        }
+    }
+    var identifierGetCount: Int = 0
+    var identifierGetHandler: (() -> String)? = nil
+    var _identifier: String = ""
     var snapshot: [String: Int] {
         snapshotGetCount += 1
         if let handler = snapshotGetHandler {
@@ -718,11 +939,25 @@ final class PropertyShapedMock: PropertyShaped {
     }
     var snapshotGetCount: Int = 0
     var snapshotGetHandler: (() -> [String: Int])? = nil
-    var themeProvider: ThemeProviding
+    var themeProvider: ThemeProviding {
+        get {
+            themeProviderGetCount += 1
+            if let handler = themeProviderGetHandler {
+                return handler()
+            }
+            return _themeProvider
+        }
+        set {
+            _themeProvider = newValue
+        }
+    }
+    var themeProviderGetCount: Int = 0
+    var themeProviderGetHandler: (() -> ThemeProviding)? = nil
+    var _themeProvider: ThemeProviding
 
     // MARK: - Initializer
     init(themeProvider: ThemeProviding) {
-        self.themeProvider = themeProvider
+        self._themeProvider = themeProvider
     }
 }
 
@@ -731,13 +966,55 @@ final class PropertyShapedMock: PropertyShaped {
 final class PushNotificationRepositoryProtocolMock: PushNotificationRepositoryProtocol {
 
     // MARK: - Variables
-    var authorizationStatus: RecordPermission
-    nonisolated(unsafe) var installationId: String = ""
-    var isNotificationsEnabled: Bool = false
+    var authorizationStatus: RecordPermission {
+        get {
+            authorizationStatusGetCount += 1
+            if let handler = authorizationStatusGetHandler {
+                return handler()
+            }
+            return _authorizationStatus
+        }
+        set {
+            _authorizationStatus = newValue
+        }
+    }
+    var authorizationStatusGetCount: Int = 0
+    var authorizationStatusGetHandler: (() -> RecordPermission)? = nil
+    var _authorizationStatus: RecordPermission
+    nonisolated var installationId: String {
+        get {
+            installationIdGetCount += 1
+            if let handler = installationIdGetHandler {
+                return handler()
+            }
+            return _installationId
+        }
+        set {
+            _installationId = newValue
+        }
+    }
+    nonisolated(unsafe) var installationIdGetCount: Int = 0
+    nonisolated(unsafe) var installationIdGetHandler: (() -> String)? = nil
+    nonisolated(unsafe) var _installationId: String = ""
+    var isNotificationsEnabled: Bool {
+        get {
+            isNotificationsEnabledGetCount += 1
+            if let handler = isNotificationsEnabledGetHandler {
+                return handler()
+            }
+            return _isNotificationsEnabled
+        }
+        set {
+            _isNotificationsEnabled = newValue
+        }
+    }
+    var isNotificationsEnabledGetCount: Int = 0
+    var isNotificationsEnabledGetHandler: (() -> Bool)? = nil
+    var _isNotificationsEnabled: Bool = false
 
     // MARK: - Initializer
     init(authorizationStatus: RecordPermission) {
-        self.authorizationStatus = authorizationStatus
+        self._authorizationStatus = authorizationStatus
     }
 
     // MARK: - Methods
@@ -796,19 +1073,89 @@ final class TimelineBuildableMock: TimelineBuildable {
 final class TimelineDependencyMock: TimelineDependency {
 
     // MARK: - Variables
-    var analytics: AnalyticsTracking
-    var audioSessionConfigurer: AudioSessionConfiguring
-    var memoryRepository: MemoryRepositoryProtocol
-    var themeProvider: ThemeProviding
-    var userRepository: UserRepositoryProtocol
+    var analytics: AnalyticsTracking {
+        get {
+            analyticsGetCount += 1
+            if let handler = analyticsGetHandler {
+                return handler()
+            }
+            return _analytics
+        }
+        set {
+            _analytics = newValue
+        }
+    }
+    var analyticsGetCount: Int = 0
+    var analyticsGetHandler: (() -> AnalyticsTracking)? = nil
+    var _analytics: AnalyticsTracking
+    var audioSessionConfigurer: AudioSessionConfiguring {
+        get {
+            audioSessionConfigurerGetCount += 1
+            if let handler = audioSessionConfigurerGetHandler {
+                return handler()
+            }
+            return _audioSessionConfigurer
+        }
+        set {
+            _audioSessionConfigurer = newValue
+        }
+    }
+    var audioSessionConfigurerGetCount: Int = 0
+    var audioSessionConfigurerGetHandler: (() -> AudioSessionConfiguring)? = nil
+    var _audioSessionConfigurer: AudioSessionConfiguring
+    var memoryRepository: MemoryRepositoryProtocol {
+        get {
+            memoryRepositoryGetCount += 1
+            if let handler = memoryRepositoryGetHandler {
+                return handler()
+            }
+            return _memoryRepository
+        }
+        set {
+            _memoryRepository = newValue
+        }
+    }
+    var memoryRepositoryGetCount: Int = 0
+    var memoryRepositoryGetHandler: (() -> MemoryRepositoryProtocol)? = nil
+    var _memoryRepository: MemoryRepositoryProtocol
+    var themeProvider: ThemeProviding {
+        get {
+            themeProviderGetCount += 1
+            if let handler = themeProviderGetHandler {
+                return handler()
+            }
+            return _themeProvider
+        }
+        set {
+            _themeProvider = newValue
+        }
+    }
+    var themeProviderGetCount: Int = 0
+    var themeProviderGetHandler: (() -> ThemeProviding)? = nil
+    var _themeProvider: ThemeProviding
+    var userRepository: UserRepositoryProtocol {
+        get {
+            userRepositoryGetCount += 1
+            if let handler = userRepositoryGetHandler {
+                return handler()
+            }
+            return _userRepository
+        }
+        set {
+            _userRepository = newValue
+        }
+    }
+    var userRepositoryGetCount: Int = 0
+    var userRepositoryGetHandler: (() -> UserRepositoryProtocol)? = nil
+    var _userRepository: UserRepositoryProtocol
 
     // MARK: - Initializer
     init(analytics: AnalyticsTracking, audioSessionConfigurer: AudioSessionConfiguring, memoryRepository: MemoryRepositoryProtocol, themeProvider: ThemeProviding, userRepository: UserRepositoryProtocol) {
-        self.analytics = analytics
-        self.audioSessionConfigurer = audioSessionConfigurer
-        self.memoryRepository = memoryRepository
-        self.themeProvider = themeProvider
-        self.userRepository = userRepository
+        self._analytics = analytics
+        self._audioSessionConfigurer = audioSessionConfigurer
+        self._memoryRepository = memoryRepository
+        self._themeProvider = themeProvider
+        self._userRepository = userRepository
     }
 }
 
@@ -875,7 +1222,21 @@ final class UserRepositoryProtocolMock: UserRepositoryProtocol {
 final class VocabularyCanonicalMock: VocabularyCanonical {
 
     // MARK: - Variables
-    var identifier: String = ""
+    var identifier: String {
+        get {
+            identifierGetCount += 1
+            if let handler = identifierGetHandler {
+                return handler()
+            }
+            return _identifier
+        }
+        set {
+            _identifier = newValue
+        }
+    }
+    var identifierGetCount: Int = 0
+    var identifierGetHandler: (() -> String)? = nil
+    var _identifier: String = ""
 
     // MARK: - Methods
     func refresh() {

--- a/Tests/Checks/Snapshots/Mocks.generated.swift
+++ b/Tests/Checks/Snapshots/Mocks.generated.swift
@@ -869,6 +869,80 @@ final class PlaybackRetainingMock: PlaybackRetaining {
     var retainHandler: ((_ player: FeedAudioPlayer) -> ())? = nil
 }
 
+// MARK: - PropertyEffectful
+final class PropertyEffectfulMock: PropertyEffectful {
+
+    // MARK: - Variables
+    var config: String {
+        get async throws {
+            configGetCount += 1
+            if let handler = configGetHandler {
+                return try await handler()
+            }
+            return _config
+        }
+    }
+    var configGetCount: Int = 0
+    var configGetHandler: (() async throws -> String)? = nil
+    var _config: String = ""
+    var loader: ThemeProviding {
+        get async {
+            loaderGetCount += 1
+            if let handler = loaderGetHandler {
+                return await handler()
+            }
+            return _loader
+        }
+    }
+    var loaderGetCount: Int = 0
+    var loaderGetHandler: (() async -> ThemeProviding)? = nil
+    var _loader: ThemeProviding
+    var plain: String {
+        get {
+            plainGetCount += 1
+            if let handler = plainGetHandler {
+                return handler()
+            }
+            return _plain
+        }
+        set {
+            _plain = newValue
+        }
+    }
+    var plainGetCount: Int = 0
+    var plainGetHandler: (() -> String)? = nil
+    var _plain: String = ""
+    var secret: String {
+        get throws {
+            secretGetCount += 1
+            if let handler = secretGetHandler {
+                return try handler()
+            }
+            return _secret
+        }
+    }
+    var secretGetCount: Int = 0
+    var secretGetHandler: (() throws -> String)? = nil
+    var _secret: String = ""
+    var token: String {
+        get async {
+            tokenGetCount += 1
+            if let handler = tokenGetHandler {
+                return await handler()
+            }
+            return _token
+        }
+    }
+    var tokenGetCount: Int = 0
+    var tokenGetHandler: (() async -> String)? = nil
+    var _token: String = ""
+
+    // MARK: - Initializer
+    init(loader: ThemeProviding) {
+        self._loader = loader
+    }
+}
+
 // MARK: - PropertyShaped
 final class PropertyShapedMock: PropertyShaped {
 

--- a/Tests/Checks/Snapshots/Mocks.generated.swift
+++ b/Tests/Checks/Snapshots/Mocks.generated.swift
@@ -153,16 +153,11 @@ final class AudioSessionConfiguringMock: AudioSessionConfiguring {
 
     // MARK: - Variables
     var recordPermission: RecordPermission {
-        get {
-            recordPermissionGetCount += 1
-            if let handler = recordPermissionGetHandler {
-                return handler()
-            }
-            return _recordPermission
+        recordPermissionGetCount += 1
+        if let handler = recordPermissionGetHandler {
+            return handler()
         }
-        set {
-            _recordPermission = newValue
-        }
+        return _recordPermission
     }
     var recordPermissionGetCount: Int = 0
     var recordPermissionGetHandler: (() -> RecordPermission)? = nil
@@ -208,16 +203,11 @@ final class CaptureDependencyMock: CaptureDependency {
 
     // MARK: - Variables
     var analytics: AnalyticsTracking {
-        get {
-            analyticsGetCount += 1
-            if let handler = analyticsGetHandler {
-                return handler()
-            }
-            return _analytics
+        analyticsGetCount += 1
+        if let handler = analyticsGetHandler {
+            return handler()
         }
-        set {
-            _analytics = newValue
-        }
+        return _analytics
     }
     var analyticsGetCount: Int = 0
     var analyticsGetHandler: (() -> AnalyticsTracking)? = nil
@@ -240,31 +230,21 @@ final class CaptureDependencyMock: CaptureDependency {
     var draftSetCount: Int = 0
     var _draft: String = ""
     nonisolated var installationId: String {
-        get {
-            installationIdGetCount += 1
-            if let handler = installationIdGetHandler {
-                return handler()
-            }
-            return _installationId
+        installationIdGetCount += 1
+        if let handler = installationIdGetHandler {
+            return handler()
         }
-        set {
-            _installationId = newValue
-        }
+        return _installationId
     }
     nonisolated(unsafe) var installationIdGetCount: Int = 0
     nonisolated(unsafe) var installationIdGetHandler: (() -> String)? = nil
     nonisolated(unsafe) var _installationId: String = ""
     var memoryRepository: MemoryRepositoryProtocol {
-        get {
-            memoryRepositoryGetCount += 1
-            if let handler = memoryRepositoryGetHandler {
-                return handler()
-            }
-            return _memoryRepository
+        memoryRepositoryGetCount += 1
+        if let handler = memoryRepositoryGetHandler {
+            return handler()
         }
-        set {
-            _memoryRepository = newValue
-        }
+        return _memoryRepository
     }
     var memoryRepositoryGetCount: Int = 0
     var memoryRepositoryGetHandler: (() -> MemoryRepositoryProtocol)? = nil
@@ -315,31 +295,21 @@ final class DetailPresentingMock: DetailPresenting {
 
     // MARK: - Variables
     var policy: (any DetailSheet & DetailPolicy)? {
-        get {
-            policyGetCount += 1
-            if let handler = policyGetHandler {
-                return handler()
-            }
-            return _policy
+        policyGetCount += 1
+        if let handler = policyGetHandler {
+            return handler()
         }
-        set {
-            _policy = newValue
-        }
+        return _policy
     }
     var policyGetCount: Int = 0
     var policyGetHandler: (() -> (any DetailSheet & DetailPolicy)?)? = nil
     var _policy: (any DetailSheet & DetailPolicy)? = nil
     var restoredSheet: (any DetailSheet)? {
-        get {
-            restoredSheetGetCount += 1
-            if let handler = restoredSheetGetHandler {
-                return handler()
-            }
-            return _restoredSheet
+        restoredSheetGetCount += 1
+        if let handler = restoredSheetGetHandler {
+            return handler()
         }
-        set {
-            _restoredSheet = newValue
-        }
+        return _restoredSheet
     }
     var restoredSheetGetCount: Int = 0
     var restoredSheetGetHandler: (() -> (any DetailSheet)?)? = nil
@@ -551,76 +521,51 @@ final class MainDependencyMock: MainDependency {
 
     // MARK: - Variables
     var analytics: AnalyticsTracking {
-        get {
-            analyticsGetCount += 1
-            if let handler = analyticsGetHandler {
-                return handler()
-            }
-            return _analytics
+        analyticsGetCount += 1
+        if let handler = analyticsGetHandler {
+            return handler()
         }
-        set {
-            _analytics = newValue
-        }
+        return _analytics
     }
     var analyticsGetCount: Int = 0
     var analyticsGetHandler: (() -> AnalyticsTracking)? = nil
     var _analytics: AnalyticsTracking
     var memoryRepository: MemoryRepositoryProtocol {
-        get {
-            memoryRepositoryGetCount += 1
-            if let handler = memoryRepositoryGetHandler {
-                return handler()
-            }
-            return _memoryRepository
+        memoryRepositoryGetCount += 1
+        if let handler = memoryRepositoryGetHandler {
+            return handler()
         }
-        set {
-            _memoryRepository = newValue
-        }
+        return _memoryRepository
     }
     var memoryRepositoryGetCount: Int = 0
     var memoryRepositoryGetHandler: (() -> MemoryRepositoryProtocol)? = nil
     var _memoryRepository: MemoryRepositoryProtocol
     var pushNotificationRepository: PushNotificationRepositoryProtocol {
-        get {
-            pushNotificationRepositoryGetCount += 1
-            if let handler = pushNotificationRepositoryGetHandler {
-                return handler()
-            }
-            return _pushNotificationRepository
+        pushNotificationRepositoryGetCount += 1
+        if let handler = pushNotificationRepositoryGetHandler {
+            return handler()
         }
-        set {
-            _pushNotificationRepository = newValue
-        }
+        return _pushNotificationRepository
     }
     var pushNotificationRepositoryGetCount: Int = 0
     var pushNotificationRepositoryGetHandler: (() -> PushNotificationRepositoryProtocol)? = nil
     var _pushNotificationRepository: PushNotificationRepositoryProtocol
     var themeProvider: ThemeProviding {
-        get {
-            themeProviderGetCount += 1
-            if let handler = themeProviderGetHandler {
-                return handler()
-            }
-            return _themeProvider
+        themeProviderGetCount += 1
+        if let handler = themeProviderGetHandler {
+            return handler()
         }
-        set {
-            _themeProvider = newValue
-        }
+        return _themeProvider
     }
     var themeProviderGetCount: Int = 0
     var themeProviderGetHandler: (() -> ThemeProviding)? = nil
     var _themeProvider: ThemeProviding
     var userRepository: UserRepositoryProtocol {
-        get {
-            userRepositoryGetCount += 1
-            if let handler = userRepositoryGetHandler {
-                return handler()
-            }
-            return _userRepository
+        userRepositoryGetCount += 1
+        if let handler = userRepositoryGetHandler {
+            return handler()
         }
-        set {
-            _userRepository = newValue
-        }
+        return _userRepository
     }
     var userRepositoryGetCount: Int = 0
     var userRepositoryGetHandler: (() -> UserRepositoryProtocol)? = nil
@@ -1285,16 +1230,11 @@ final class PropertyEffectfulMock: PropertyEffectful {
     var loaderGetHandler: (() async -> ThemeProviding)? = nil
     var _loader: ThemeProviding
     var plain: String {
-        get {
-            plainGetCount += 1
-            if let handler = plainGetHandler {
-                return handler()
-            }
-            return _plain
+        plainGetCount += 1
+        if let handler = plainGetHandler {
+            return handler()
         }
-        set {
-            _plain = newValue
-        }
+        return _plain
     }
     var plainGetCount: Int = 0
     var plainGetHandler: (() -> String)? = nil
@@ -1379,16 +1319,11 @@ final class PropertyShapedMock: PropertyShaped {
     var draftSetCount: Int = 0
     var _draft: String = ""
     var identifier: String {
-        get {
-            identifierGetCount += 1
-            if let handler = identifierGetHandler {
-                return handler()
-            }
-            return _identifier
+        identifierGetCount += 1
+        if let handler = identifierGetHandler {
+            return handler()
         }
-        set {
-            _identifier = newValue
-        }
+        return _identifier
     }
     var identifierGetCount: Int = 0
     var identifierGetHandler: (() -> String)? = nil
@@ -1403,16 +1338,11 @@ final class PropertyShapedMock: PropertyShaped {
     var snapshotGetCount: Int = 0
     var snapshotGetHandler: (() -> [String: Int])? = nil
     var themeProvider: ThemeProviding {
-        get {
-            themeProviderGetCount += 1
-            if let handler = themeProviderGetHandler {
-                return handler()
-            }
-            return _themeProvider
+        themeProviderGetCount += 1
+        if let handler = themeProviderGetHandler {
+            return handler()
         }
-        set {
-            _themeProvider = newValue
-        }
+        return _themeProvider
     }
     var themeProviderGetCount: Int = 0
     var themeProviderGetHandler: (() -> ThemeProviding)? = nil
@@ -1432,46 +1362,31 @@ final class PushNotificationRepositoryProtocolMock: PushNotificationRepositoryPr
 
     // MARK: - Variables
     var authorizationStatus: RecordPermission {
-        get {
-            authorizationStatusGetCount += 1
-            if let handler = authorizationStatusGetHandler {
-                return handler()
-            }
-            return _authorizationStatus
+        authorizationStatusGetCount += 1
+        if let handler = authorizationStatusGetHandler {
+            return handler()
         }
-        set {
-            _authorizationStatus = newValue
-        }
+        return _authorizationStatus
     }
     var authorizationStatusGetCount: Int = 0
     var authorizationStatusGetHandler: (() -> RecordPermission)? = nil
     var _authorizationStatus: RecordPermission
     nonisolated var installationId: String {
-        get {
-            installationIdGetCount += 1
-            if let handler = installationIdGetHandler {
-                return handler()
-            }
-            return _installationId
+        installationIdGetCount += 1
+        if let handler = installationIdGetHandler {
+            return handler()
         }
-        set {
-            _installationId = newValue
-        }
+        return _installationId
     }
     nonisolated(unsafe) var installationIdGetCount: Int = 0
     nonisolated(unsafe) var installationIdGetHandler: (() -> String)? = nil
     nonisolated(unsafe) var _installationId: String = ""
     var isNotificationsEnabled: Bool {
-        get {
-            isNotificationsEnabledGetCount += 1
-            if let handler = isNotificationsEnabledGetHandler {
-                return handler()
-            }
-            return _isNotificationsEnabled
+        isNotificationsEnabledGetCount += 1
+        if let handler = isNotificationsEnabledGetHandler {
+            return handler()
         }
-        set {
-            _isNotificationsEnabled = newValue
-        }
+        return _isNotificationsEnabled
     }
     var isNotificationsEnabledGetCount: Int = 0
     var isNotificationsEnabledGetHandler: (() -> Bool)? = nil
@@ -1560,76 +1475,51 @@ final class TimelineDependencyMock: TimelineDependency {
 
     // MARK: - Variables
     var analytics: AnalyticsTracking {
-        get {
-            analyticsGetCount += 1
-            if let handler = analyticsGetHandler {
-                return handler()
-            }
-            return _analytics
+        analyticsGetCount += 1
+        if let handler = analyticsGetHandler {
+            return handler()
         }
-        set {
-            _analytics = newValue
-        }
+        return _analytics
     }
     var analyticsGetCount: Int = 0
     var analyticsGetHandler: (() -> AnalyticsTracking)? = nil
     var _analytics: AnalyticsTracking
     var audioSessionConfigurer: AudioSessionConfiguring {
-        get {
-            audioSessionConfigurerGetCount += 1
-            if let handler = audioSessionConfigurerGetHandler {
-                return handler()
-            }
-            return _audioSessionConfigurer
+        audioSessionConfigurerGetCount += 1
+        if let handler = audioSessionConfigurerGetHandler {
+            return handler()
         }
-        set {
-            _audioSessionConfigurer = newValue
-        }
+        return _audioSessionConfigurer
     }
     var audioSessionConfigurerGetCount: Int = 0
     var audioSessionConfigurerGetHandler: (() -> AudioSessionConfiguring)? = nil
     var _audioSessionConfigurer: AudioSessionConfiguring
     var memoryRepository: MemoryRepositoryProtocol {
-        get {
-            memoryRepositoryGetCount += 1
-            if let handler = memoryRepositoryGetHandler {
-                return handler()
-            }
-            return _memoryRepository
+        memoryRepositoryGetCount += 1
+        if let handler = memoryRepositoryGetHandler {
+            return handler()
         }
-        set {
-            _memoryRepository = newValue
-        }
+        return _memoryRepository
     }
     var memoryRepositoryGetCount: Int = 0
     var memoryRepositoryGetHandler: (() -> MemoryRepositoryProtocol)? = nil
     var _memoryRepository: MemoryRepositoryProtocol
     var themeProvider: ThemeProviding {
-        get {
-            themeProviderGetCount += 1
-            if let handler = themeProviderGetHandler {
-                return handler()
-            }
-            return _themeProvider
+        themeProviderGetCount += 1
+        if let handler = themeProviderGetHandler {
+            return handler()
         }
-        set {
-            _themeProvider = newValue
-        }
+        return _themeProvider
     }
     var themeProviderGetCount: Int = 0
     var themeProviderGetHandler: (() -> ThemeProviding)? = nil
     var _themeProvider: ThemeProviding
     var userRepository: UserRepositoryProtocol {
-        get {
-            userRepositoryGetCount += 1
-            if let handler = userRepositoryGetHandler {
-                return handler()
-            }
-            return _userRepository
+        userRepositoryGetCount += 1
+        if let handler = userRepositoryGetHandler {
+            return handler()
         }
-        set {
-            _userRepository = newValue
-        }
+        return _userRepository
     }
     var userRepositoryGetCount: Int = 0
     var userRepositoryGetHandler: (() -> UserRepositoryProtocol)? = nil
@@ -1760,16 +1650,11 @@ final class VocabularyCanonicalMock: VocabularyCanonical {
 
     // MARK: - Variables
     var identifier: String {
-        get {
-            identifierGetCount += 1
-            if let handler = identifierGetHandler {
-                return handler()
-            }
-            return _identifier
+        identifierGetCount += 1
+        if let handler = identifierGetHandler {
+            return handler()
         }
-        set {
-            _identifier = newValue
-        }
+        return _identifier
     }
     var identifierGetCount: Int = 0
     var identifierGetHandler: (() -> String)? = nil

--- a/Tests/Checks/Snapshots/Mocks.generated.swift
+++ b/Tests/Checks/Snapshots/Mocks.generated.swift
@@ -1065,6 +1065,37 @@ final class NamingUnderscoresMock: NamingUnderscores {
     var perform2_0Handler: ((_ value: Int) -> ())? = nil
 }
 
+// MARK: - NamingUnlabelledOverload
+// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
+// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.
+// Not named after their declaration:
+//   `send(to:)` members are named `sendTo*` — overload of `send`, argument labels appended
+final class NamingUnlabelledOverloadMock: NamingUnlabelledOverload {
+
+    // MARK: - Methods
+    func send(_ value: String) {
+        sendCallCount += 1
+        sendArgs.append(value)
+        if let __sendHandler = self.sendHandler {
+            __sendHandler(value)
+        }
+    }
+    var sendCallCount: Int = 0
+    var sendArgs: [String] = []
+    var sendHandler: ((_ value: String) -> ())? = nil
+    // `send(to:)` members are named `sendTo*` — overload of `send`, argument labels appended
+    func send(to target: String) {
+        sendToCallCount += 1
+        sendToArgs.append(target)
+        if let __sendToHandler = self.sendToHandler {
+            __sendToHandler(target)
+        }
+    }
+    var sendToCallCount: Int = 0
+    var sendToArgs: [String] = []
+    var sendToHandler: ((_ target: String) -> ())? = nil
+}
+
 // MARK: - NamingUppercase
 // Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,
 // `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.

--- a/Tests/Checks/run-checks.sh
+++ b/Tests/Checks/run-checks.sh
@@ -11,9 +11,10 @@
 #   3. near-miss  a misspelled selector fails generation naming the canonical
 #                 spelling; a misspelled option still generates and writes one
 #                 comment line
-#   4. collision  two members that would carry one name fail generation naming
+#   4. refusal    a construct the templates cannot emit fails generation naming
 #                 the protocol and the member, instead of writing a file the
-#                 consumer's compiler rejects
+#                 consumer's compiler rejects: two members that would carry one
+#                 name, and a requirement declaring `throws(E)`
 #   5. typecheck  they compile clean together under Swift 5 + complete
 #                 concurrency checking, and under the Swift 6 language mode —
 #                 zero warnings, zero errors
@@ -215,15 +216,16 @@ else
   fi
 fi
 
-# ── 4. Collision ──────────────────────────────────────────────────
+# ── 4. Refusal ────────────────────────────────────────────────────
 # Each case here fails generation on purpose, so none of it can live in
 # Fixtures/ — one fixture that fails takes the whole lane's generation with it,
 # the way the near-miss selector case does. What is checked is that the failure
-# names the protocol and the member, rather than the template emitting a file
-# whose two identical declarations the consumer's compiler reports instead.
+# names the protocol and the member, rather than the template emitting a file the
+# consumer's compiler rejects: two identical declarations, or a witness that
+# throws `any Error` against a requirement that throws `E`.
 echo ""
-echo "── collision ──"
-COLLISION_DIR="$WORK_DIR/collision"
+echo "── refusal ──"
+COLLISION_DIR="$WORK_DIR/refusal"
 rm -rf "$COLLISION_DIR"
 
 # <case>:<protocol>:<member named in the message>
@@ -232,6 +234,8 @@ COLLISION_CASES=(
   "readcount:CollidingReadCount:draftGetCount"
   "store:CollidingStore:_draft"
   "overload:CollidingOverload:sendToVoidCallCount"
+  "typedthrowsvar:TypedThrowingProperty:secret"
+  "typedthrowsfunc:TypedThrowingMethod:load"
 )
 
 mkdir -p "$COLLISION_DIR/bookkeeping"
@@ -263,6 +267,27 @@ cat > "$COLLISION_DIR/store/Store.swift" <<'SWIFT'
 public protocol CollidingStore: AnyObject {
     var draft: String { get set }
     var _draft: String { get set }
+}
+SWIFT
+
+mkdir -p "$COLLISION_DIR/typedthrowsvar"
+cat > "$COLLISION_DIR/typedthrowsvar/TypedThrowsVar.swift" <<'SWIFT'
+// A typed throw on a property requirement. The accessor writes bare `throws`,
+// which does not satisfy `throws(E)`.
+public enum LoadFailure: Error { case unavailable }
+/// sourcery: ProtocolMock
+public protocol TypedThrowingProperty: AnyObject {
+    var secret: String { get throws(LoadFailure) }
+}
+SWIFT
+
+mkdir -p "$COLLISION_DIR/typedthrowsfunc"
+cat > "$COLLISION_DIR/typedthrowsfunc/TypedThrowsFunc.swift" <<'SWIFT'
+// The same on a method. `MockMethod.throwingDecl` writes bare `throws` too.
+public enum LoadFailure: Error { case unavailable }
+/// sourcery: ProtocolMock
+public protocol TypedThrowingMethod: AnyObject {
+    func load() throws(LoadFailure) -> String
 }
 SWIFT
 

--- a/Tests/Checks/run-checks.sh
+++ b/Tests/Checks/run-checks.sh
@@ -236,6 +236,7 @@ COLLISION_CASES=(
   "overload:CollidingOverload:sendToVoidCallCount"
   "typedthrowsvar:TypedThrowingProperty:secret"
   "typedthrowsfunc:TypedThrowingMethod:load"
+  "effectfulstream:EffectfulStreaming:frames"
 )
 
 mkdir -p "$COLLISION_DIR/bookkeeping"
@@ -288,6 +289,18 @@ public enum LoadFailure: Error { case unavailable }
 /// sourcery: ProtocolMock
 public protocol TypedThrowingMethod: AnyObject {
     func load() throws(LoadFailure) -> String
+}
+SWIFT
+
+mkdir -p "$COLLISION_DIR/effectfulstream"
+cat > "$COLLISION_DIR/effectfulstream/EffectfulStream.swift" <<'SWIFT'
+// A publisher requirement declared `{ get async }`. The member hands back a
+// `Deferred` whose closure reads the handler when the code under test
+// subscribes, and that closure is synchronous.
+import Combine
+/// sourcery: ProtocolMock
+public protocol EffectfulStreaming: AnyObject {
+    var frames: AnyPublisher<Int, Never> { get async }
 }
 SWIFT
 

--- a/Tests/Checks/run-checks.sh
+++ b/Tests/Checks/run-checks.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Template checks — run every template over Checks/Fixtures, then hold the
-# results to three gates:
+# results to seven gates:
 #
 #   1. snapshot   each generated file matches Checks/Snapshots (record with --record)
 #   2. zero-match each template still WRITES its file over sources with no
@@ -15,10 +15,13 @@
 #                 the protocol and the member, instead of writing a file the
 #                 consumer's compiler rejects: two members that would carry one
 #                 name, and a requirement declaring `throws(E)`
-#   5. typecheck  they compile clean together under Swift 5 + complete
+#   5. naming     every `… members are named `X*` …` comment matches the member
+#                 below it, and each class's index lists exactly the members
+#                 commented inside it
+#   6. typecheck  they compile clean together under Swift 5 + complete
 #                 concurrency checking, and under the Swift 6 language mode —
 #                 zero warnings, zero errors
-#   6. behaviour  they do what a consumer needs: mocks count calls, run handlers
+#   7. behaviour  they do what a consumer needs: mocks count calls, run handlers
 #                 and deliver values pushed into their subjects; Components
 #                 forward to the parent and hold what the level owns
 #
@@ -337,7 +340,91 @@ for entry in "${COLLISION_CASES[@]}"; do
   fi
 done
 
-# ── 5. Typecheck, both language modes ─────────────────────────────
+# ── 5. Naming comments ────────────────────────────────────────────
+# `MockNaming.methodPrefix` returns a method's prefix and, when that prefix is
+# not the declared name, the comment recording it — one call, so a comment that
+# disagrees with the member below it cannot be produced (`spec.md` D16(a)). This
+# gate reads both back out of the generated file: the prefix a comment names has
+# to be the prefix the witness under it counts, and each class's index has to
+# list exactly the members commented inside that class. What it catches is a
+# later edit that writes a comment where a member is emitted instead of asking
+# `MockNaming` for one, which is what `AGENTS.md` §"State a rule once" forbids
+# and what no other gate reads.
+echo ""
+echo "── naming-comments ──"
+
+naming_comment_violations() {
+  awk '
+    /^\/\/ MARK: - / { cls = substr($0, 12) }
+    / members are named `/ {
+      is_index = ($0 ~ /^\/\/   `/)
+      text = $0
+      sub(/^[ \t]*/, "", text)
+      sub(/^\/\/ +/, "", text)
+      if (is_index) { indexed[cls SUBSEP text] = 1; next }
+      witnessed[cls SUBSEP text] = 1
+      at = NR
+      if (match(text, /named `[A-Za-z0-9_]+\*`/) == 0) {
+        printf "    line %d: the comment names no prefix: %s\n", at, text; bad++; next
+      }
+      prefix = substr(text, RSTART + 7, RLENGTH - 9)
+      if ((getline decl) <= 0 || decl !~ /func /) {
+        printf "    line %d: the comment is not above a func: %s\n", at, text; bad++; next
+      }
+      if ((getline body) <= 0) {
+        printf "    line %d: the witness has no body: %s\n", at, text; bad++; next
+      }
+      sub(/^[ \t]*/, "", body)
+      if (body != prefix "CallCount += 1") {
+        printf "    line %d: the comment says `%s`, the witness counts `%s`\n", at, prefix, body
+        bad++
+      }
+      next
+    }
+    END {
+      for (k in witnessed) if (!(k in indexed)) {
+        split(k, m, SUBSEP)
+        printf "    %s: commented at the witness, missing from the index: %s\n", m[1], m[2]
+        bad++
+      }
+      for (k in indexed) if (!(k in witnessed)) {
+        split(k, m, SUBSEP)
+        printf "    %s: in the index, missing at the witness: %s\n", m[1], m[2]
+        bad++
+      }
+      exit (bad ? 1 : 0)
+    }
+  ' "$1"
+}
+
+NAMING_GENERATED="$WORK_DIR/Mocks.generated.swift"
+NAMING_COMMENTED="$(grep -cE '^[[:space:]]+// `.+` members are named `' "$NAMING_GENERATED" || true)"
+if naming_comment_violations "$NAMING_GENERATED" > "$WORK_DIR/naming-comments.log" 2>&1; then
+  echo "  $NAMING_COMMENTED renamed members, each commented at its witness and in its class's index"
+else
+  cat "$WORK_DIR/naming-comments.log"
+  fail "a naming comment does not describe the member below it"
+fi
+
+# Red controls. Without them the gate passes on a file that carries no comment
+# at all, which is the state it exists to detect.
+naming_control="$WORK_DIR/naming-control-prefix.swift"
+sed 's/members are named `endAt\*`/members are named `endsAt*`/' "$NAMING_GENERATED" > "$naming_control"
+if naming_comment_violations "$naming_control" > "$WORK_DIR/naming-control-prefix.log" 2>&1; then
+  fail "the naming-comment gate passed a comment naming a prefix the witness does not count"
+else
+  echo "  the same check fails on a comment naming the wrong prefix"
+fi
+
+naming_control_index="$WORK_DIR/naming-control-index.swift"
+grep -v '^//   `end(at:)` members are named' "$NAMING_GENERATED" > "$naming_control_index"
+if naming_comment_violations "$naming_control_index" > "$WORK_DIR/naming-control-index.log" 2>&1; then
+  fail "the naming-comment gate passed a class index missing one of its members"
+else
+  echo "  the same check fails on a class index missing one of its members"
+fi
+
+# ── 6. Typecheck, both language modes ─────────────────────────────
 typecheck() {
   local label="$1"; shift
   local log="$WORK_DIR/typecheck-$label.log"
@@ -360,7 +447,7 @@ echo "── typecheck ──"
 typecheck "swift5-complete" -swift-version 5 -strict-concurrency=complete
 typecheck "swift6" -swift-version 6
 
-# ── 6. Behaviour ──────────────────────────────────────────────────
+# ── 7. Behaviour ──────────────────────────────────────────────────
 echo ""
 echo "── behaviour ──"
 BEHAVIOUR_BIN="$WORK_DIR/behaviour"

--- a/Tests/Checks/run-checks.sh
+++ b/Tests/Checks/run-checks.sh
@@ -229,6 +229,8 @@ rm -rf "$COLLISION_DIR"
 # <case>:<protocol>:<member named in the message>
 COLLISION_CASES=(
   "bookkeeping:CollidingBookkeeping:draftSetCount"
+  "readcount:CollidingReadCount:draftGetCount"
+  "store:CollidingStore:_draft"
   "overload:CollidingOverload:sendToVoidCallCount"
 )
 
@@ -239,6 +241,28 @@ cat > "$COLLISION_DIR/bookkeeping/Bookkeeping.swift" <<'SWIFT'
 public protocol CollidingBookkeeping: AnyObject {
     var draft: String { get set }
     var draftSetCount: Int { get set }
+}
+SWIFT
+
+mkdir -p "$COLLISION_DIR/readcount"
+cat > "$COLLISION_DIR/readcount/ReadCount.swift" <<'SWIFT'
+// `<var>GetCount` is emitted for every property requirement, so a protocol that
+// declares one of its own collides where it did not before.
+/// sourcery: ProtocolMock
+public protocol CollidingReadCount: AnyObject {
+    var draft: String { get set }
+    var draftGetCount: Int { get set }
+}
+SWIFT
+
+mkdir -p "$COLLISION_DIR/store"
+cat > "$COLLISION_DIR/store/Store.swift" <<'SWIFT'
+// The backing store a property requirement's accessors sit over. A protocol may
+// declare `_draft` itself, and the mock cannot hold two.
+/// sourcery: ProtocolMock
+public protocol CollidingStore: AnyObject {
+    var draft: String { get set }
+    var _draft: String { get set }
 }
 SWIFT
 

--- a/Tests/Checks/run-checks.sh
+++ b/Tests/Checks/run-checks.sh
@@ -11,10 +11,13 @@
 #   3. near-miss  a misspelled selector fails generation naming the canonical
 #                 spelling; a misspelled option still generates and writes one
 #                 comment line
-#   4. typecheck  they compile clean together under Swift 5 + complete
+#   4. collision  two members that would carry one name fail generation naming
+#                 the protocol and the member, instead of writing a file the
+#                 consumer's compiler rejects
+#   5. typecheck  they compile clean together under Swift 5 + complete
 #                 concurrency checking, and under the Swift 6 language mode —
 #                 zero warnings, zero errors
-#   5. behaviour  they do what a consumer needs: mocks count calls, run handlers
+#   6. behaviour  they do what a consumer needs: mocks count calls, run handlers
 #                 and deliver values pushed into their subjects; Components
 #                 forward to the parent and hold what the level owns
 #
@@ -212,7 +215,67 @@ else
   fi
 fi
 
-# ── 4. Typecheck, both language modes ─────────────────────────────
+# ── 4. Collision ──────────────────────────────────────────────────
+# Each case here fails generation on purpose, so none of it can live in
+# Fixtures/ — one fixture that fails takes the whole lane's generation with it,
+# the way the near-miss selector case does. What is checked is that the failure
+# names the protocol and the member, rather than the template emitting a file
+# whose two identical declarations the consumer's compiler reports instead.
+echo ""
+echo "── collision ──"
+COLLISION_DIR="$WORK_DIR/collision"
+rm -rf "$COLLISION_DIR"
+
+# <case>:<protocol>:<member named in the message>
+COLLISION_CASES=(
+  "bookkeeping:CollidingBookkeeping:draftSetCount"
+  "overload:CollidingOverload:sendToVoidCallCount"
+)
+
+mkdir -p "$COLLISION_DIR/bookkeeping"
+cat > "$COLLISION_DIR/bookkeeping/Bookkeeping.swift" <<'SWIFT'
+// A requirement whose name is another requirement's bookkeeping member.
+/// sourcery: ProtocolMock
+public protocol CollidingBookkeeping: AnyObject {
+    var draft: String { get set }
+    var draftSetCount: Int { get set }
+}
+SWIFT
+
+mkdir -p "$COLLISION_DIR/overload"
+cat > "$COLLISION_DIR/overload/Overload.swift" <<'SWIFT'
+// Two overloads sharing their labels, their parameter count and their return
+// type, differing only in a parameter type — which no part of the name derives
+// from. The long form and the return-type discriminator both leave them equal,
+// which is step 4 of the overload chain.
+/// sourcery: ProtocolMock
+public protocol CollidingOverload: AnyObject {
+    func send(to target: String)
+    func send(to target: Int)
+}
+SWIFT
+
+for entry in "${COLLISION_CASES[@]}"; do
+  case_name="${entry%%:*}"
+  rest="${entry#*:}"
+  protocol_name="${rest%%:*}"
+  member_name="${rest##*:}"
+  log="$WORK_DIR/collision-$case_name.log"
+  if "$SOURCERY" --sources "$COLLISION_DIR/$case_name" \
+       --templates "$GIT_ROOT/templates/Mocks.swifttemplate" \
+       --output "$COLLISION_DIR/$case_name.generated.swift" \
+       --args "import=Combine,import=Foundation" \
+       --disableCache --quiet > "$log" 2>&1; then
+    fail "$case_name: a colliding member generated instead of failing"
+  elif grep -q "$protocol_name" "$log" && grep -q "$member_name" "$log"; then
+    echo "  $case_name: fails, naming $protocol_name and $member_name"
+  else
+    tail -10 "$log"
+    fail "$case_name: failed, but the message does not name $protocol_name and $member_name"
+  fi
+done
+
+# ── 5. Typecheck, both language modes ─────────────────────────────
 typecheck() {
   local label="$1"; shift
   local log="$WORK_DIR/typecheck-$label.log"
@@ -235,7 +298,7 @@ echo "── typecheck ──"
 typecheck "swift5-complete" -swift-version 5 -strict-concurrency=complete
 typecheck "swift6" -swift-version 6
 
-# ── 5. Behaviour ──────────────────────────────────────────────────
+# ── 6. Behaviour ──────────────────────────────────────────────────
 echo ""
 echo "── behaviour ──"
 BEHAVIOUR_BIN="$WORK_DIR/behaviour"

--- a/Tests/Checks/run-plugin-checks.sh
+++ b/Tests/Checks/run-plugin-checks.sh
@@ -150,7 +150,14 @@ echo "── building the fixture ──"
 if [ "$KEEP" = "0" ]; then
   # Keep the resolved dependencies and the downloaded artifact bundle; drop
   # everything the plugin produced, so the caches below really are cold.
-  rm -rf "$FIXTURE_SCRATCH/plugins/outputs"
+  #
+  # `build.db` goes with them. Deleting the outputs alone leaves llbuild's
+  # manifest naming files that are gone, and the plugin is not re-run when
+  # nothing it reads has changed — the build then fails with "missing inputs"
+  # naming the two generated files. A run that failed downstream of generation,
+  # followed by a run that changes only a fixture source, is the sequence that
+  # reaches it.
+  rm -rf "$FIXTURE_SCRATCH/plugins/outputs" "$FIXTURE_SCRATCH/build.db"
 fi
 
 BUILD_LOG="$WORK_DIR/fixture-build.log"
@@ -256,7 +263,7 @@ echo "── no-defaults ──"
 if diff -q "$FIXTURE_DIR/Sources/Verbatim/.Sourcery.Verbatim.yml" "$VERBATIM_CONFIG" > /dev/null; then
   pass "a config declaring everything comes out byte-identical"
 else
-  diff -u "$FIXTURE_DIR/Sources/Verbatim/.Sourcery.Verbatim.yml" "$VERBATIM_CONFIG" | head -20
+  diff -u "$FIXTURE_DIR/Sources/Verbatim/.Sourcery.Verbatim.yml" "$VERBATIM_CONFIG" | head -20 || true
   fail "a config declaring everything was rewritten"
 fi
 
@@ -488,16 +495,20 @@ fi
 
 BUNDLE_ROUTE_SCRATCH="$WORK_DIR/bundle-route"
 BUNDLE_ROUTE_LOG="$WORK_DIR/bundle-route.log"
+# Cold every run. The remark the gate below greps for is written while the
+# plugin runs, and a warm build does not run it, so a second invocation reported
+# a failure the fixture had not caused.
+if [ "$KEEP" = "0" ]; then rm -rf "$BUNDLE_ROUTE_SCRATCH"; fi
 if ! swift build --package-path "$BUNDLE_ROUTE_DIR" --scratch-path "$BUNDLE_ROUTE_SCRATCH" \
      "${SWIFT_FLAGS[@]}" -v > "$BUNDLE_ROUTE_LOG" 2>&1; then
-  grep -E "error:" "$BUNDLE_ROUTE_LOG" | head -10
+  grep -E "error:" "$BUNDLE_ROUTE_LOG" | head -10 || true
   fail "the bundle-route fixture did not build — a bare name did not resolve without a templates/ in the checkout"
 else
   pass "a bare template name resolves with no templates/ in the consumed checkout"
   if grep -qF "shipped templates come from the pinned artifact bundle" "$BUNDLE_ROUTE_LOG"; then
     pass "and the log names the artifact bundle as the route"
   else
-    grep -o "shipped templates come from [^\"]*" "$BUNDLE_ROUTE_LOG" | head -1
+    grep -o "shipped templates come from [^\"]*" "$BUNDLE_ROUTE_LOG" | head -1 || true
     fail "the log does not name the pinned artifact bundle as the route"
   fi
   BUNDLE_ROUTE_CONFIG="$(find "$BUNDLE_ROUTE_SCRATCH/plugins/outputs" -path "*/.sourceryConfigs/*" -type f 2>/dev/null | head -1)"

--- a/Tests/Evals/README.md
+++ b/Tests/Evals/README.md
@@ -14,6 +14,7 @@ skill and run that case again.
 | `cross-module-protocol` | a protocol declared in another module | `${SOURCERY_SOURCES}`, and another `--sources` on the CLI lane |
 | `does-not-conform` | why `PaymentsMock` does not conform to `Refunding` | the refined protocol was not among the parsed sources |
 | `publisher-hangs` | why a test awaiting the mock's publisher hangs | the backing `PassthroughSubject` does not replay |
+| `member-names` | which members a mock gives for underscored names and an overload group | the declared name verbatim; the fewest-parameter overload keeps it, the rest take their argument labels |
 
 ## Running them
 

--- a/Tests/Evals/member-names/graders/no-generated-file-needed.md
+++ b/Tests/Evals/member-names/graders/no-generated-file-needed.md
@@ -1,0 +1,5 @@
+---
+type: regex
+match: contains
+---
+perform1_0CallCount

--- a/Tests/Evals/member-names/graders/overload-names.md
+++ b/Tests/Evals/member-names/graders/overload-names.md
@@ -1,0 +1,12 @@
+---
+type: llm
+focus: last_message
+---
+The answer gives the three `end` overloads distinct prefixes and says which rule produced them: the
+overload with the fewest parameters keeps the plain name, so `end()` gives `endCallCount`, and each
+other one appends its capitalized argument label — `end(at fieldValues:)` gives `endAtCallCount` and
+`end(atDocument document:)` gives `endAtDocumentCallCount`.
+
+It fails if it appends the parameter *name* as well as the label (`endAtFieldValuesCallCount`,
+`endAtDocumentDocumentCallCount`), if it gives the plain name to an overload that is not the
+shortest, or if it says overloads cannot be distinguished.

--- a/Tests/Evals/member-names/graders/property-members.md
+++ b/Tests/Evals/member-names/graders/property-members.md
@@ -1,0 +1,10 @@
+---
+type: llm
+focus: last_message
+---
+The answer says a read-only property requirement generates a read counter and a handler too —
+`pageSizeGetCount` and `pageSizeGetHandler` for `pageSize` — and not only the `{ get set }` one, and
+names `_pageSize` (or `_setting4_2`) as the store a test seeds and reads without moving a counter.
+
+It fails if it says a read-only or a stored property generates no members, or if it offers only
+`pageSizeSetCount`.

--- a/Tests/Evals/member-names/graders/skill-fired.md
+++ b/Tests/Evals/member-names/graders/skill-fired.md
@@ -1,0 +1,7 @@
+---
+type: tool_used
+tool: Skill
+input_match: swift-sourcery-mocks
+min: 1
+arm: with-only
+---

--- a/Tests/Evals/member-names/graders/verbatim-prefix.md
+++ b/Tests/Evals/member-names/graders/verbatim-prefix.md
@@ -1,0 +1,11 @@
+---
+type: llm
+focus: last_message
+---
+The answer states that the bookkeeping prefix is the declared name, taken verbatim, and applies it:
+`perform1_0CallCount` / `perform1_0Handler` for `perform1_0()`, `IDCallCount` / `IDHandler` for
+`ID()`, and `setting4_2GetCount` / `setting4_2GetHandler` / `setting4_2SetCount` for `setting4_2`.
+
+It fails if it lowercases, camel-cases or strips the underscore from any of them —
+`perform10CallCount`, `iDCallCount` or `performCallCount` are each wrong — or if it applies one rule
+to the methods and a different one to the property.

--- a/Tests/Evals/member-names/prompt.md
+++ b/Tests/Evals/member-names/prompt.md
@@ -1,0 +1,23 @@
+---
+description: Which members a mock generates for a protocol whose names carry underscores and whose methods overload. The answer is derivable from the declarations.
+tags: [naming, authoring]
+allowed_tools: [Read, Glob, Grep, Skill]
+max_turns: 10
+expected_outcome: The prefix is the declared name verbatim — perform1_0CallCount, setting4_2GetCount, IDCallCount — and the overload that keeps the plain name is the one with the fewest parameters, the others taking their argument labels: endCallCount, endAtCallCount, endAtDocumentCallCount.
+---
+
+I am writing a test against a generated mock of this protocol and I do not have the generated file
+in front of me. Which members does the mock give me for each requirement?
+
+```swift
+/// sourcery: ProtocolMock
+protocol QueryBuilding {
+    var setting4_2: Int { get set }
+    var pageSize: Int { get }
+    func perform1_0()
+    func ID() -> String
+    func end()
+    func end(at fieldValues: [String])
+    func end(atDocument document: String)
+}
+```

--- a/Tests/Examples/ExampleProjectSpm/Sources/ExampleProjectSpmTests/SwiftSourceryTemplatesMocksSpec.swift
+++ b/Tests/Examples/ExampleProjectSpm/Sources/ExampleProjectSpmTests/SwiftSourceryTemplatesMocksSpec.swift
@@ -53,6 +53,15 @@ class SwiftSourceryTemplatesMocksSpec: QuickSpec {
           it("entityObserverEvent call count increased") {
             expect(sut.entityObserverEventCallCount) == 1
           }
+          // The count says an event arrived; the recorder says which one.
+          // Asserting the value took a handler appending into a local array
+          // before `<name>Events`, and no spec in the reference consumer did
+          // that for any member (spec 004 §1.9, D13). `Event` declares no
+          // `Equatable` conformance, so the value is read through
+          // `compactMap(\.element)` rather than compared whole.
+          it("entityObserverEvents records the element that was pushed in") {
+            expect(sut.entityObserverEvents.compactMap(\.element)) == ["next element"]
+          }
         } // context("entityObserver.on() called")
       }
     } // describe("mock with AnyObserver")

--- a/Tests/Examples/ExampleProjectSpm/Sources/ExampleProjectSpmTests/SwiftSourceryTemplatesMocksSpec.swift
+++ b/Tests/Examples/ExampleProjectSpm/Sources/ExampleProjectSpmTests/SwiftSourceryTemplatesMocksSpec.swift
@@ -94,7 +94,7 @@ class SwiftSourceryTemplatesMocksSpec: QuickSpec {
         }
       } // context("save() called")
       it("still carries the refining protocol's own requirement") {
-        sut.profileID = "abc"
+        sut._profileID = "abc"
         expect(sut.profileID) == "abc"
       }
     } // describe("mock of a protocol refining another module's protocol")

--- a/skills/swift-sourcery-mocks/SKILL.md
+++ b/skills/swift-sourcery-mocks/SKILL.md
@@ -192,17 +192,48 @@ XCTAssertEqual(service.fetchDataArgs, ["m1"])
 service.fetchDataHandler = { id, completion in completion("payload", nil) }
 ```
 
-| member | what it holds |
-| --- | --- |
-| `<method>CallCount` | how many times the requirement was called |
-| `<method>Args` | what each call was passed, in order. One recordable parameter gives `[T]`; two or more give `[(first: A, second: B)]`, labelled with the parameter names |
-| `<method>Handler` | the closure the test sets to control the return value and the side effects. `async` and `throws` are carried through to it |
-| `<var>GetCount` / `<var>GetHandler` / `<var>SetCount` | the same three for a property requirement |
-| `<method>Subject` / `<var>Subject` | the subject backing an `AnyPublisher` or an RxSwift member, which the test drives with `send` |
-| `<method>CancelCallCount` | for a method returning `AnyCancellable` or a `Disposable`: how many times the returned token was cancelled |
+**A mock member is the declared name plus a suffix.** The name is taken verbatim — no case change,
+no underscore removal — with backticks dropped: `func perform1_0()` gives `perform1_0CallCount`,
+`func ID()` gives `IDCallCount`, ``func `do`()`` gives `doCallCount`, `var setting4_2: Int` gives
+`setting4_2GetCount`.
+
+**Overloads.** The overload with the fewest parameters keeps the plain name. Each other one appends
+the capitalized argument label of every parameter, or the parameter name where there is no label —
+`func end(atDocument document:)` gives `endAtDocument`, `func putData(_ data:metadata:)` gives
+`putDataDataMetadata`. Overloads differing only in return type get a suffix from that type, and
+anything still colliding fails generation naming both members.
+
+| member | on | what it holds |
+| --- | --- | --- |
+| `<method>CallCount` | method | how many times the requirement was called |
+| `<method>Args` | method | what each call was passed, in order. One recordable parameter gives `[T]`; two or more give `[(first: A, second: B)]`, labelled with the parameter names |
+| `<method>Handler` | method | the closure the test sets to control the return value and the side effects. `async` and `throws` are carried through to it |
+| `<var>GetCount` / `<var>GetHandler` | property | every property requirement counts its reads, and the handler supplies the value |
+| `<var>SetCount` | property | writes to a `{ get set }` requirement |
+| `_<var>` | property | the stored value. Seed or read it to leave the counters where they are |
+| `<name>Subject` | both | the subject backing an `AnyPublisher` or an RxSwift member, which the test drives with `send` |
+| `<name>SubscribeCount` / `<name>SubscribeCancelCount` | both | for an `AnyPublisher` member: that the code under test subscribed, and that it cancelled |
+| `<name>OutputCount` / `<name>Outputs` / `<name>OutputHandler` | both | for an `AnyPublisher` member: the values it **delivered** — counted, recorded, handed to the handler |
+| `<name>CompletionCount` | both | for an `AnyPublisher` member: the stream finished or failed |
+| `<name>EventCallCount` / `<name>Events` / `<name>EventHandler` | both | for an `AnyObserver` member: the events pushed **in** — counted, recorded, handed to the handler |
+| `<method>CancelCallCount` / `<method>CancelHandler` | method | for a method returning `AnyCancellable`: the returned token was cancelled |
+| `<method>DisposeCallCount` / `<method>DisposeHandler` | method | for a method returning an RxSwift `Disposable`: the returned token was disposed |
+
+A returned token's suffix is the call that token exposes — `cancel()` on `AnyCancellable`,
+`dispose()` on `Disposable`.
 
 Closure parameters, a generic method's parameters and anything annotated `skipArgumentRecording` are
-not recorded — assert through the handler.
+not recorded — assert through the handler. `skipArgumentRecording` covers `<name>Outputs` and
+`<name>Events` too.
+
+**A property requirement declared `{ get async }`, `{ get throws }` or `{ get async throws }`**
+generates the accessor it declares, and `<var>GetHandler` carries the same effects. Swift has no
+effectful setter, so such a requirement has no `<var>SetCount`; seed `_<var>`.
+
+**A publisher member's handler is read when the code under test subscribes**, not when it reads the
+member — so a `<var>GetHandler` set after the publisher was captured still decides the stream.
+`<name>OutputCount` counts delivery, not sending: a value sent while nobody is subscribed goes
+nowhere and counts nothing.
 
 Return values default without a handler: `Optional` gives `nil`, `Void` gives nothing, known types
 give a usable empty value. Mock classes are `final` — set a handler rather than subclassing one.
@@ -212,7 +243,8 @@ The generated file compiles at zero diagnostics under `-swift-version 5
 mock class, `nonisolated` is carried through, and a `Sendable` protocol gets `@unchecked Sendable`.
 
 The emitted Swift for each shape, and the member map to the Kotlin twin, is
-[references/generated-api.md](references/generated-api.md).
+[references/generated-api.md](references/generated-api.md); the publisher and RxSwift shapes and
+their counters are [references/stream-members.md](references/stream-members.md).
 
 ## Publishers are subject-backed
 

--- a/skills/swift-sourcery-mocks/SKILL.md
+++ b/skills/swift-sourcery-mocks/SKILL.md
@@ -152,7 +152,7 @@ class's index. Search for either spelling.
 | `<method>Args` | method | what each call was passed, in order: `[T]` for one recordable parameter, `[(first: A, second: B)]` for more, labelled with the parameter names |
 | `<method>Handler` | method | the closure the test sets to decide the return value and the side effects; `async` and `throws` carry through to it |
 | `<var>GetCount` / `<var>GetHandler` | property | every property requirement counts its reads; the handler supplies the value |
-| `<var>SetCount` / `_<var>` | property | writes to a `{ get set }` requirement, and the stored value — seed or read `_<var>` to leave the counters where they are |
+| `<var>SetCount` / `_<var>` | property | writes to a `{ get set }` requirement, and the store — `_<var>` reads and seeds without moving a counter, and is the only way to seed a `{ get }` one |
 | `<name>Subject` | both | the subject behind an `AnyPublisher` or RxSwift member, which the test drives with `send` |
 | `<name>SubscribeCount` / `<name>SubscribeCancelCount` / `<name>CompletionCount` | both | an `AnyPublisher` member: the code under test subscribed, cancelled, saw the stream end |
 | `<name>OutputCount` / `<name>Outputs` / `<name>OutputHandler` | both | an `AnyPublisher` member: what it **delivered** — counted, recorded, handed to the handler |

--- a/skills/swift-sourcery-mocks/SKILL.md
+++ b/skills/swift-sourcery-mocks/SKILL.md
@@ -8,44 +8,26 @@ metadata:
 
 # Swift mock generation with swift-sourcery-templates
 
-Three templates, each selected by an annotation on a protocol: `Mocks` writes the mock class,
-`TypeErase` the type-erasing wrapper, `Component` the forwarding class of a dependency-injection
-tree.
+Three templates — `Mocks`, `TypeErase`, `Component` — each selected by an annotation on a protocol.
 
 ## Pick the lane first
 
 | what the repository is | lane |
 | --- | --- |
-| a SwiftPM package whose mocks compile into a test target of that same package | the build-tool plugin |
-| an Xcode project with no `Package.swift` | the same plugin, through `XcodeBuildToolPlugin`. `${SOURCERY_SOURCES}` reaches the target's own input-file directories and no further, so name every other directory in `sources:` under `${SOURCERY_PROJECT}` |
-| mocks committed to the repository, so a consumer or a cold CI job runs no generator | `mock-templates generate`, with `mock-templates validate` as the CI gate |
-| a library shipping mocks to downstream packages | `mock-templates generate`, committed. Generated mocks are `internal`, so the consumer writes `@testable import` |
+| a SwiftPM package whose mocks compile into a test target of the same package | the build-tool plugin |
+| an Xcode project with no `Package.swift` | the same plugin, through `XcodeBuildToolPlugin`; `${SOURCERY_SOURCES}` reaches the target's own input-file directories and no further, so name the others under `${SOURCERY_PROJECT}` |
+| mocks committed, so a consumer or a cold CI job runs no generator | `mock-templates generate`, with `mock-templates validate` as the CI gate |
+| a library shipping mocks downstream | `mock-templates generate`, committed. Generated mocks are `internal`, so the consumer writes `@testable import` |
 
-One lane per target: a package that generates at build time commits no generated file; a repository
-that commits them does not run the plugin.
+One lane per target: a package generating at build time commits no generated file; one that commits
+them does not run the plugin.
 
 ## Annotate the protocol
 
-```swift
-/// sourcery: ProtocolMock
-protocol DataService {
-    func fetchData(id: String, completion: @escaping (String?, Error?) -> Void)
-}
-```
-
-Several annotations on one declaration are comma-separated — `/// sourcery: ProtocolMock,
-DuetComponent` — and a value is written with `=`, as in `/// sourcery: subject = "CurrentValue"`.
-
-**A protocol you do not own** is annotated through an empty extension, in a directory of its own
-that the generation config also scans:
-
-```swift
-// SourceryAnnotations/ExternalFramework+Mocks.swift
-import ExternalFramework
-
-/// sourcery: ProtocolMock
-extension ExternalProtocol {}
-```
+`/// sourcery: ProtocolMock` above `protocol DataService { … }` is the whole of it. Several
+annotations on one declaration are comma-separated — `/// sourcery: ProtocolMock, DuetComponent` —
+and a value is written with `=`: `/// sourcery: subject = "CurrentValue"`. **A protocol you do not
+own** is annotated from an empty `extension ExternalProtocol {}`, in a directory the config scans.
 
 <!-- annotations:start -->
 <!-- Rendered from templates/Annotations/AnnotationRegistry.swift by Scripts/render-annotations.sh. Do not edit inside this block. -->
@@ -75,9 +57,8 @@ Annotation names are matched exactly, including case.
 | `componentAccess = "public"` | Protocol | Emit a `public` Component; the default is internal |
 <!-- annotations:end -->
 
-The legacy spellings `CreateMock`, `ObjcProtocol` and `TypeErase` still select the same templates;
-write the table's names in new code, because a release after the current one stops accepting them
-and generation then fails naming the replacement.
+`CreateMock`, `ObjcProtocol` and `TypeErase` still select the same templates, but write the table's
+names in new code: a later release stops accepting them.
 [references/writing-testable-protocols.md](references/writing-testable-protocols.md) has what to
 annotate, the shapes that generate well, and the isolation a mock restates.
 
@@ -87,23 +68,14 @@ annotate, the shapes that generate well, and the isolation a mock restates.
    `git ls-remote --tags https://github.com/modaal-agent/swift-sourcery-templates.git | tail -1`:
 
 ```swift
-dependencies: [
-    .package(url: "https://github.com/modaal-agent/swift-sourcery-templates.git", from: "<newest tag>"),
-],
-targets: [
-    .testTarget(
-        name: "MyModuleTests",
-        dependencies: [.target(name: "MyModule")],
-        plugins: [.plugin(name: "SourcerySwiftCodegenPlugin", package: "swift-sourcery-templates")]
-    ),
-]
+.package(url: "https://github.com/modaal-agent/swift-sourcery-templates.git", from: "<newest tag>"),
+// and on every target that generates:
+plugins: [.plugin(name: "SourcerySwiftCodegenPlugin", package: "swift-sourcery-templates")]
 ```
 
-2. Put a `*.sourcery*.yml` config in the source directory of every target that generates — three
-   lines is enough:
+2. Put a `*.sourcery*.yml` config in the source directory of every generating target — three lines:
 
 ```yml
-# Sources/MyModuleTests/.Sourcery.Mocks.yml
 templates:
   - Mocks
 ```
@@ -111,82 +83,50 @@ templates:
 The plugin fills in the sources, the output directory the build collects from, and — for a test
 target with exactly one direct dependency on a module of the same package — `args.testable`.
 
-3. Build. The plugin logs every exported variable, every default it supplied and every template
-   name it resolved.
+3. Build. The plugin logs every variable it exported, every default it supplied and every template
+   it resolved.
 
-**Reading beyond the target.** `${SOURCERY_SOURCES}` expands to the target's own sources plus the
-recursive closure of its dependencies, one directory per module, so a mock carries requirements its
-protocol inherits further down the graph:
+**Reading beyond the target.** `${SOURCERY_SOURCES}` is the target's own sources plus the recursive
+closure of its dependencies, so a mock carries requirements inherited further down the graph. Write
+it under `sources:`, with any further directory beside it, such as
+`${SOURCERY_TARGET_MyModuleTests}/SourceryAnnotations`. A list without it is scanned as written.
 
-```yml
-templates:
-  - Mocks
-sources:
-  - ${SOURCERY_SOURCES}
-  - ${SOURCERY_TARGET_MyModuleTests}/SourceryAnnotations
-```
+**Where it writes.** Omit `output:`, or write `${SOURCERY_OUTPUT_DIR}`. Any other directory fails the
+build: a prebuild command's outputs are collected only from the one it declared.
 
-A `sources:` list without the placeholder is scanned exactly as written.
-
-**Where it writes.** Omit `output:`, or write `output: ${SOURCERY_OUTPUT_DIR}`. Any other directory
-fails the build: a prebuild command's outputs are collected only from the directory it declared.
+**Finding what it wrote.** The generated file is a build product, not a file in the repository:
+`find .build -path '*/SourcerySwiftCodegenPlugin/.generatedFiles/*' -name '*.generated.swift'`. An
+Xcode project's build root is derived data rather than `.build`.
 
 **Naming a template.** A `templates:` entry may be the bare name of a shipped template — `Mocks`,
-`TypeErase`, `Component` — and Sourcery writes one `<Template>.generated.swift` per entry.
-
-Everything else is carried through unread, and every path the config writes must be absolute: the
-plugin runs a copy of it from its own work directory.
+`TypeErase`, `Component` — one `<Template>.generated.swift` per entry. The rest of the config is
+carried through unread, and every path it writes must be absolute: the plugin runs a copy from its
+own work directory.
 [references/spm-plugin.md](references/spm-plugin.md) has the exported variables, the resolution order
-for a template name, and Xcode.
+for a template name, Xcode, and how to find the output there.
 
 ## The CLI lane
 
-`mock-templates generate` writes the output under a fingerprint block naming the bundle tag, the
-config, the path and SHA-256 of every scanned source, and the SHA-256 of the generated body.
-`validate` re-hashes all of it without running the generator, so a cold CI job proves the committed
-files current in seconds.
+`mock-templates generate` writes the output under a fingerprint block — the bundle tag, the config,
+the path and SHA-256 of every scanned source, and the SHA-256 of the body. `validate` re-hashes it
+without running the generator, so a cold CI job proves the files current in seconds. The CLI ships in
+the release artifact bundle with the engine and `templates/`, all at one tag;
+[references/cli-lane.md](references/cli-lane.md) has the download, every flag and `imprint`.
 
-`mock-templates` ships in the release artifact bundle with the generator engine and `templates/`,
-all at one tag. [references/cli-lane.md](references/cli-lane.md) has the download, every flag and
-`imprint`.
+Generate one output file per module, in a script the repository commits. `generate` takes
+`--sourcery` and `--templates` from the unpacked bundle, one or more `--sources`, `--args`,
+`--bundle-version`, `--root "$(pwd)"` and `--output`; `cli-lane.md` above has the loop to copy.
 
-Generate one output file per module, in a script the repository commits:
-
-```bash
-VERSION=<newest tag>
-BUNDLE="swift-sourcery-templates-$VERSION.artifactbundle"
-"$BUNDLE/mock-templates/bin/mock-templates" generate \
-  --sourcery "$BUNDLE/sourcery/bin/sourcery" \
-  --templates "$BUNDLE/templates/Mocks.swifttemplate" \
-  --sources Sources/MyModule \
-  --sources SourceryAnnotations \
-  --args "import=Foundation,testable=MyModule" \
-  --bundle-version "$VERSION" \
-  --root "$(pwd)" \
-  --output Tests/MyModuleTests/Generated/MyModuleMocks.swift
-```
-
-Gate it in CI with the CLI alone, which needs no engine download:
-
-```bash
-mock-templates validate \
-  --file Tests/MyModuleTests/Generated/MyModuleMocks.swift \
-  --root "$(pwd)" \
-  --sources Sources/MyModule \
-  --sources SourceryAnnotations \
-  --template Mocks.swifttemplate \
-  --args "import=Foundation,testable=MyModule"
-```
-
-`validate` fails on an input that changed, went missing or was added, on a hand-edited body, and —
-with `--template` and `--args` — on a config that no longer matches the one that generated the file.
+Gate it in CI with `mock-templates validate`, which needs no engine download: `--file` the generated
+file, `--root "$(pwd)"`, and the same `--sources`, `--template` and `--args`. It fails on an input
+that changed, went missing or was added, on a hand-edited body, and — given `--template` and
+`--args` — on a config that no longer matches.
 
 ## What the generated mock gives a test
 
 ```swift
 let service = DataServiceMock()
 sut.load(id: "m1")
-
 XCTAssertEqual(service.fetchDataCallCount, 1)
 XCTAssertEqual(service.fetchDataArgs, ["m1"])
 service.fetchDataHandler = { id, completion in completion("payload", nil) }
@@ -194,89 +134,75 @@ service.fetchDataHandler = { id, completion in completion("payload", nil) }
 
 **A mock member is the declared name plus a suffix.** The name is taken verbatim — no case change,
 no underscore removal — with backticks dropped: `func perform1_0()` gives `perform1_0CallCount`,
-`func ID()` gives `IDCallCount`, ``func `do`()`` gives `doCallCount`, `var setting4_2: Int` gives
-`setting4_2GetCount`.
+``func `do`()`` gives `doCallCount`, `var setting4_2: Int` gives `setting4_2GetCount`.
 
-**Overloads.** The overload with the fewest parameters keeps the plain name. Each other one appends
-the capitalized argument label of every parameter, or the parameter name where there is no label —
-`func end(atDocument document:)` gives `endAtDocument`, `func putData(_ data:metadata:)` gives
-`putDataDataMetadata`. Overloads differing only in return type get a suffix from that type, and
-anything still colliding fails generation naming both members.
+**Overloads.** The one with the fewest parameters keeps the plain name; each other appends the
+capitalized argument label of every parameter, or the parameter name where there is no label —
+`func end(atDocument document:)` gives `endAtDocument`. Overloads differing only in return type get
+a suffix from that type, and anything still colliding fails generation naming both members.
+
+**The generated file names the ones it did not derive.** It states the rule at the top and under
+every `// MARK:`, and a member whose prefix is not its declared name carries ``// `end(at:)` members
+are named `endAt*` — overload of `end`, argument labels appended`` above the witness and in its
+class's index. Search for either spelling.
 
 | member | on | what it holds |
 | --- | --- | --- |
 | `<method>CallCount` | method | how many times the requirement was called |
-| `<method>Args` | method | what each call was passed, in order. One recordable parameter gives `[T]`; two or more give `[(first: A, second: B)]`, labelled with the parameter names |
-| `<method>Handler` | method | the closure the test sets to control the return value and the side effects. `async` and `throws` are carried through to it |
-| `<var>GetCount` / `<var>GetHandler` | property | every property requirement counts its reads, and the handler supplies the value |
-| `<var>SetCount` | property | writes to a `{ get set }` requirement |
-| `_<var>` | property | the stored value. Seed or read it to leave the counters where they are |
-| `<name>Subject` | both | the subject backing an `AnyPublisher` or an RxSwift member, which the test drives with `send` |
-| `<name>SubscribeCount` / `<name>SubscribeCancelCount` | both | for an `AnyPublisher` member: that the code under test subscribed, and that it cancelled |
-| `<name>OutputCount` / `<name>Outputs` / `<name>OutputHandler` | both | for an `AnyPublisher` member: the values it **delivered** — counted, recorded, handed to the handler |
-| `<name>CompletionCount` | both | for an `AnyPublisher` member: the stream finished or failed |
-| `<name>EventCallCount` / `<name>Events` / `<name>EventHandler` | both | for an `AnyObserver` member: the events pushed **in** — counted, recorded, handed to the handler |
-| `<method>CancelCallCount` / `<method>CancelHandler` | method | for a method returning `AnyCancellable`: the returned token was cancelled |
-| `<method>DisposeCallCount` / `<method>DisposeHandler` | method | for a method returning an RxSwift `Disposable`: the returned token was disposed |
+| `<method>Args` | method | what each call was passed, in order: `[T]` for one recordable parameter, `[(first: A, second: B)]` for more, labelled with the parameter names |
+| `<method>Handler` | method | the closure the test sets to decide the return value and the side effects; `async` and `throws` carry through to it |
+| `<var>GetCount` / `<var>GetHandler` | property | every property requirement counts its reads; the handler supplies the value |
+| `<var>SetCount` / `_<var>` | property | writes to a `{ get set }` requirement, and the stored value — seed or read `_<var>` to leave the counters where they are |
+| `<name>Subject` | both | the subject behind an `AnyPublisher` or RxSwift member, which the test drives with `send` |
+| `<name>SubscribeCount` / `<name>SubscribeCancelCount` / `<name>CompletionCount` | both | an `AnyPublisher` member: the code under test subscribed, cancelled, saw the stream end |
+| `<name>OutputCount` / `<name>Outputs` / `<name>OutputHandler` | both | an `AnyPublisher` member: what it **delivered** — counted, recorded, handed to the handler |
+| `<name>EventCallCount` / `<name>Events` / `<name>EventHandler` | both | an `AnyObserver` member: the events pushed **in**, the same three ways |
+| `<method>CancelCallCount` / `<method>CancelHandler`, `<method>DisposeCallCount` / `<method>DisposeHandler` | method | the returned `AnyCancellable` was cancelled, or the returned RxSwift `Disposable` disposed |
 
-A returned token's suffix is the call that token exposes — `cancel()` on `AnyCancellable`,
-`dispose()` on `Disposable`.
+A returned token's suffix is the call it exposes: `cancel()`, `dispose()`. Closure parameters, a
+generic method's parameters and anything `skipArgumentRecording` covers are not recorded — assert
+through the handler; that annotation drops `<name>Outputs` and `<name>Events` too.
 
-Closure parameters, a generic method's parameters and anything annotated `skipArgumentRecording` are
-not recorded — assert through the handler. `skipArgumentRecording` covers `<name>Outputs` and
-`<name>Events` too.
+**A property declared `{ get async }`, `{ get throws }` or `{ get async throws }`** generates the
+accessor it declares, and `<var>GetHandler` carries the same effects. Swift has no effectful setter,
+so it has no `<var>SetCount`; seed `_<var>`. A member with no handler set returns a default — `nil`
+for an `Optional`, a usable empty value for a known type. Mock classes are `final`: set a handler
+rather than subclassing one.
 
-**A property requirement declared `{ get async }`, `{ get throws }` or `{ get async throws }`**
-generates the accessor it declares, and `<var>GetHandler` carries the same effects. Swift has no
-effectful setter, so such a requirement has no `<var>SetCount`; seed `_<var>`.
-
-**A publisher member's handler is read when the code under test subscribes**, not when it reads the
-member — so a `<var>GetHandler` set after the publisher was captured still decides the stream.
-`<name>OutputCount` counts delivery, not sending: a value sent while nobody is subscribed goes
-nowhere and counts nothing.
-
-Return values default without a handler: `Optional` gives `nil`, `Void` gives nothing, known types
-give a usable empty value. Mock classes are `final` — set a handler rather than subclassing one.
-
-The generated file compiles at zero diagnostics under `-swift-version 5
--strict-concurrency=complete` and under `-swift-version 6`: the protocol's global actor lands on the
-mock class, `nonisolated` is carried through, and a `Sendable` protocol gets `@unchecked Sendable`.
-
-The emitted Swift for each shape, and the member map to the Kotlin twin, is
-[references/generated-api.md](references/generated-api.md); the publisher and RxSwift shapes and
-their counters are [references/stream-members.md](references/stream-members.md).
-
-## Publishers are subject-backed
-
-An `AnyPublisher` requirement, on a property or a method, is generated with a subject the test sends
-into, named `<var>Subject` or `<method>Subject`:
+**Drive a publisher member through its subject:**
 
 ```swift
-let repo = MemoryRepositoryMock()
-var received: [[MemoryDrop]] = []
-let token = repo.ownMemories.sink { received.append($0) }   // subscribe first
-repo.ownMemoriesSubject.send([drop])                        // then send
+let token = repo.ownMemories.sink { received.append($0) }  // subscribe first
+repo.ownMemoriesSubject.send([drop])                       // then send
 ```
 
-The default is a `PassthroughSubject`, which delivers nothing to a subscriber that arrives after the
-value was sent, so a test that seeds in `setUp` and subscribes in the body waits. To make the member
-replay, annotate it `subject = "CurrentValue"` — a `CurrentValueSubject` seeded with the `Output`'s
-default value — or return a publisher of your own from `<var>GetHandler`. A test that collects to the
-end also has to `send(completion: .finished)`.
+The default `PassthroughSubject` delivers nothing to a subscriber that arrives after the value was
+sent, so subscribe first or annotate the member `subject = "CurrentValue"` to replay one; a test
+collecting to the end also has to `send(completion: .finished)`.
+
+[references/generated-api.md](references/generated-api.md) has the emitted Swift for each shape and
+the Kotlin member map; [references/stream-members.md](references/stream-members.md) the publisher and
+RxSwift shapes, their counters, and when each handler is read.
 
 ## When it goes wrong
 
-| symptom | cause | action |
-| --- | --- | --- |
-| `type 'XMock' does not conform to protocol 'Y'` | the refined protocol was not among the parsed sources | plugin: put `- ${SOURCERY_SOURCES}` in `sources:`. CLI: add the other module's directory as another `--sources` |
-| the target compiles and a generated type is missing | `output:` named a directory the build does not collect from | omit `output:`, or write `${SOURCERY_OUTPUT_DIR}` |
-| `'createmock' on 'Foo' is not 'ProtocolMock'` | the spelling differs from the registry's only in case | spell it exactly — matching includes case |
-| a protocol generates no mock and nothing is reported | the declaration carries no selector, or the file is not under any scanned source root | annotate it, or add its directory to the sources |
-| the generator will not run — unidentified developer | the downloaded engine binary is quarantined | `xattr -dr com.apple.quarantine <artifact bundle>/sourcery/bin/sourcery` |
-| a Combine test hangs, or a continuation resumes twice | a `PassthroughSubject`-backed `AnyPublisher` member does not replay | subscribe before sending, or annotate `subject = "CurrentValue"` |
-| `<method>Args` does not exist | every parameter is a closure, the method is generic, or `skipArgumentRecording` is on the method or its protocol | assert through `<method>Handler` |
-| a Component fails generation naming a member | `static`, `init` and `subscript` requirements and associated types cannot be forwarded | hand-write that member, or annotate `DuetComponent, owns` and write the subclass |
-| the Swift 6 test body is rejected | calling a `nonisolated async` member of a non-Sendable mock from the main actor crosses an isolation boundary | make the test body non-isolated |
+- `type 'XMock' does not conform to protocol 'Y'` — the refined protocol was not parsed. Plugin:
+  `- ${SOURCERY_SOURCES}` in `sources:`. CLI: the other module's directory as another `--sources`.
+- the target compiles and a generated type is missing — `output:` named a directory the build does
+  not collect from. Omit it, or write `${SOURCERY_OUTPUT_DIR}`.
+- `'createmock' on 'Foo' is not 'ProtocolMock'` — spelling is matched including case.
+- a protocol generates no mock and nothing is reported — no selector on the declaration, or the file
+  is under no scanned source root.
+- the generator will not run, unidentified developer — the engine binary is quarantined:
+  `xattr -dr com.apple.quarantine <bundle>/sourcery/bin/sourcery`.
+- a Combine test hangs, or a continuation resumes twice — a `PassthroughSubject`-backed member does
+  not replay. Subscribe before sending, or annotate `subject = "CurrentValue"`.
+- `<method>Args` does not exist — every parameter is a closure, the method is generic, or
+  `skipArgumentRecording` covers it. Assert through `<method>Handler`.
+- a Component fails generation naming a member — `static`, `init`, `subscript` and associated types
+  cannot be forwarded. Hand-write it, or annotate `DuetComponent, owns` and write the subclass.
+- the Swift 6 test body is rejected — calling a `nonisolated async` member of a non-Sendable mock
+  from the main actor crosses isolation. Make the test body non-isolated.
 
-[references/troubleshooting.md](references/troubleshooting.md) has each of these in full, with the
-diagnostic text to match against.
+[references/troubleshooting.md](references/troubleshooting.md) has each in full, with the diagnostic
+text.

--- a/skills/swift-sourcery-mocks/SKILL.md
+++ b/skills/swift-sourcery-mocks/SKILL.md
@@ -69,7 +69,7 @@ Annotation names are matched exactly, including case.
 | `globalActor = "MyIsolation"` | Protocol | Declare the mock's global actor when the attribute name does not end in `Actor` |
 | `uncheckedSendable` | Protocol | Force `@unchecked Sendable` on the mock when the `Sendable` refinement is not visible to Sourcery |
 | `subject = "CurrentValue"` | Variable / method | Choose the subject backing an `AnyPublisher` member — `CurrentValue` or `Passthrough` |
-| `skipArgumentRecording` | Protocol / method | Do not generate `<method>Args`; call counting and the handler are unaffected |
+| `skipArgumentRecording` | Protocol / method / variable | Do not generate `<method>Args`, `<name>Outputs` or `<name>Events`; counting and the handlers are unaffected |
 | `owns` | Protocol | Emit `<X>ComponentBase` (non-final) for a hand-written subclass that holds what the level owns |
 | `componentName = "Foo"` | Protocol | Name the emitted Component `Foo` instead of deriving it from the protocol |
 | `componentAccess = "public"` | Protocol | Emit a `public` Component; the default is internal |

--- a/skills/swift-sourcery-mocks/references/generated-api.md
+++ b/skills/swift-sourcery-mocks/references/generated-api.md
@@ -130,9 +130,8 @@ var _draft: String = ""
 
 `_<var>` is what a test seeds and reads without moving a counter, and for a `{ get }` requirement it
 is the only way to seed one: the witness is get-only, as the requirement is, and `<var>SetCount` is
-emitted for a `{ get set }` requirement only. `mock._<var> = value` is the same expression on the
-Kotlin side. A requirement with no synthesizable default is an initializer parameter, keeps its name
-there, and seeding it at construction moves no counter.
+emitted for a `{ get set }` requirement only. A requirement with no synthesizable default is an
+initializer parameter, keeps its name there, and seeding it at construction moves no counter.
 
 `/// sourcery: const` makes the store a `let`, fixed at construction. `/// sourcery: handler` drops
 the store: the getter runs `<var>GetHandler` and traps with that string when the test set none.
@@ -228,9 +227,11 @@ table with the columns the other way round.
 | `<method>CallCount` | `<fn>CallCount` |
 | `<method>Args` | `<fn>Args`, elements of a nested `<Fn>Args` data class rather than a tuple |
 | `<method>Handler` | `<fn>Handler` |
-| `<var>GetCount`, `<var>GetHandler` | `<prop>GetCount`, `<prop>GetHandler` — on a `Flow` property only |
-| `<var>SetCount` | `<prop>SetCount` |
-| `<name>Subject` for an `AnyPublisher` member | `<fn>Channel` for a `Flow` member |
+| `<var>GetCount`, `<var>GetHandler` | `<prop>GetCount`, `<prop>GetHandler`, on every property |
+| `<var>SetCount` | `<prop>SetCount`, on a `var` requirement |
+| `_<var>` | `_<prop>` — the store a test seeds and reads without moving a counter, and the only way to seed a read-only requirement on either side |
+| `<name>Subject` for an `AnyPublisher` member, broadcast to every subscriber | `<fn>Channel` for a `Flow` member, single-consumer |
+| `<name>SubscribeCount`, `<name>SubscribeCancelCount`, `<name>OutputCount`, `<name>Outputs`, `<name>OutputHandler`, `<name>CompletionCount` | the same six, on a `Flow`-returning function or a read-only `Flow` property |
 | `fatalError("<method>Handler expected to be set.")` | the same string, thrown as `IllegalStateException` |
 | the initializer-seeded bag | the constructor-seeded bag |
 
@@ -238,12 +239,11 @@ Members with no counterpart there — the rows to check before assuming the dial
 
 | this side | Kotlin |
 | --- | --- |
-| `<var>GetCount` / `<var>GetHandler` / `_<var>` on **every** property | a stored property has `SetCount` alone; no read counter, no handler, no store |
-| `<name>SubscribeCount`, `<name>SubscribeCancelCount`, `<name>OutputCount`, `<name>Outputs`, `<name>OutputHandler`, `<name>CompletionCount` | none — a `Flow` property is the channel, unwrapped |
+| a method whose `<method>Handler` supplies the publisher — its subscribe, output and completion counters stay at zero | that processor wraps a handler-supplied `Flow`, so the counters move |
 | `<name>EventCallCount` / `<name>Events` / `<name>EventHandler` for an `AnyObserver` member | none — a sink-shaped requirement reaches no branch there |
 | `<method>CancelCallCount`, `<method>DisposeCallCount` | none |
 | the per-declaration annotations | none — that processor selects targets in the build script |
 
-Both property getters now trap with the same sentence as both method forms,
+Both property getters trap with the same sentence as both method forms,
 `<name>GetHandler expected to be set.` The names, the subject-backed stream shape and that string are
 shared deliberately: renaming one is a change to both generators, not a local refactor.

--- a/skills/swift-sourcery-mocks/references/generated-api.md
+++ b/skills/swift-sourcery-mocks/references/generated-api.md
@@ -10,8 +10,9 @@ backticks dropped and nothing else changed: `func perform1_0()` gives `perform1_
 
 ## The file
 
-A generated file opens with a `// Generated using Sourcery` banner and `// DO NOT EDIT`, then the
-imports the parsed sources needed, then one class per annotated protocol:
+A generated file opens with a `// Generated using Sourcery` banner and `// DO NOT EDIT`, the imports
+the parsed sources needed, and a comment block stating how members are named. Then one class per
+annotated protocol:
 
 ```swift
 final class DataServiceMock: DataService {
@@ -203,8 +204,8 @@ Adding a wider overload later therefore does not rename members an existing test
 **The requirement set includes what the protocol inherits, so a refinement can move a name.** A
 protocol declaring `func data() -> [String: Any]?` keeps `dataCallCount`; one refining it and
 overriding the return type has two requirements, and both take step 3's suffix —
-`dataStringAnyOptionalCallCount` and `dataStringAnyCallCount`. Nothing in either declaration says
-so; `/// sourcery: methodName = "customName"` is how a member's name is pinned.
+`dataStringAnyOptionalCallCount` and `dataStringAnyCallCount`. Neither declaration says so; the
+generated file does, above the witness. `/// sourcery: methodName = "customName"` pins a name.
 
 ## What is not recorded
 
@@ -214,8 +215,7 @@ so; `/// sourcery: methodName = "customName"` is how a member's name is pinned.
 - the method is generic — a stored property can only name the class's generic parameters;
 - `skipArgumentRecording` is on the method, or on the protocol, which applies it to every method.
 
-A method with no parameters gets no `<method>Args` either. Symptoms and fixes are in
-[troubleshooting.md](troubleshooting.md).
+A method with no parameters gets none either. See [troubleshooting.md](troubleshooting.md).
 
 ## The same vocabulary in the Kotlin twin
 

--- a/skills/swift-sourcery-mocks/references/generated-api.md
+++ b/skills/swift-sourcery-mocks/references/generated-api.md
@@ -3,6 +3,11 @@
 Every snippet below is the Swift the templates emit, copied from a generated file. It is what a test
 writes against, so the names and the fallbacks here are the ones to assert on.
 
+**The rule, in one sentence: a mock member is the declared name plus a suffix.** Verbatim, with
+backticks dropped and nothing else changed: `func perform1_0()` gives `perform1_0CallCount`,
+`func ID()` gives `IDCallCount`, ``func `do`()`` gives `doCallCount`, `var setting4_2: Int` gives
+`setting4_2GetCount`. An overload is the one case where the name is not the declaration, below.
+
 ## The file
 
 A generated file opens with a `// Generated using Sourcery` banner and `// DO NOT EDIT`, then the
@@ -83,79 +88,80 @@ var uploadHandler: ((_ fileName: String) async throws -> (URL))? = nil
 | any `Optional` | `nil` |
 | `Array`, `Dictionary`, `Set`, a tuple of defaultable types | `[]`, `[:]`, `Set()`, the element-wise default |
 | `String`, `Bool`, the integer and floating-point types, `TimeInterval`, `CGFloat`, `CGPoint`, `CGSize`, `CGRect` | `""`, `false`, `0`, `0.0`, `CGFloat(0)`, `.zero` |
-| `AnyPublisher<Output, Failure>`, and the RxSwift stream types | the member's own subject, erased — see below |
-| `AnyCancellable` or `Disposable` | a token that counts its own cancellation |
+| `AnyPublisher<Output, Failure>`, and the RxSwift stream types | a construct over the member's own subject — see [stream-members.md](stream-members.md) |
+| `AnyCancellable` | a token that counts its own `cancel()` |
+| `Disposable` | a token that counts its own `dispose()` |
 | anything else | `fatalError("<method>Handler expected to be set.")` |
 
 A method whose return type is in the last row is the one to seed before the call. `<method>CallCount`
 and `<method>Args` are recorded first, so the arguments of the call that trapped are readable in the
 debugger.
 
-## Publisher members
+## Stream members
 
-An `AnyPublisher` requirement is backed by a subject the test sends into. On a property:
-
-```swift
-var ownMemories: AnyPublisher<[MemoryDrop], Never> {
-    ownMemoriesGetCount += 1
-    if let handler = ownMemoriesGetHandler {
-        return handler()
-    }
-    return ownMemoriesSubject.eraseToAnyPublisher()
-}
-var ownMemoriesGetCount: Int = 0
-var ownMemoriesGetHandler: (() -> AnyPublisher<[MemoryDrop], Never>)? = nil
-lazy var ownMemoriesSubject = PassthroughSubject<[MemoryDrop], Never>()
-```
-
-On a method the same subject sits behind `<method>Handler`, as `<method>Subject`. The default is a
-`PassthroughSubject`, which delivers nothing to a subscriber that arrives after the value was sent,
-and the erased publisher finishes only when the test sends a completion:
-
-```swift
-mock.ownMemoriesSubject.send([drop])
-mock.ownMemoriesSubject.send(completion: .finished)
-```
-
-`/// sourcery: subject = "CurrentValue"` on the requirement makes it a `CurrentValueSubject` seeded
-with the `Output`'s default value, which replays that value to a late subscriber. An `Output` with no
-default value fails generation naming the member, because a `CurrentValueSubject` has to be seeded;
-set `<name>GetHandler` to a stream that replays instead.
-
-An RxSwift `Observable`, `Single` or `AnyObserver` member takes the same shape, backed by a
-`PublishSubject` under the same `<name>Subject` name.
+An `AnyPublisher` member hands back a construct the mock owns over a subject the test sends into and
+counts what crossed it — `<name>SubscribeCount`, `<name>OutputCount`, `<name>Outputs`,
+`<name>CompletionCount`, `<name>SubscribeCancelCount`; an `AnyObserver` member counts and records
+what the code under test pushed in. The emitted Swift and the RxSwift shapes are in
+[stream-members.md](stream-members.md).
 
 ## Properties
 
+Every property requirement is accessors over a store named `_<var>`, and every read is counted:
+
 ```swift
-// var requirement: stored, and writes are counted. Construction does not count.
-var draft: String = "" {
-    didSet {
+var draft: String {
+    get {
+        draftGetCount += 1
+        if let handler = draftGetHandler { return handler() }
+        return _draft
+    }
+    set {
         draftSetCount += 1
+        _draft = newValue
     }
 }
+var draftGetCount: Int = 0
+var draftGetHandler: (() -> String)? = nil
 var draftSetCount: Int = 0
-
-// read-only requirement with a default value: a var a test can re-seed.
-var identifier: String = ""
-
-// read-only requirement without one: a stored property and an initializer parameter.
-var analytics: AnalyticsTracking
-init(analytics: AnalyticsTracking, memoryRepository: MemoryRepositoryProtocol) { … }
+var _draft: String = ""
 ```
 
-There is no `<var>GetCount` for a stored property — a read of a stored `var` is not counted; the
-counted form is the computed one publisher members and effectful requirements take. A protocol of
-properties alone therefore generates an initializer-seeded bag, and adding a requirement without a
-default value to it breaks every construction of the mock at compile time.
+`_<var>` is what a test seeds and reads when it does not want to move a counter. `<var>SetCount` is
+emitted for a `{ get set }` requirement only — a read-only requirement's witness is still settable,
+and re-seeding it counts nothing, as it always did. A requirement with no synthesizable default is
+an initializer parameter, keeps its own name there, and seeding it at construction moves no counter.
 
-Under a `@MainActor` protocol, a `nonisolated` member's storage is declared `nonisolated(unsafe)`,
-because a nonisolated member cannot mutate main-actor isolated storage.
+`/// sourcery: const` makes the store a `let` and the witness get-only. `/// sourcery: handler` drops
+the store: the getter runs `<var>GetHandler` and traps with `<var>GetHandler expected to be set.`
+when the test set none.
+
+An effectful requirement generates the accessor it declares, and its handler carries the same
+effects:
+
+```swift
+var config: Config {
+    get async throws {
+        configGetCount += 1
+        if let handler = configGetHandler { return try await handler() }
+        return _config
+    }
+}
+var configGetHandler: (() async throws -> Config)? = nil
+var _config: Config
+```
+
+Swift has no effectful setter, so such a requirement has no `<var>SetCount`; `_<var>` stays
+assignable. A requirement declared `throws(SomeError)` fails generation naming the member: the mock
+writes bare `throws`, which does not satisfy it.
+
+Under a `@MainActor` protocol, a `nonisolated` member's store and counters are declared
+`nonisolated(unsafe)`, because a nonisolated member cannot mutate main-actor isolated storage.
 
 ## Cancellation tokens
 
-A method returning `AnyCancellable` or an RxSwift `Disposable` records the cancellation as well as
-the call:
+A method returning `AnyCancellable` or an RxSwift `Disposable` records the release as well as the
+call. The suffix is the call the returned token exposes, so the two frameworks keep their own word:
 
 ```swift
 func registerURLHandler(_ tag: String, priority: Int) -> AnyCancellable {
@@ -169,23 +175,36 @@ var registerURLHandlerCancelCallCount: Int = 0
 var registerURLHandlerCancelHandler: (() -> ())? = nil
 ```
 
-A test asserts that the caller released the registration by reading `<method>CancelCallCount`. The
-count belongs to the mock, not to the token, so it survives the token going out of scope.
+A `Disposable`-returning method gets `<method>DisposeCallCount` and `<method>DisposeHandler` the same
+way. The count belongs to the mock, not to the token, so it survives the token going out of scope.
 
 ## Overloads
 
-Overloads would collide on the shared bookkeeping names. The overload with the fewest parameters
-keeps the plain name; each other overload appends its parameter labels and names, capitalized:
+Overloads would collide on the shared bookkeeping names, so the chain below runs over the mock's
+whole requirement set — **inherited requirements included**.
+
+1. The overload with the fewest parameters keeps the plain name.
+2. Every other one appends, per parameter in declaration order, the capitalized **argument label**,
+   or the capitalized parameter name where the parameter has no label.
+3. If that still collides, every overload in the group takes the step-2 form plus a suffix derived
+   from its return type.
+4. If a collision survives step 3, generation fails naming both members.
 
 ```swift
 func update(id: String)                → updateCallCount, updateArgs, updateHandler
-func update(id: String, force: Bool)   → updateIdForceCallCount, updateIdForceArgs, updateIdForceHandler
+func update(id: String, force: Bool)   → updateIdForceCallCount, …
+func end(atDocument document: String)  → endAtDocumentCallCount, …   // the label, not label + name
+func end(at fieldValues: [String])     → endAtCallCount, …
+func putData(_ data: Data, metadata: M) → putDataDataMetadataCallCount, …   // no label: the name
 ```
 
-Adding a wider overload later therefore does not rename the members an existing test already uses.
-Two overloads with the same number of parameters take the long form on both sides, and overloads
-differing only in return type get a suffix derived from that type. `methodName = "customName"` on a
-method names its members outright.
+Adding a wider overload later therefore does not rename members an existing test uses.
+
+**The requirement set includes what the protocol inherits, so a refinement can move a name.** A
+protocol declaring `func data() -> [String: Any]?` keeps `dataCallCount`; one refining it and
+overriding the return type has two requirements, and both take step 3's suffix —
+`dataStringAnyOptionalCallCount` and `dataStringAnyCallCount`. Nothing in either declaration says
+so; `/// sourcery: methodName = "customName"` is how a member's name is pinned.
 
 ## What is not recorded
 
@@ -209,16 +228,22 @@ table with the columns the other way round.
 | `<method>CallCount` | `<fn>CallCount` |
 | `<method>Args` | `<fn>Args`, elements of a nested `<Fn>Args` data class rather than a tuple |
 | `<method>Handler` | `<fn>Handler` |
-| `<var>GetCount`, `<var>GetHandler` | `<prop>GetCount`, `<prop>GetHandler` |
+| `<var>GetCount`, `<var>GetHandler` | `<prop>GetCount`, `<prop>GetHandler` — on a `Flow` property only |
 | `<var>SetCount` | `<prop>SetCount` |
-| `<method>Subject` for an `AnyPublisher` member | `<fn>Channel` for a `Flow` member |
+| `<name>Subject` for an `AnyPublisher` member | `<fn>Channel` for a `Flow` member |
 | `fatalError("<method>Handler expected to be set.")` | the same string, thrown as `IllegalStateException` |
 | the initializer-seeded bag | the constructor-seeded bag |
 
-Members with no counterpart there: `<method>CancelCallCount`, and the per-declaration annotations of
-this generator, which that processor has no equivalent for because it selects targets in the build
-script. The property getter that traps is spelled differently on this side — `` `<var>GetHandler`
-must be set! `` — where the method form matches Kotlin's string exactly.
+Members with no counterpart there — the rows to check before assuming the dialects match:
 
-The names, the subject-backed stream shape and the handler-expected string are shared deliberately.
-Renaming one of them is a change to both generators, not a local refactor.
+| this side | Kotlin |
+| --- | --- |
+| `<var>GetCount` / `<var>GetHandler` / `_<var>` on **every** property | a stored property has `SetCount` alone; no read counter, no handler, no store |
+| `<name>SubscribeCount`, `<name>SubscribeCancelCount`, `<name>OutputCount`, `<name>Outputs`, `<name>OutputHandler`, `<name>CompletionCount` | none — a `Flow` property is the channel, unwrapped |
+| `<name>EventCallCount` / `<name>Events` / `<name>EventHandler` for an `AnyObserver` member | none — a sink-shaped requirement reaches no branch there |
+| `<method>CancelCallCount`, `<method>DisposeCallCount` | none |
+| the per-declaration annotations | none — that processor selects targets in the build script |
+
+Both property getters now trap with the same sentence as both method forms,
+`<name>GetHandler expected to be set.` The names, the subject-backed stream shape and that string are
+shared deliberately: renaming one is a change to both generators, not a local refactor.

--- a/skills/swift-sourcery-mocks/references/generated-api.md
+++ b/skills/swift-sourcery-mocks/references/generated-api.md
@@ -128,14 +128,14 @@ var draftSetCount: Int = 0
 var _draft: String = ""
 ```
 
-`_<var>` is what a test seeds and reads when it does not want to move a counter. `<var>SetCount` is
-emitted for a `{ get set }` requirement only — a read-only requirement's witness is still settable,
-and re-seeding it counts nothing, as it always did. A requirement with no synthesizable default is
-an initializer parameter, keeps its own name there, and seeding it at construction moves no counter.
+`_<var>` is what a test seeds and reads without moving a counter, and for a `{ get }` requirement it
+is the only way to seed one: the witness is get-only, as the requirement is, and `<var>SetCount` is
+emitted for a `{ get set }` requirement only. `mock._<var> = value` is the same expression on the
+Kotlin side. A requirement with no synthesizable default is an initializer parameter, keeps its name
+there, and seeding it at construction moves no counter.
 
-`/// sourcery: const` makes the store a `let` and the witness get-only. `/// sourcery: handler` drops
-the store: the getter runs `<var>GetHandler` and traps with `<var>GetHandler expected to be set.`
-when the test set none.
+`/// sourcery: const` makes the store a `let`, fixed at construction. `/// sourcery: handler` drops
+the store: the getter runs `<var>GetHandler` and traps with that string when the test set none.
 
 An effectful requirement generates the accessor it declares, and its handler carries the same
 effects:

--- a/skills/swift-sourcery-mocks/references/spm-plugin.md
+++ b/skills/swift-sourcery-mocks/references/spm-plugin.md
@@ -97,6 +97,47 @@ without it and the failure surfaces as a missing type far from its cause. Three 
 - `output: ${SOURCERY_OUTPUT_DIR}` — the same directory, written out;
 - any other directory — the build fails, naming both paths.
 
+## Finding the generated file on disk
+
+It is a build product under the build root, not a file in the package tree, and nothing writes a
+copy or a pointer into the tree — a prebuild command may write only inside the directory the plugin
+declared. Both lanes put it under one path segment, `SourcerySwiftCodegenPlugin/.generatedFiles/`:
+
+```
+# SwiftPM
+<build>/plugins/outputs/<package, lowercased>/<Target>/destination/
+    SourcerySwiftCodegenPlugin/.generatedFiles/<config stem>/<Template>.generated.swift
+
+# Xcode
+<DerivedData>/<Project>-<hash>/Build/Intermediates.noindex/BuildToolPluginIntermediates/
+    <project>.output/<Target>/SourcerySwiftCodegenPlugin/.generatedFiles/<config stem>/<Template>.generated.swift
+```
+
+The config stem is the config's file name without its leading dot and its extension, so
+`.Sourcery.Mocks.yml` writes into `.generatedFiles/Sourcery.Mocks/`. One command finds the files on
+either lane:
+
+```bash
+find "$BUILD_ROOT" -path '*/SourcerySwiftCodegenPlugin/.generatedFiles/*' -name '*.generated.swift'
+```
+
+`$BUILD_ROOT` is `.build` for a package. For an Xcode project it is derived data, which may be
+relocated, so read it rather than assume it:
+
+```bash
+xcodebuild -project X.xcodeproj -showBuildSettings 2>/dev/null | awk -F' = ' '/ BUILD_DIR = /{print $2}'
+```
+
+**The build log names the directory outright.** For every config the plugin supplies `output:` for,
+it remarks:
+
+```
+.Sourcery.Mocks.yml: the plugin supplied sources: …; output: /abs/path/…/.generatedFiles/Sourcery.Mocks.
+```
+
+`swift build -v` prints it; in Xcode it is in the build log under the target's plugin step. Read it
+when the `find` comes back empty — it says whether the plugin ran at all.
+
 ## `args.testable`, and the arguments that stay yours
 
 `args.import`, `args.excludedSwiftLintRules` and the choice of template are carried through unread.

--- a/skills/swift-sourcery-mocks/references/stream-members.md
+++ b/skills/swift-sourcery-mocks/references/stream-members.md
@@ -1,0 +1,89 @@
+# Stream members, shape by shape
+
+What an `AnyPublisher` requirement and an RxSwift one generate, and which counter answers which
+question. The rest of the generated API is in [generated-api.md](generated-api.md).
+
+## A publisher member
+
+An `AnyPublisher` requirement hands back a construct the mock owns, over a subject the test sends
+into. On a property:
+
+```swift
+var ownMemories: AnyPublisher<[MemoryDrop], Never> {
+    ownMemoriesGetCount += 1
+    return Deferred { [weak self, subject = ownMemoriesSubject] () -> AnyPublisher<[MemoryDrop], Never> in
+        self?.ownMemoriesSubscribeCount += 1
+        if let handler = self?.ownMemoriesGetHandler {
+            return handler()
+        }
+        return subject.eraseToAnyPublisher()
+    }
+    .handleEvents(receiveOutput: { [weak self] value in
+        self?.ownMemoriesOutputCount += 1
+        self?.ownMemoriesOutputs.append(value)
+        self?.ownMemoriesOutputHandler?(value)
+    }, receiveCompletion: { [weak self] _ in self?.ownMemoriesCompletionCount += 1 },
+       receiveCancel: { [weak self] in self?.ownMemoriesSubscribeCancelCount += 1 })
+    .eraseToAnyPublisher()
+}
+var ownMemoriesGetCount: Int = 0
+var ownMemoriesGetHandler: (() -> AnyPublisher<[MemoryDrop], Never>)? = nil
+var ownMemoriesSubscribeCount: Int = 0
+var ownMemoriesSubscribeCancelCount: Int = 0
+var ownMemoriesOutputCount: Int = 0
+var ownMemoriesOutputs: [[MemoryDrop]] = []
+var ownMemoriesOutputHandler: (([MemoryDrop]) -> Void)? = nil
+var ownMemoriesCompletionCount: Int = 0
+lazy var ownMemoriesSubject = PassthroughSubject<[MemoryDrop], Never>()
+```
+
+Four counters a test reads instead of inferring: `<var>GetCount` says the code under test asked for
+the stream, `<name>SubscribeCount` that it subscribed, `<name>OutputCount` that a value reached it,
+`<name>CompletionCount` that the stream ended. `<name>SubscribeCancelCount` is the cancellation.
+
+```swift
+mock.ownMemoriesSubject.send([drop])
+mock.ownMemoriesSubject.send(completion: .finished)
+XCTAssertEqual(mock.ownMemoriesSubscribeCount, 1)
+XCTAssertEqual(mock.ownMemoriesOutputs, [[drop]])
+```
+
+**`<name>OutputCount` counts delivery, not sending.** A value sent while nobody is subscribed is
+dropped by the `PassthroughSubject` and counts nothing; one sent to two subscribers counts twice.
+`<name>OutputHandler` runs after the counter and the recorder, and can send the next value from
+inside itself — which is how a test drives a chain without subscribing itself.
+
+**A property's `<var>GetHandler` is read at subscribe time**, so this works:
+
+```swift
+let captured = mock.ownMemories            // the code under test holds the publisher
+mock.ownMemoriesGetHandler = { Just([drop]).eraseToAnyPublisher() }
+captured.sink { … }                        // the handler decides the stream
+```
+
+A method keeps `<method>Handler` at call time, where the arguments are and where the member's
+`async` and `throws` apply; only the subject fallback is deferred. A handler set on a method
+bypasses the subject, so `<method>SubscribeCount` stays at zero.
+
+`/// sourcery: subject = "CurrentValue"` on the requirement makes it a `CurrentValueSubject` seeded
+with the `Output`'s default value, which replays that value to a late subscriber. An `Output` with no
+default value fails generation naming the member, because a `CurrentValueSubject` has to be seeded;
+set `<name>GetHandler` to a stream that replays instead.
+
+A publisher requirement declared `{ get async }` or `{ get throws }` fails generation: the closure
+that reads its handler runs synchronously. Return the stream from a method instead.
+
+An RxSwift `Observable`, `Single` or `AnyObserver` member is backed by a `PublishSubject` under the
+same `<name>Subject` name and keeps its own shape. An `AnyObserver` member — a sink, where the code
+under test pushes in — records what it was handed:
+
+```swift
+sut.entityObserver().onNext("next element")
+XCTAssertEqual(mock.entityObserverEventCallCount, 1)
+XCTAssertEqual(mock.entityObserverEvents.compactMap(\.element), ["next element"])
+```
+
+`Event` declares no `Equatable` conformance, so `<name>Events` is read through `compactMap(\.element)`,
+`error` and `isCompleted` rather than compared whole. `[Output]` on the Combine side compares
+directly. `/// sourcery: skipArgumentRecording` on the member or the protocol drops `<name>Outputs`
+and `<name>Events`, leaving the counters and the handlers.

--- a/skills/swift-sourcery-mocks/references/troubleshooting.md
+++ b/skills/swift-sourcery-mocks/references/troubleshooting.md
@@ -108,6 +108,18 @@ name, and the requirement set includes what the protocol inherits, so a refineme
 requirement into an overload group that its own declaration does not show. `/// sourcery: methodName
 = "customName"` pins a member's name.
 
+**The generated file states every one of these.** A member whose prefix is not its declared name
+carries a comment above the witness and an entry under that class's `// MARK:` line, each naming
+both spellings:
+
+```swift
+// `end(at:)` members are named `endAt*` — overload of `end`, argument labels appended
+func end(at fieldValues: [String]) {
+```
+
+Search the generated file for either spelling — the declaration as written, or the prefix a member
+carries.
+
 ## A property's `<var>GetCount` moved and the test did not read it
 
 Every property requirement counts its reads, so an assertion that reads `mock.draft` moves
@@ -159,6 +171,20 @@ is on the test's side rather than the mock's.
 
 Mock classes are `final`. Set a handler instead — every method and every property has one, and a
 handler can hold whatever a subclass would have overridden.
+
+## The generated file is not in the repository
+
+On the plugin lane it never is: it is a build product under the build root, and no committed copy
+exists. Find it, on either lane, with
+
+```bash
+find "$BUILD_ROOT" -path '*/SourcerySwiftCodegenPlugin/.generatedFiles/*' -name '*.generated.swift'
+```
+
+where `$BUILD_ROOT` is `.build` for a package and derived data for an Xcode project. If that comes
+back empty the plugin did not run or did not write: the build log names the directory it supplied,
+which [spm-plugin.md](spm-plugin.md) quotes. On the CLI lane the file is committed at the `output:`
+the config names.
 
 ## The build succeeds and the committed generated file is stale
 

--- a/skills/swift-sourcery-mocks/references/troubleshooting.md
+++ b/skills/swift-sourcery-mocks/references/troubleshooting.md
@@ -120,6 +120,14 @@ func end(at fieldValues: [String]) {
 Search the generated file for either spelling — the declaration as written, or the prefix a member
 carries.
 
+## `cannot assign to property: 'x' is a get-only property`
+
+The witness declares what the requirement declares, so a `{ get }` requirement is get-only on the
+mock too. Seed it through the store: `mock.documentID = "d1"` becomes `mock._documentID = "d1"`,
+which moves no counter and is the same expression on the Kotlin side. Older releases emitted a
+settable stored property for a read-only requirement, so the assignment compiled and counted
+nothing. `<var>SetCount` is emitted for a `{ get set }` requirement only.
+
 ## A property's `<var>GetCount` moved and the test did not read it
 
 Every property requirement counts its reads, so an assertion that reads `mock.draft` moves

--- a/skills/swift-sourcery-mocks/references/troubleshooting.md
+++ b/skills/swift-sourcery-mocks/references/troubleshooting.md
@@ -94,10 +94,42 @@ A double that seeded itself would emit a value nobody wrote the moment the code 
 subscribes, and turn the test's own `send` into a second element — which is what resumes a bridging
 continuation twice.
 
+## `value of type 'XMock' has no member '<name>'`
+
+The prefix is the **declared name**, verbatim, with backticks dropped: `func perform1_0()` gives
+`perform1_0CallCount`, not `perform10CallCount`; `func ID()` gives `IDCallCount`. Older releases
+applied a case-and-underscore transform to methods and not to properties, so a name a test learned
+from a generated file made before the templates were bumped can be stale — regenerate, and read the
+member off the file.
+
+For an **overloaded** requirement the name carries the argument labels: `func end(atDocument
+document:)` gives `endAtDocument`. Only the overload with the fewest parameters keeps the plain
+name, and the requirement set includes what the protocol inherits, so a refinement can put a
+requirement into an overload group that its own declaration does not show. `/// sourcery: methodName
+= "customName"` pins a member's name.
+
+## A property's `<var>GetCount` moved and the test did not read it
+
+Every property requirement counts its reads, so an assertion that reads `mock.draft` moves
+`draftGetCount` itself. Read `mock._draft` — the store behind the accessors — to read or seed the
+value without moving a counter.
+
+## `<name>SubscribeCount` is zero and the stream delivered
+
+`<var>GetCount` counts the code under test *asking* for the publisher; `<name>SubscribeCount` counts
+it *subscribing*. A code path that reads the member and stores it without subscribing moves the
+first and not the second, and nothing is delivered to it.
+
+`<name>OutputCount` is the third question: it counts delivery, not sending. A value sent while
+nobody is subscribed is dropped by the `PassthroughSubject` and counts nothing. Where a method's
+`<method>Handler` is set, the member never reaches the deferred subject at all, so
+`<method>SubscribeCount` stays at zero by design.
+
 ## `<method>Args` does not exist
 
 Argument recording is skipped for three shapes: a method whose parameters are all closures, a
 generic method, and anything annotated `skipArgumentRecording` on the method or on its protocol.
+`skipArgumentRecording` drops `<name>Outputs` and `<name>Events` too, for the same reason.
 
 Assert through `<method>Handler` instead — it receives every parameter, closures included.
 

--- a/skills/swift-sourcery-mocks/references/writing-testable-protocols.md
+++ b/skills/swift-sourcery-mocks/references/writing-testable-protocols.md
@@ -112,7 +112,7 @@ Annotation names are matched exactly, including case.
 | `globalActor = "MyIsolation"` | Protocol | Declare the mock's global actor when the attribute name does not end in `Actor` |
 | `uncheckedSendable` | Protocol | Force `@unchecked Sendable` on the mock when the `Sendable` refinement is not visible to Sourcery |
 | `subject = "CurrentValue"` | Variable / method | Choose the subject backing an `AnyPublisher` member — `CurrentValue` or `Passthrough` |
-| `skipArgumentRecording` | Protocol / method | Do not generate `<method>Args`; call counting and the handler are unaffected |
+| `skipArgumentRecording` | Protocol / method / variable | Do not generate `<method>Args`, `<name>Outputs` or `<name>Events`; counting and the handlers are unaffected |
 | `owns` | Protocol | Emit `<X>ComponentBase` (non-final) for a hand-written subclass that holds what the level owns |
 | `componentName = "Foo"` | Protocol | Name the emitted Component `Foo` instead of deriving it from the protocol |
 | `componentAccess = "public"` | Protocol | Emit a `public` Component; the default is internal |

--- a/specs/004-mock-member-naming/spec.md
+++ b/specs/004-mock-member-naming/spec.md
@@ -1733,3 +1733,132 @@ header (D14b), the class index (D15b), and the line above the witness (D15a) —
 and its red control. `MockGenerator` emits the first three, `MockMethod` the fourth, and every
 string comes from `MockNaming`. The `methodName` fixture §10.4 names is still added, because no
 fixture in the tree carries that annotation today.
+
+---
+
+## 11. What landed: P10 and P11
+
+### P10 — the naming comments, and the gate that reads them back
+
+`MockNaming` gained `MethodPrefix`, a second `methodPrefix` overload returning it, the two comment
+line spellings, the index header and the two header blocks. `MockMethod.mockedPrefix` calls it once
+and `mockedMethodName` reads `.prefix` off the result, so the name and the comment come from one
+call. `MockGenerator` emits the file header, the per-class header and the class's index;
+`MockMethod.mockImpl` emits the line above the witness.
+
+**What decides that a comment is written is the prefix against the declared name, not which branch
+produced it.** `useShortName: false` on a method with no parameters appends nothing, so the flags
+would have claimed a rename that did not happen; `/// sourcery: methodName` may also repeat the
+declared name. Both cases are `prefix == declaredName` and get no comment.
+
+**Two wordings changed from the drafts in D15.** The return-type cause reads ``overload of `data`
+returning `[String: Any]?` `` rather than "differing only in return type": a class whose index holds
+both members of such a group would otherwise carry the same line twice, with only the prefix telling
+them apart. And `SourceryRuntime.Method.selectorName` is `refresh` for a method that takes nothing
+and `end(at:)` for one that does, so `methodPrefix` appends `()` where it is absent — the spelling
+the comment carries is then the declaration's in both cases.
+
+Because the return type is what the comment shows, `methodPrefix` takes `returnTypeName:` and
+derives the discriminator itself. `MockMethod.returnTypeDiscriminator` is gone; the token in the
+name and the type in the comment are now one input.
+
+**Fixtures.** `Naming.swift` gained `NamingAnnotated` (`methodName`, which no fixture carried) and
+the `NamingReturnTypeBase` / `NamingReturnTypes` pair, so all three causes are in the fast lane's
+snapshot rather than two of them in `Tests/Examples/`. `Tests/Checks/README.md` gained a table for
+`Naming.swift` and one for `Properties.swift`, which P2 and P5 added without listing.
+
+**The gate (D16(b))** is `run-checks.sh`'s fifth, `naming-comments`, and the earlier typecheck and
+behaviour gates are renumbered 6 and 7. It reads every `` `X` members are named `Y*` `` line out of
+the generated file: a line inside a class must sit above a `func` whose first statement is
+`<prefix>CallCount += 1`, and each class's index must be exactly the set of lines commented inside it. Two
+red controls, both on a copy of the generated file: one renames a prefix in a comment, one deletes
+an index entry.
+
+| measured | count |
+| --- | --- |
+| renamed members in the fixture snapshot | 7 — 4 overload long forms, 2 return-type discriminators, 1 `methodName` |
+| lines added to the fixture snapshot | 140, all comments |
+| `modaal-firebase-wrappers`, regenerated from this tree | 2934 → **3148 lines**, +214 |
+| where those 214 go | 7 files × (1 blank + 5 header), 34 classes × 2, 10 index headers, 47 index entries, 47 witness lines |
+| renamed members in the consumer | **47, in 10 of its 34 classes** — §10.1's count, confirmed |
+| generated code changed | none — the diff against P9's regeneration is comments and seven blank lines |
+
+`CHANGELOG.md`'s entry takes the new paragraph, the 3148, and a table row for the 214 lines.
+`README.md`, `CONTRIBUTING.md` §"Design rules already decided", `SKILL.md`, `references/generated-api.md`
+and `references/troubleshooting.md` each state it once. `generated-api.md` was at its 250-line cap,
+so two sentences there were tightened to pay for the new one.
+
+### P11 — finding the generated file (D17(a), (a2))
+
+`references/spm-plugin.md` gained `## Finding the generated file on disk`: both lanes' path shapes,
+what the config stem is, the `find` over
+`*/SourcerySwiftCodegenPlugin/.generatedFiles/*`, the `xcodebuild -showBuildSettings` line for
+relocated derived data, and the plugin's own remark naming the directory — which was in every build
+log and documented nowhere. `references/troubleshooting.md` gained
+`## The generated file is not in the repository`. `SKILL.md`'s plugin lane gained **Finding what it
+wrote**, with the `find`.
+
+No template, plugin or CLI change, so no snapshot moved. **D17(f) is not implemented**, per §10.5:
+the lane-comparison line was not ruled.
+
+### Lanes
+
+`run-checks.sh` (snapshot recorded after reading the diff), `run-skill-checks.sh`,
+`run-annotation-checks.sh`, `run-cli-checks.sh`, `run-plugin-checks.sh` and
+`Tests/Examples/ExampleProjectSpm/test-ios.sh` — 20 tests, 0 failures. `run-xcode-checks.sh` was not
+run.
+
+**One lane defect found, not fixed and not caused by this phase.** `run-plugin-checks.sh` exits 1 on
+a second run without printing a failure: its artifact-bundle section reuses
+`$WORK_DIR/bundle-route` as the scratch path (line 489), the warm build does not re-run the plugin,
+the remark it greps for is absent, and the `grep -o … | head -1` in that else branch takes the
+script down under `set -eo pipefail` before `fail` can name it. Deleting that scratch directory and
+re-running is green.
+
+### The skill body against the compaction floor
+
+`specs/002-annotation-registry-and-agent-skill/spec.md` §3.1 records that auto-compaction keeps the
+first 5,000 tokens of each loaded skill, and its §15.2 left `SKILL.md` at 250 lines and 13,654 bytes,
+reported at **~4.8k on invoke**. P8, P10 and P11 each added to that body. Measured with 002 §15.1's
+procedure — `claude plugin marketplace add ./`, `claude plugin install swift-sourcery-mocks --scope
+local`, `claude plugin details swift-sourcery-mocks`, Claude Code 2.1.268:
+
+| state | lines | bytes | on invoke |
+| --- | ---: | ---: | ---: |
+| `master` (002 §15.2) | 250 | 13,654 | ~4.8k |
+| P8 | 282 | 16,361 | — |
+| after P10 and P11 | 297 | 17,180 | **~6.1k** |
+| after the trim | 208 | 13,988 | **~4.9k** |
+
+P8 crossed the floor on its own; P10 and P11 added ~0.3k on top. Always-on is unchanged at ~290 —
+the description was not touched, and SC4 reports it at 740 characters.
+
+**Four moves, on 002 §15.3's pattern: material a reference already carries in full leaves the body.**
+
+1. The CLI `generate` invocation. `references/cli-lane.md` §"The script shape worth copying" has the
+   same flags in a loop over modules; the body names each flag and points at it.
+2. The `protocol DataService { … }` snippet and the external-protocol extension block.
+   `references/writing-testable-protocols.md` §"What to annotate" carries both.
+3. The `## Publishers are subject-backed` section, folded into §"What the generated mock gives a
+   test" as the two-line subscribe-then-send example plus the `PassthroughSubject` rule. The
+   paragraph on when a publisher's handler is read went with it —
+   `references/stream-members.md` states both, and the body's link now says so.
+4. `## When it goes wrong` re-formed from a three-column table to a list of the same nine entries,
+   which drops the column scaffolding.
+
+The rest is prose compression. No instruction was removed, every one of the nine `mock-templates`
+flags is still named (SC7), every reference is still linked at its point of need (SC8), and the
+block between the annotation markers was not touched (AC6 reports all three rendered blocks
+current). All thirteen skill checks pass.
+
+**Measurement cleanup.** The install reads the working tree, so it was made local-scope and then
+undone: plugin uninstalled, marketplace removed, and the `.claude/settings.local.json` the local
+install wrote deleted. State before and after: one marketplace (`claude-plugins-official`), no
+local plugin.
+
+**The third sighting of the gap 002 §15.6 names.** No check measures the token budget: SC5 counts
+lines, 400 for the body, and 002 §15.6 records the line budget passing on both occasions the token
+budget was breached — ~5.1k at 258 lines, ~5.5k at 273 lines. This is the third: SC5 passed at 297
+lines while the body was ~1.1k over the floor, and nothing in CI said so. `claude plugin details` is
+still the only thing that reads the figure, and it needs `claude` and an install on the runner —
+which is the reason 002 §15.6 gives for `run-skill-checks.sh` not doing it.

--- a/specs/004-mock-member-naming/spec.md
+++ b/specs/004-mock-member-naming/spec.md
@@ -1511,3 +1511,225 @@ sentence naming the state of the twin as of the tag is written when that decisio
 Lanes run at this phase, all green: `run-checks.sh`, `run-skill-checks.sh`,
 `run-annotation-checks.sh`, `run-cli-checks.sh`, `run-plugin-checks.sh`, and
 `Tests/Examples/ExampleProjectSpm/test-ios.sh` at P7. `run-xcode-checks.sh` was not run.
+
+---
+
+## 10. Proposed: making a non-derivable name readable in the file, and finding the file
+
+Proposals only. Nothing here is implemented, and P1–P9 are complete without it. Two questions, asked
+after P9: how an agent reading a generated file learns that a member's name is not its declaration,
+and how an agent finds that file at all on the plugin lane.
+
+### 10.1 What is left after P8, measured
+
+§2.1 and §2.2 make most names derivable, and P8 states the rule in `SKILL.md`, `README.md` and
+`references/generated-api.md`. Three cases stay underivable **from the declaration a reader has in
+front of them**, even knowing the rule:
+
+1. **An overload's long form** (§2.2 step 2). Whether a declaration is in an overload group at all
+   depends on the mock's whole requirement set, inherited requirements included, so a protocol
+   refining another can put a requirement into a group that neither declaration shows (§1.4, §3 D3).
+2. **The return-type discriminator** (§2.2 step 3). `dataStringAnyOptional` appears in no
+   declaration.
+3. **`/// sourcery: methodName = "…"`**, which is visible at the declaration but not at the mock.
+
+Counted over generated output as of P9:
+
+| | methods | prefix ≠ declared name | classes with at least one |
+| --- | ---: | ---: | ---: |
+| `Tests/Checks/Snapshots/Mocks.generated.swift` | 56 | **4** (7%) | 4 of 33 |
+| `modaal-firebase-wrappers`, regenerated (7 modules) | 152 | **47** (30%) | 10 of 34 |
+
+The consumer's are concentrated: `CollectionReferenceProtocolMock` 12, `QueryProtocolMock` 11,
+`CloudFileStoringMock` 6, `CloudStorageReferencingMock` 6, then six classes with three or fewer. A
+query-builder API overloads heavily, and that is where an agent's derived guess is wrong 30% of the
+time.
+
+**Property prefixes need nothing.** `MockNaming.variablePrefix` is the declared name minus backticks
+in every branch, so no property name is underivable and no property comment is proposed.
+
+All three causes are known to `MockMethod` at emission — `useShortName`, `useReturnTypeInName` and
+`annotatedMethodName` — so no new analysis is needed to write the comment.
+
+### D14 — where the naming rule is stated inside a generated file
+
+**Ruled (a) and (b) — §10.5.**
+
+- **(a) One header per file, under the Sourcery banner (recommended).** Four lines stating §2.1 and
+  naming the overload exception. Cost is O(files): 28 lines across the consumer's seven.
+- (b) One header per class, under the existing `// MARK: - <Protocol>` line. In view wherever an
+  agent lands, at O(classes): 34 headers in the consumer, ~170 lines.
+- (c) Nothing; the rule is in `SKILL.md` and `README.md` as of P8. Leaves an agent reading a
+  generated file with no statement of the rule in the file it is reading.
+
+(a) and (b) differ only in whether the statement is in view when an agent reads a slice of a large
+file rather than the whole of it. The consumer's regenerated output is 2934 lines, which is read in
+slices; that is the case for (b), and D15(b) covers it more cheaply.
+
+### D15 — how a name that is not the declaration is recorded
+
+**Ruled (c) — §10.5.**
+
+- **(a) One comment line above the witness, naming the selector, the prefix and the cause
+  (recommended).** Emitted only for the three cases in §10.1, so most members get nothing:
+
+  ```swift
+  // `end(at:)` members are named `endAt*` — overload of `end`, argument labels appended
+  func end(at fieldValues: [String]) {
+      endAtCallCount += 1
+  ```
+
+  ```swift
+  // `data()` members are named `dataStringAnyOptional*` — overload of `data` differing only in return type
+  // `refresh()` members are named `reloadNow*` — `/// sourcery: methodName = "reloadNow"`
+  ```
+
+  The line carries both spellings, so `grep "end(at:)"` and `grep endAt` each find it. Cost: 47
+  lines in the consumer (1.6% of 2934), 4 in the snapshot.
+- (b) A per-class index line instead, listing the class's non-derived names under the `MARK:`.
+  Ten lines in the consumer, one per class that has any, and in view on landing — but a line listing
+  12 mappings is long, and it is not beside the declaration it describes.
+- (c) Both (a) and (b). 57 lines in the consumer; the index is then a second statement of what the
+  per-member lines already say.
+- (d) Neither. An agent that guesses `endAtFieldValues` gets a compile error naming the member it
+  wrote, and finds the real name by reading the class — which is what the evaluation measured as the
+  cost.
+
+### D16 — how the comment is kept true
+
+**Ruled (a) and (b) — §10.5.**
+
+The comment is a claim about the name, so it must be produced by the function that produces the
+name. `MockNaming` gains one function taking the same three inputs `methodPrefix` takes and
+returning the comment or `nil`; `MockMethod` calls it where it already calls `methodPrefix`. Written
+at the emission site instead, it becomes a second statement of the rule, which is what `AGENTS.md`
+§"State a rule once" exists to prevent and what §1.8 measured the cost of.
+
+- **(a) Generate it from `MockNaming`, and let the snapshot be the gate (recommended).** A comment
+  that disagrees with the name below it cannot be produced, and the snapshot diff shows both.
+- (b) The same, plus a check in `run-checks.sh` asserting that each comment's stated prefix equals
+  the `CallCount` on the following lines, with a red control. Cheap — one pass over the snapshot —
+  and it gates a hand-edit of the template that (a) makes impossible by construction.
+
+### 10.2 When this should land, if it lands
+
+**In the same release as P1–P9.** It changes every generated file, so a consumer regenerates and
+re-fingerprints either way; landing it in this tag costs nothing beyond the regenerate already
+required by §2.1 and §2.2. Landing it later forces a second regenerate of every consumer, and a
+second `mock-templates validate` failure, for comments alone.
+
+### 10.3 Finding the generated file on the plugin lane
+
+Measured on this machine — both lanes write under one path segment,
+`SourcerySwiftCodegenPlugin/.generatedFiles/`:
+
+```
+# SwiftPM
+<build>/plugins/outputs/<package lowercased>/<Target>/destination/
+    SourcerySwiftCodegenPlugin/.generatedFiles/<Config stem>/<Template>.generated.swift
+
+# Xcode
+<DerivedData>/<Project>-<hash>/Build/Intermediates.noindex/BuildToolPluginIntermediates/
+    <project>.output/<Target>/SourcerySwiftCodegenPlugin/.generatedFiles/<Config stem>/<Template>.generated.swift
+```
+
+So one command finds them on either lane, given the build root:
+
+```bash
+find "$BUILD_ROOT" -path '*/SourcerySwiftCodegenPlugin/.generatedFiles/*' -name '*.generated.swift'
+```
+
+`$BUILD_ROOT` is `.build` for a SwiftPM package. For an Xcode project it is derived data, which may
+be relocated, so it is read rather than assumed:
+
+```bash
+xcodebuild -project X.xcodeproj -showBuildSettings 2>/dev/null | awk -F' = ' '/ BUILD_DIR = /{print $2}'
+```
+
+### D17 — what to do about it
+
+**Ruled (a) and (a2) — §10.5. (f) was not ruled and is not in P11.**
+
+- **(a) Document it, in `references/spm-plugin.md` (recommended).** A "Finding the generated file"
+  section carrying the two path shapes, the `find`, and the `xcodebuild -showBuildSettings` line.
+  No build change, and it works against every version already released.
+- **(a2) …and document the build-log route beside it (recommended, same section).** The plugin
+  already emits the absolute directory:
+  `Diagnostics.remark("<config>: the plugin supplied output: <abs path>")`
+  (`Plugins/SourcerySwiftCodegenPlugin/SourcerySwiftCodegenPlugin.swift:529-550`). It is in every
+  build log today and is documented nowhere. `references/troubleshooting.md` already tells a reader
+  to read that log for a missing type (`spm-plugin.md:162`); this is the same log and one more thing
+  it answers.
+- (b) The skill instructs the adopting repository to commit a three-line
+  `Scripts/find-generated-mocks.sh` once, so later sessions run one command rather than
+  reconstructing the `find`. Durable across agent sessions; it is a file in the consumer's repository
+  that this repository cannot update.
+- (c) A **command plugin** — `swift package plugin generate-mocks
+  --allow-writing-to-package-directory` — writing the generated files into the package tree. A build
+  tool plugin cannot: its commands are sandboxed to `pluginWorkDirectory`. A command plugin can.
+  **Not recommended:** `mock-templates generate` already writes committed, in-tree, greppable output
+  and is the documented lane for exactly that (`references/cli-lane.md`), so this adds a second route
+  to the same result. Worth revisiting only to reuse the plugin's config discovery.
+- (d) A symlink or pointer file written into the package directory by the build tool plugin.
+  **Impossible**, on the same sandbox fact as (c).
+- (e) Emit the absolute output path into the generated file's own banner. It answers "where did this
+  come from" for a reader who already has the file, which is not the question asked.
+
+**(f) State the discoverability difference where a consumer picks a lane.**
+`references/cli-lane.md` and `references/spm-plugin.md` compare the two on fingerprinting, CI and
+checkout size. Generated output that is committed and greppable at a stable path, against output
+under a derived-data path that has to be found, is one more line in that comparison, and it is the
+line that matters for a repository whose tests are written by agents.
+
+### 10.4 Phasing, if this is taken
+
+**P10 — the comments (D14, D15, D16).** `MockNaming` gains the header text and the per-member
+comment function; `MockMethod` calls the second where it calls `methodPrefix`; `MockGenerator` emits
+the header. Fixtures already cover all three causes — `NamingOverloads` (§2.2 step 2),
+`ReturnTypeOverload` in `Tests/Examples/` and the `data()` pair (step 3) — and a `methodName` fixture
+is added, which the tree does not have today. Gates: the snapshot diff, both language modes, and the
+example lane, which is where the return-type-discriminated names are asserted on.
+
+**P11 — the plugin-output documentation (D17).** `references/spm-plugin.md` gains the section;
+`references/troubleshooting.md` gains a "the generated file is not where I looked" entry; the
+lane-comparison line in D17(f) goes in both references. `SKILL.md` gets one line, in its body, with
+the `find`. No template change, so no snapshot moves.
+
+P10 belongs in this release (§10.2). P11 is independent of the tag and can land at any point.
+
+### 10.5 Ruled
+
+Ruled 2026-09-12. The options listed in D14, D15, D16 and D17 stand as written; this section names
+which of them are taken, and supersedes the `(recommended)` mark in each of those four sections
+where the ruling differs from it.
+
+| decision | taken | against the mark in that section |
+| --- | --- | --- |
+| D14 — where the rule is stated in the file | **(a) and (b)** — a header at the top of the file *and* one under every class's `MARK:` line | (a) alone was marked |
+| D15 — how a renamed member is recorded | **(c)** — the per-class index *and* the line above the witness | (a) alone was marked |
+| D16 — how the comment is kept true | **(a) and (b)** — generated from `MockNaming`, *and* asserted by a gate in `run-checks.sh` with a red control | (a) alone was marked |
+| D17 — finding the generated file on the plugin lane | **(a) and (a2)** — the path shapes and the `find` in `references/spm-plugin.md`, and the build-log remark beside them | as marked |
+
+D14(b) is taken for the fact D14 records against it: a 2934-line generated file is read in slices,
+and the per-class header is what puts the rule in the slice an agent lands in. The class header is
+the same two lines for every class, with nothing interpolated from the protocol, so the snapshot
+diff a new protocol produces is those two lines and the class.
+
+D15(c) states the same sentence in two places — above the witness and in its class's index — and
+both come from one call, so the two cannot disagree.
+
+D16(b) gates what D16(a) makes impossible by construction. What it catches is a later edit that
+writes a comment where a member is emitted instead of asking `MockNaming` for one, which is what
+`AGENTS.md` §"State a rule once" forbids and what no other check reads. The gate also asserts that a
+class's index and its witness lines are the same set, so a member commented in one place and not the
+other fails the run.
+
+**Not taken:** D17(b), (c), (d) and (e), each for the reason D17 gives. **Not ruled:** D17(f), the
+lane-comparison line for `references/cli-lane.md` and `references/spm-plugin.md`. It is out of P11's
+scope and stays open.
+
+**What this makes P10 emit, against §10.4's two items:** four — the file header (D14a), the class
+header (D14b), the class index (D15b), and the line above the witness (D15a) — plus the gate (D16b)
+and its red control. `MockGenerator` emits the first three, `MockMethod` the fourth, and every
+string comes from `MockNaming`. The `methodName` fixture §10.4 names is still added, because no
+fixture in the tree carries that annotation today.

--- a/specs/004-mock-member-naming/spec.md
+++ b/specs/004-mock-member-naming/spec.md
@@ -1280,3 +1280,58 @@ Gates: `run-checks.sh`, diff read, then `--record`; both language modes clean; b
 pass; `Tests/Examples/ExampleProjectSpm/test-ios.sh` 19 tests, 0 failures, including
 `UploadProgressingMock, progressGetCount == 0`, which reads a publisher property's counter this
 phase leaves to P7.
+
+### P6 — an effectful property requirement generates the accessor it declares
+
+`MockVar` reads `variable.isAsync` and `variable.throws` into `effectsDecl` (` async`, ` throws`,
+` async throws`) and `effectfulCallDecl` (`try `, `await `), and writes both into the accessor, into
+`<var>GetHandler`'s type and into the call that consults it. `PropertyEffectfulMock.config` emits
+`get async throws`, `configGetHandler: (() async throws -> String)?` and
+`return try await handler()`.
+
+A new `accessor(getter:setter:)` builds the witness in one place: a bare getter body where there are
+no effects and no setter, `get` / `set` blocks where there is a setter, and a `get\(effectsDecl)`
+block where there are effects — a bare body cannot carry `async` or `throws`. It serves the
+smart-default branch too, so an effectful publisher property would carry its effects through the
+same code, though no fixture declares one.
+
+An effectful requirement is get-only: Swift has no effectful setter, so `hasSetter` is false
+whenever `hasEffects` is true, and no `<var>SetCount` is emitted. `_<var>` stays assignable, which is
+how `PropertyEffectfulMock(loader:)`'s value is re-seeded.
+
+**Typed throws are refused on both paths, which §2.6 chose and P6's plan mentioned only for the
+property.** `MockVar.mockImpl` throws `MockError.typedThrowsUnsupported` when
+`variable.throwsTypeName` is non-nil, and `MockMethod.from` does the same over
+`method.throwsTypeName` — the method path writes bare `throws` at `MockMethod.throwingDecl` and had
+the identical defect. The message names the protocol, the member, the error type and the fix.
+
+Measured on Sourcery 2.3.0, which is what `Scripts/engine-pin.sh` pins, over a probe declaring all
+five shapes:
+
+| declaration | `isAsync` | `throws` | `throwsTypeName` |
+| --- | --- | --- | --- |
+| `var plain: Int { get }` | false | false | nil |
+| `var a: Int { get async }` | true | false | nil |
+| `var t: Int { get throws }` | false | true | nil |
+| `var at: Int { get async throws }` | true | true | nil |
+| `var typed: Int { get throws(ProbeError) }` | false | true | `ProbeError` |
+| `func mTyped() throws(ProbeError) -> Int` | — | true | `ProbeError` |
+
+So `throws` alone cannot distinguish a typed throw from an untyped one, and `throwsTypeName` is what
+both refusals test.
+
+`Tests/Checks/Fixtures/Properties.swift` gains `PropertyEffectful`: `{ get async throws }`,
+`{ get async }`, `{ get throws }`, a plain sibling, and one `{ get async }` requirement with no
+synthesizable default so the initializer seeds an effectful member's store.
+`Tests/Checks/Behaviour/Main.swift` gains `checkEffectfulProperties`, 6 assertions: an `{ get async }`
+accessor suspends and returns the store and counts the read, an `{ get async throws }` handler's
+error propagates out of the accessor while the read that threw is still counted, a `{ get throws }`
+accessor returns the store, and seeding an effectful requirement's store counts no read.
+
+The `collision` gate is renamed **`refusal`** and gains the two typed-throws cases — the gate is
+every construct the templates refuse to emit, not only colliding names. Six cases.
+
+Gates: `run-checks.sh`, diff read, then `--record` — 74 added lines, no deleted line; both language
+modes clean; behaviour checks pass; `Tests/Examples/ExampleProjectSpm/test-ios.sh` 19 tests, 0
+failures. P8 deletes `CONTRIBUTING.md` §"Open items"'s effectful-property entry, which this phase
+closes, and adds typed throws in its place.

--- a/specs/004-mock-member-naming/spec.md
+++ b/specs/004-mock-member-naming/spec.md
@@ -2195,3 +2195,39 @@ diagnostic naming the requirement. §2.1's backtick rule here is unaffected.
 scratch) and `Tests/Examples/ExampleProjectSpm/test-ios.sh` at 20 tests, 0 failures — its log read
 rather than its exit status. `run-xcode-checks.sh` was not run. The skill body measures ~4.9k tokens
 on invoke at 208 lines, unchanged by P12's one-row edit, against 002 §3.1's 5,000-token floor.
+
+### Correction, and the two lane defects fixed
+
+Supersedes the "Two lane defects found" list in P12's entry above, and the "not fixed" line in §11's
+P10 entry.
+
+**1. `Tests/Examples/ExampleProjectSpm/test-ios.sh` is not defective.** The claim that it exits 0 on
+a failed build is wrong: the failing run exited **65**. What reported 0 was the shell compound the
+run was wrapped in — `./test-ios.sh > log 2>&1; echo "exit=$?"` — whose own status is the `echo`'s,
+and the status printed into the log was read as the script's. `set -eo pipefail` at `:21` and the
+`xcodebuild test | xcbeautify` pipeline already carry the build's status out. Nothing was changed
+there.
+
+**2. `run-plugin-checks.sh` — three edits, and both failure modes reproduced before and after.**
+
+- **A run that fails downstream of generation broke the next run.** `:150-161` deleted
+  `$FIXTURE_SCRATCH/plugins/outputs` and left llbuild's `build.db` naming those files, and the
+  plugin is re-run only when something it reads has changed — so a following run that changes a
+  fixture source and nothing else failed with `couldn't build … because of missing inputs` naming
+  the two generated files. `build.db` is now deleted with the outputs. **Red control, run by hand:**
+  reintroduce `mock.profileID = "id"` in `PluginFixture/Tests/AppTests/AppTests.swift`, run (exit 1,
+  "the fixture package did not build"), restore it, run again — exit 0, where before the fix the
+  second run failed on missing inputs.
+- **The bundle-route gate needed a cold build and did not get one.** `$WORK_DIR/bundle-route` was
+  reused, so a second invocation's warm build never ran the plugin, and the remark the gate greps
+  for was absent. It is now removed before that build unless `--keep`. **Control:** two consecutive
+  invocations, both `ALL PLUGIN CHECKS PASSED` (cold 37s / 38s, warm 1s), where the second used to
+  exit 1 printing nothing.
+- **Three failure branches could end the run before `fail` recorded anything.** `diff … | head -20`
+  at `:259`, `grep … | head -10` at `:493` and `grep -o … | head -1` at `:500` each return non-zero
+  exactly in the case that branch exists for, and `set -eo pipefail` turns that into an exit. Each
+  takes `|| true`. This is the mechanism §11 recorded as "takes the script down before `fail` can
+  name it", and it is why the bundle-route failure printed no diagnostic.
+
+No automated control covers the failed-run-then-recover sequence; it was run by hand, and the result
+is recorded here.

--- a/specs/004-mock-member-naming/spec.md
+++ b/specs/004-mock-member-naming/spec.md
@@ -1862,3 +1862,225 @@ budget was breached — ~5.1k at 258 lines, ~5.5k at 273 lines. This is the thir
 lines while the body was ~1.1k over the floor, and nothing in CI said so. `claude plugin details` is
 still the only thing that reads the figure, and it needs `claude` and an install on the runner —
 which is the reason 002 §15.6 gives for `run-skill-checks.sh` not doing it.
+
+---
+
+## 12. Aligning with `kotlin-ksp-mocks`: what its §11 and §12 ask of this repository
+
+Read on 2026-09-12 from
+`/Volumes/DATA01/Projects/kotlin-ksp-mocks/specs/002-property-accessors-and-stream-counters/spec.md`
+§11 and §12. That section was written against this branch at `c332601` — its P1 to P11 — and rules
+four decisions on its own side: **D15 (c), D16 (a), D17 (a), D18 (c)**. Its §12.3 hands four items
+to this repository.
+
+This section extracts those four, states each against the current tree with the line numbers checked
+here, adds what they cost measured on this repository and on `modaal-firebase-wrappers`, and
+proposes D18 to D21. **Nothing here is implemented and nothing is ruled.** §9's P9 amendment makes
+the Kotlin re-alignment the gate on the tag; this is that work in progress, not its close — the gate
+lifts when D18 to D21 are ruled and whatever they take has landed.
+
+### 12.1 What the comparison confirms
+
+Its §11.1 reports the two generators agreeing on every member name a test writes — `CallCount`,
+`Args`, `Handler`, `GetCount`, `GetHandler`, `SetCount`, `_<prop>`, the six stream words — and on
+the `"<fn>Handler expected to be set."` string, which is §2.4's wording byte for byte. Four shapes
+agree beyond the names: the property accessor's statement order and the order its members are
+emitted in, the stream member order, the overload long form, and refusing generation on a collision
+by reading the names back out of the emitted declarations. `<name>Subject` against `<fn>Channel` is
+the one name that differs by decision, as §9's twin table already records.
+
+### 12.2 The four items its §12.3 hands here
+
+**1. The twin table is stale in three rows** (`references/generated-api.md:226-245`). It describes
+that processor as it was before its P1 to P3, and `run-skill-checks.sh` reads this repository's
+renderer and not that one, so nothing goes red on it. Their §12.3 item 1 gives the replacement rows:
+`<var>GetCount` / `<var>GetHandler` map to `<prop>GetCount` / `<prop>GetHandler` **on every
+property**; `<var>SetCount` to `<prop>SetCount` on a `var` requirement; `_<var>` to `_<prop>`; and
+the six stream members map across on a `Flow`-returning function or a read-only `Flow` property. Two
+rows leave the "no counterpart" table — `:241` and `:242` — and the `AnyObserver`,
+`AnyCancellable` / `Disposable` and per-declaration-annotation rows stay. Two prose claims move with
+them: `references/generated-api.md:131-132` ("a read-only requirement's witness is still settable")
+and `CONTRIBUTING.md:242-243` ("The witness stays settable wherever it was settable before that
+change"), both of which state the rule item 2 replaces.
+
+**2. D15 (c) — the witness of a `{ get }` requirement becomes get-only.** Their D2 (a) emits
+`override val` and keeps `mock._<prop> = value` as the seed path; ruling (c) asks this side to
+match, so that **`mock._<prop> = value` is the only assignment that seeds a read-only requirement,
+and it is the same expression on both platforms** (their §12.4). The edit is two lines:
+`MockVar.swift:178` becomes `let hasSetter = !hasEffects && variable.isMutable`, and the
+`if variable.isMutable && hasSetter` guard at `:195` reduces to `hasSetter`. `const` and `handler`
+are already get-only and do not move; the store stays `var _<var>` for everything but `const`.
+
+What it supersedes here is not §2.5 — §2.5 never stated it — but the rule P5 decided against a
+measurement, in §9's P5 entry: "the witness stays settable wherever it is settable today", the table
+under it, and the comment at `MockVar.swift:167-177` recording why. Their §12.4 argues the break
+lands only on code holding the concrete `<Type>Mock`: a `{ get }` requirement exposes no setter
+through an existential or a generic parameter, so nothing assigns one through the protocol.
+Measured in §12.3.
+
+**3. Wrap a method's handler-supplied publisher** (their §12.3 item 3, their §9 and D6). A method
+returning `AnyPublisher` returns the handler's publisher before the `Deferred` / `handleEvents`
+chain — `Snapshots/Mocks.generated.swift:441-455` is the emitted shape — so a seeded method stream
+moves no `SubscribeCount`, `OutputCount` or `CompletionCount`, while the property branch reads its
+handler *inside* the `Deferred` and is counted. Their §2.3 wraps both. Ruled on neither side.
+Combine counts a subscription inside the `Deferred` closure, so adopting it means giving the
+handler's publisher a `Deferred` of its own —
+`Deferred { self?.<name>SubscribeCount += 1; return handler(args) }` — ahead of the existing chain.
+Until it lands, `<name>OutputCount` means "values delivered" on both platforms for a property and
+for a channel-backed method, and "values delivered by the subject only" for a handler-seeded method
+here.
+
+**4. The record 004 owes.** Under this repository's append-only rule it goes in a follow-up file
+beside 004 rather than into the sections it corrects: §8's closing paragraph ("Until it lands, its
+stored-property branch emits `SetCount` alone") and P8's row for that repository's
+`references/generated-api.md` are both superseded by its P1 to P4, and D15 (c) supersedes the
+settable-witness rule P5 decided.
+
+### 12.3 What D15 (c) costs here, measured on 2026-09-12
+
+Their §12.4 leaves the consumer count unmeasured. It is measured here against the output this branch
+generates at `c332601`. A witness that loses its setter is one whose `set` block carries no
+`<var>SetCount` — a read-only requirement backed by a store:
+
+| | witnesses that become get-only | `{ get set }` witnesses, unaffected |
+| --- | ---: | ---: |
+| `Tests/Checks/Snapshots/Mocks.generated.swift` | **23** | 5 |
+| `modaal-firebase-wrappers`, 7 modules regenerated | **69** | 4 |
+
+What stops compiling, by grep for an assignment to one of the 52 distinct names those 69 witnesses
+carry, over that repository's `Tests/` and `Examples/`:
+
+| | sites | where |
+| --- | ---: | --- |
+| `modaal-firebase-wrappers`' own tests | **12** | `FirebaseAuthCombineTests` (4), `DocumentReferenceCombineTests` (4), `QueryDocumentSnapshotProtocolTests` (2), `FirestoreCombineTests` (1), `QueryCombineTests` (1) |
+| this repository's `Tests/Checks/Behaviour/Main.swift` | **3** | `recordPermission` at `:45`, `installationId` at `:110` and `:530` — P5 recorded the third as `:422`, before P6 and P7 grew the file |
+
+Every receiver at those 12 sites is a `<Protocol>Mock` — `newDocMock.documentID`, `mock.count`,
+`userMock.uid`, `snapshot.documents` — so the grep's one false-positive risk, a non-mock receiver
+with a member of the same name, does not occur. Each site becomes `_<var>`.
+
+**One assertion inverts rather than moving.** `Main.swift:46` reads
+`expect(mock.recordPermission == .granted, "a read-only requirement is settable on the mock")`. It
+is the behaviour-harness form of the rule D15 (c) retires, so it is deleted or rewritten rather than
+re-pointed at `_recordPermission`.
+
+**No deprecation window exists.** `@available(*, deprecated)` marks a property and not one accessor,
+so a release that keeps the setter and warns on it cannot be written. The change lands as
+`cannot assign to property: … is a get-only property` at each site.
+
+### 12.4 Three divergences that ask nothing of this repository
+
+- **The collision diagnostic text** (their §11.2 item 3). Theirs names the two declarations behind
+  the name; `MockError.collidingMemberNames` (`MockGenerator.swift:202-209`) names the type, the
+  member and `/// sourcery: methodName`, which has no counterpart there. Neither string is part of
+  the shared contract — the member names and `"<fn>Handler expected to be set."` are.
+- **`skipArgumentRecording` has no counterpart** (their §11.2 item 4, their D9). It turns
+  `<var>Outputs` off as well as `<method>Args` here, so this side can generate a stream member that
+  counts without recording. §9's twin table already carries the annotation row.
+- **D18 (c), keyword-named requirements.** Their §11.3 measured that a Kotlin interface declaring
+  ``val `object` `` generates a file that fails the consumer's compile with 48 errors, and ruled
+  (c): each language's reserved words stop at its own boundary, and such an interface is the
+  adopter's to rename. §2.1's backtick rule here is unaffected — `object` and `in` are ordinary
+  Swift identifiers, `func` and `guard` are the reverse.
+
+### 12.5 One divergence neither side has measured
+
+Their §11.2 item 5: inside an overload group both sides order by parameter count first, and then
+differ. Here `areInAscendingOrder` (`MockMethod.swift:391-403`) prefers the overload whose first
+parameter has no argument label; there, their spec reports `MockRenderer.kt:161-178` ordering by the
+joined rendered parameter types. Two overloads with the same parameter count can therefore keep the
+plain name on one platform and take the long form on the other. No fixture in either repository
+declares such a pair, so neither side has a generated file showing which name it produces.
+`Naming.swift`'s `NamingOverloads` is where one would go: `reference(withPath:)` and
+`reference(forURL:)` already have equal parameter counts, but both carry labels, so they exercise
+the fallback rather than the tie-break. D21.
+
+### 12.6 Decisions this section proposes
+
+**D18 — does a `{ get }` requirement's witness become get-only?**
+
+**Ruled (a) — §12.8.**
+
+- **(a) Adopt D15 (c) (recommended).** `mock._<var> = value` becomes the one seed path, the same
+  expression a test writes on both platforms, and the mock stops offering a setter the protocol does
+  not declare. Cost, from §12.3: 23 fixture witnesses and 69 consumer witnesses change shape, 12
+  consumer assignment sites and 3 of this repository's own stop compiling, and one behaviour
+  assertion inverts. It is a second source break, and this is the release to take it in: a consumer
+  is already fixing compile errors from §2.1's renames, and `_<var>` is named in each new one.
+- (b) Keep the settable witness and ask the Kotlin side to reconsider D15 (c). Their §11.6 listed
+  that as its own option (c) and ruled against it; re-opening it costs a second round and leaves
+  `mock.<prop> = value` compiling on one platform only.
+- (c) Adopt it behind an annotation — a `/// sourcery:` verb that keeps the setter. It adds a record
+  to `AnnotationRegistry.swift` and a verb to every rendered table, for a migration aid D6 already
+  ruled against for names.
+
+**D19 — when the twin table is corrected.**
+
+**Ruled (a) — §12.8.**
+
+- **(a) In this branch, before the tag (recommended).** The rows describe a processor that has
+  already shipped its P1 to P3, and `CHANGELOG.md`'s entry points a reader at
+  `references/generated-api.md` for the Kotlin map. If D18 (a) is taken, the transitional row their
+  §12.3 item 1 names is never needed: both changes land together.
+- (b) In a follow-up file and a separate documentation push after the tag. It leaves the tag
+  shipping a table that is wrong in three rows.
+
+**D20 — wrapping a method's handler-supplied publisher.**
+
+**Ruled (a) — §12.8.**
+
+- **(a) Not in this release (recommended).** It is unruled on both sides, it changes what
+  `<name>SubscribeCount` and `<name>OutputCount` mean for a handler-seeded method, and §2.7's
+  refusal and P7's construct are what this release already asks a consumer to absorb. Record it as
+  open here and in their §11.7.
+- (b) Take it now, so `<name>OutputCount` means "values delivered" for every member on both
+  platforms. One `Deferred` around the handler's publisher in `MockMethod`'s branch, a behaviour
+  check that a seeded method stream moves `SubscribeCount`, and a snapshot re-record.
+
+**D21 — the overload tie-break (§12.5).**
+
+**Ruled (a) — §12.8.**
+
+- **(a) Add the fixture, then decide (recommended).** Two overloads with equal parameter counts
+  where one has no argument label — `func send(_ value: String)` and `func send(to target: String)`
+  — put the rule in `Snapshots/Mocks.generated.swift`, where the Kotlin side can read what this one
+  produces. One fixture protocol, and it is what a comparison needs before either side changes.
+- (b) Make the two rules one rule now, in both repositories, with no fixture on either side.
+- (c) Record it as a known divergence in both twin tables and leave it. A protocol that hits it gets
+  different member names on the two platforms, and nothing says so.
+
+### 12.7 Phasing, if these are taken
+
+**P12 — the get-only witness (D18).** `MockVar.swift:178` and `:195`; the three assignments and the
+one assertion in `Tests/Checks/Behaviour/Main.swift`; `references/generated-api.md:131-132` and
+`CONTRIBUTING.md:242-243` restated; `CHANGELOG.md` gains it as a second source break, with `_<var>`
+as the one-line fix and the 12 measured sites in the consumer. Gates: `run-checks.sh` with the
+snapshot re-recorded after the diff is read, both language modes, and the example lane.
+
+**P13 — the twin table (D19).** `references/generated-api.md:226-245` takes the rows their §12.3
+item 1 gives. No template change, so no snapshot moves. Gate: `run-skill-checks.sh` for the line
+budget. The table is in a reference and not in the body, so the skill's token figure does not move.
+
+**P14 — the overload tie-break fixture (D21 (a)).** One protocol in
+`Tests/Checks/Fixtures/Naming.swift` and a re-record. Independent of the tag.
+
+P12 and P13 land before the tag, and closing §9's P9 amendment is what they are for. P14 and D20 do
+not block it.
+
+### 12.8 Ruled
+
+Ruled 2026-09-12: **D18 (a), D19 (a), D20 (a), D21 (a)** — each section's recommendation, so nothing
+in §12.6 is superseded. What that settles:
+
+- **D18 (a).** A `{ get }` requirement's witness becomes get-only, and `mock._<var> = value` is the
+  one way a test seeds it — the same expression `kotlin-ksp-mocks` writes. It lands in this release,
+  beside §2.1's renames.
+- **D19 (a).** The twin table is corrected in this branch, before the tag. D18 (a) landing with it
+  means the transitional row their §12.3 item 1 describes is never written.
+- **D20 (a).** A method's handler-supplied publisher is not wrapped in this release. It stays open
+  here and in their §11.7, and `<name>OutputCount` keeps the two meanings §12.2 item 3 names.
+- **D21 (a).** The overload tie-break gets a fixture, so the name this generator produces is in the
+  snapshot for the Kotlin side to read. Nothing about the rule changes yet.
+
+P12, P13 and P14 are §12.7 as written. P12 and P13 close §9's P9 amendment; P14 does not block the
+tag and lands with them because it is one fixture and a re-record.

--- a/specs/004-mock-member-naming/spec.md
+++ b/specs/004-mock-member-naming/spec.md
@@ -1197,3 +1197,30 @@ added lines, no deleted line — no fixture declared an overload whose argument 
 parameter name); both language modes clean; behaviour checks pass;
 `Tests/Examples/ExampleProjectSpm/test-ios.sh` 19 tests, 0 failures, which is where the
 return-type-discriminated `data()` overloads are exercised.
+
+### P4 — one wording for both traps
+
+`MockNaming.getHandlerExpectedMessage(prefix:)` now returns
+`handlerExpectedMessage(handlerName: getHandler(prefix))`, so the property form is the method form
+with the property's handler name in it: `snapshotGetHandler expected to be set.` replaces
+`` `snapshotGetHandler` must be set! ``. One function produces both, which is what stops them
+drifting again.
+
+`Tests/Checks/Fixtures/Properties.swift` is new and declares `PropertyShaped`, one requirement per
+branch of `MockVar.mockImpl`: `identifier` (read-only, synthesizable default), `draft`
+(`{ get set }`), `themeProvider` (no default, initializer-seeded), `buildNumber`
+(`/// sourcery: const`, emitted `let buildNumber: Int = 0`), `snapshot` (`/// sourcery: handler`,
+read-only) and `cursor` (`/// sourcery: handler`, `{ get set }`).
+
+**Nothing under `Tests/` carried `/// sourcery: handler` before this file**, so the string that
+diverged from the method's appeared in no generated file this repository holds — which is how it
+stayed divergent. The two `handler` requirements put both emission shapes in the snapshot: a
+read-only one whose getter is the property body, and a mutable one whose `get` traps while its `set`
+counts.
+
+No suffix moved in this phase. D4 keeps `Dispose*` against `Disposable` and `Cancel*` against
+`AnyCancellable`, and the `SKILL.md:202` correction that documents each against its own return type
+is a document change, in P8.
+
+Gates: `run-checks.sh`, diff read, then `--record` — 39 added lines, no deleted line; both language
+modes clean; behaviour checks pass.

--- a/specs/004-mock-member-naming/spec.md
+++ b/specs/004-mock-member-naming/spec.md
@@ -1115,3 +1115,39 @@ and §2.8 leaves unchanged.
 Gate: `Tests/Checks/run-checks.sh` passed with no `--record` — both snapshots byte-identical, both
 language modes clean, all behaviour checks green. `run-annotation-checks.sh` and
 `run-skill-checks.sh` pass.
+
+### P2 — the prefix is the declared name
+
+`MockNaming.swiftifiedMemberName` is gone. `methodPrefix`, `overloadGroupKey` and `variablePrefix`
+each strip backticks and do nothing else, so §2.1's table is what the templates emit.
+
+`templates/Utility/StringLettercase.swift` went from 147 lines to 101: `lowercasedFirstWord`,
+`lowercasedFirstLetter` and `snakeCased`, and the private `lowerFirstWord`, `lowerFirstLetter` and
+`camelToSnakeCase` behind them, had no caller left. `uppercasedFirstLetter` and `camelCased` stay,
+both called only from `MockNaming.swift` and only by the overload long form and the return-type
+discriminator. The file that crashed generation on `func ID()` (§1.2) is deleted rather than fixed.
+
+**Backtick removal on the property path is load-bearing, which §7 recorded as unmeasured.**
+`Tests/Checks/Fixtures/Naming.swift` declares ``var `default`: Int { get set }``;
+`SourceryRuntime.Variable.name` carries the backticks, so the witness is emitted as
+``var `default`: Int = 0`` and the counter as `defaultSetCount`. Without the strip the counter would
+have been `` `default`SetCount ``, which is not an identifier.
+
+`Tests/Checks/Fixtures/Naming.swift` (four protocols, 11 requirements) is the new coverage:
+`NamingUnderscores` puts `func perform1_0()` beside `var setting4_2: Int { get set }`, which is §1.1;
+`NamingManyToOne` declares `load_data()` and `loadData()`, which failed generation with "not all
+duplicates resolved" before this phase and now carry `load_dataCallCount` and `loadDataCallCount`;
+`NamingUppercase` declares `ID()` and `URLSession()`, the §1.2 trap; `NamingKeywords` declares
+``var `default```, ``func `do`()`` and ``func `repeat`(times:)``.
+
+**No existing fixture member was renamed.** The recorded diff is 110 added lines and no deleted
+line: every declaration under `Tests/Checks/Fixtures/` was already lowerCamelCase with no
+underscore, which the old transform mapped to itself. That matches §5's finding for
+`modaal-firebase-wrappers` — §2.1 renames there: none — and means the transform's failures were
+reachable only through declarations no fixture carried.
+
+Gates: `Tests/Checks/run-checks.sh`, diff read, then `--record`; both language modes clean; all
+behaviour checks pass. `Tests/Examples/ExampleProjectSpm/test-ios.sh`: 19 tests, 0 failures — the
+RxSwift, type-erasure and return-type-overload specs assert on prefixes this phase could have moved
+and did not. That script resolves its scheme from the working directory, so it runs from
+`Tests/Examples/ExampleProjectSpm/`, not from the repository root; P8 adds that to `CONTRIBUTING.md`.

--- a/specs/004-mock-member-naming/spec.md
+++ b/specs/004-mock-member-naming/spec.md
@@ -1084,3 +1084,34 @@ committed generated files, and in whatever repository downstream imports that mo
 separate iteration in that repository. Until it lands, its stored-property branch emits `SetCount`
 alone (`MockRenderer.kt:127-140`) and the twin table in each repository names the row the other does
 not carry (P8).
+
+---
+
+## 9. What landed
+
+Appended as each phase of §4 completes, one entry per phase: what the phase changed, what gate it
+passed, and where it departed from the plan.
+
+### P1 — `MockNaming.swift` extracted, output unchanged
+
+`templates/Mocks/MockNaming.swift` (156 lines) now holds the prefix derivation, the overload
+component and group key, the return-type discriminator, every suffix, the handler local's spelling
+and the two `fatalError` strings. The rules moved verbatim, the §1.2 transform included, under the
+name `swiftifiedMemberName` — §2.1 deletes it in P2.
+
+The 32 sites of §1.8 are calls: `MockMethod.swift` routes `mockedMethodName`,
+`returnTypeDiscriminator`, `mockedVarCallCountName`, `mockedVarArgsName`, `mockMethodHandlerName`,
+`shortNameKey`, the handler local and the trap string; `MockVar.swift` routes `mockedVariableName`
+and its `GetCount` / `GetHandler` / `SetCount` / trap sites; `SourceryRuntimeExtensions.swift` routes
+`Subject`, `EventCallCount`, `EventHandler`, `CancelCallCount`, `CancelHandler`, `DisposeCallCount`
+and `DisposeHandler`. `Mocks.swifttemplate` and `Component.swifttemplate` both `includeFile` the new
+file before `Mocks/MockMethod` — the Component template compiles the same mock sources.
+
+Two names the module does **not** own, and why: the emitted property's own name (`var <var>:` in
+`MockVar.mockImpl`) is the protocol requirement's name and is what the conformance is checked
+against, not a bookkeeping name; and `<Protocol>Mock` itself, which `MockGenerator.swift:54` builds
+and §2.8 leaves unchanged.
+
+Gate: `Tests/Checks/run-checks.sh` passed with no `--record` — both snapshots byte-identical, both
+language modes clean, all behaviour checks green. `run-annotation-checks.sh` and
+`run-skill-checks.sh` pass.

--- a/specs/004-mock-member-naming/spec.md
+++ b/specs/004-mock-member-naming/spec.md
@@ -1224,3 +1224,59 @@ is a document change, in P8.
 
 Gates: `run-checks.sh`, diff read, then `--record` — 39 added lines, no deleted line; both language
 modes clean; behaviour checks pass.
+
+### P5 — every property requirement counts its reads
+
+`MockVar.mockImpl`'s stored branch is gone. Every property requirement that is not
+`/// sourcery: handler` now emits the accessor pair over `_<var>`, and
+`MockGenerator.swift`'s initializer assigns `MockNaming.store($0.mockedVariableName)` while its
+parameter keeps the requirement's own name — so `Mock(themeProvider:)` is unchanged and construction
+moves no counter.
+
+**One rule §2.5 did not state, decided here against a measurement: the witness stays settable
+wherever it is settable today.** A read-only requirement backed by a `var` store was emitted as a
+settable stored property (`var recordPermission: RecordPermission`), and
+`skills/swift-sourcery-mocks/references/generated-api.md:139` documents that as the way a test
+re-seeds it. Making every read-only witness get-only broke three assignments in this repository's
+own `Tests/Checks/Behaviour/Main.swift` — `recordPermission` at `:45` and `installationId` at `:110`
+and `:422` — with `cannot assign to property: … is a get-only property`, which is what §5's claim
+that the property change is "additive: nothing that compiles against those mocks today stops
+compiling" would have cost. The emitted rule is therefore:
+
+| requirement | witness | `<var>SetCount` |
+| --- | --- | --- |
+| `{ get set }` | `get` + `set` | counted on write |
+| `{ get }` | `get` + `set` | not emitted — a re-seed was uncounted before and stays uncounted |
+| `{ get }`, `/// sourcery: const` | `get` only, `let _<var>` | not emitted |
+| `{ get }`, `/// sourcery: handler` | `get` only, no store | not emitted |
+| `{ get set }`, `/// sourcery: handler` | `get` + `set`, no store | counted on write |
+
+Isolation carries through unchanged: `nonisolated var installationId` on the accessors,
+`nonisolated(unsafe) var _installationId` on the store and the counters
+(`Snapshots/Mocks.generated.swift:225-238`).
+
+Recorded diff: 408 added lines, 46 deleted. 27 property members gained `GetCount` — the snapshot
+went from 8 to 35 — against §5's estimate of 21, the difference being the properties `Naming.swift`
+and `Properties.swift` added in P2 and P4.
+
+`Tests/Checks/Behaviour/Main.swift` gains `checkPropertyCounting`, 11 assertions: construction
+counts no read, two reads count two, a seed through `_<var>` counts none, a write to a `{ get set }`
+requirement counts a write and no read, the value written is the value read, a seed through the
+store counts no write, and `<var>GetHandler` wins over the store while leaving it alone.
+
+The collision gate gains the two cases this phase's new names create: a protocol declaring
+`draftGetCount` beside `draft`, which was not a collision before (`GetCount` reached only computed
+getters), and one declaring `_draft`, which is the name D9 chose. Four cases now.
+
+**`kotlin-ksp-mocks` adopting §2.5 is not a no-op, and `SetCount` is not what divides the two
+generators.** Re-read at `MockRenderer.kt:127-140`: its stored branch emits `SetCount` for a mutable
+property and nothing at all for a read-only one — no counter, no handler, no store — while its
+`GetCount` / `GetHandler` pair exists only on the `isReadOnlyFlow` branch (`:109-123`). Swift emitted
+`SetCount` for a mutable stored property before this spec and still does, so the two have always
+agreed there. What that processor would have to adopt is `GetCount`, `GetHandler` and the store on
+every property requirement. §8's closing note stands.
+
+Gates: `run-checks.sh`, diff read, then `--record`; both language modes clean; behaviour checks
+pass; `Tests/Examples/ExampleProjectSpm/test-ios.sh` 19 tests, 0 failures, including
+`UploadProgressingMock, progressGetCount == 0`, which reads a publisher property's counter this
+phase leaves to P7.

--- a/specs/004-mock-member-naming/spec.md
+++ b/specs/004-mock-member-naming/spec.md
@@ -1151,3 +1151,49 @@ behaviour checks pass. `Tests/Examples/ExampleProjectSpm/test-ios.sh`: 19 tests,
 RxSwift, type-erasure and return-type-overload specs assert on prefixes this phase could have moved
 and did not. That script resolves its scheme from the working directory, so it runs from
 `Tests/Examples/ExampleProjectSpm/`, not from the repository root; P8 adds that to `CONTRIBUTING.md`.
+
+### P3 — the overload long form, and one collision check over every emitted name
+
+`MockNaming.overloadComponent` returns `(argumentLabel ?? parameterName).withoutBackticks
+.uppercasedFirstLetter()`, which is §2.2 step 2. `Tests/Checks/Fixtures/Naming.swift` gains
+`NamingOverloads`, whose five requirements produce `end`, `endAt`, `endAtDocument`,
+`referenceForURL` and `referenceWithPath` — §2.2's table, with `end()` keeping the plain prefix as
+the fewest-parameters overload (D3).
+
+`MockNaming.checkForCollisions(amongMemberDeclarations:typeName:)` reads the names back out of the
+declarations the class emits. `MockGenerator.generate` calls it once per type, after every member
+has been emitted, over `mock.nested.map { $0.line }` — which is exactly the class's direct members,
+because both `MockVar.mockImpl` and `MockMethod.mockImpl` return the witness and its bookkeeping as
+siblings. Reading the emitted declarations rather than enumerating names at each site is what makes
+it cover the branches in `SourceryRuntimeExtensions.swift` — `Subject`, `EventCallCount`,
+`CancelHandler` and the rest — without those sites being edited, and what makes P5's `_<var>` and
+P7's six publisher members arrive already checked.
+
+`declaredPropertyName(inDeclaration:)` reads `var` and `let` only, after stripping
+`nonisolated(unsafe) `, `nonisolated ` and `lazy `. Two `func`s may share a base name — they are the
+protocol's own overloads and Swift allows them — while two properties of one class may not, and
+every bookkeeping member is a property.
+
+`MockError.internalError("not all duplicates resolved")` is replaced at `MockMethod.from` by
+`MockError.collidingMemberNames(typeName:memberName:)`, so §2.2 step 4 and D9's property case now
+produce one wording: the mock class, the member declared twice, and the two fixes — rename the
+requirement, or `/// sourcery: methodName = "customName"` on a method.
+
+`run-checks.sh` gains a **collision** section (now gate 4 of 6), built like the near-miss one
+because each case has to fail generation and a fixture that fails takes the whole lane's generation
+with it. Two cases, each asserted to fail *and* to name its protocol and its member:
+
+| case | declarations | message names |
+| --- | --- | --- |
+| `bookkeeping` | `var draft { get set }` beside `var draftSetCount { get set }` | `CollidingBookkeeping`, `draftSetCount` |
+| `overload` | `send(to target: String)` beside `send(to target: Int)` | `CollidingOverload`, `sendToVoidCallCount` |
+
+The second is §2.2 step 4 reached: the long form gives both `sendTo`, the return-type discriminator
+appends `Void` to both, and the name that collides is therefore `sendToVoidCallCount` — the
+discriminator is in the message because it is in the name the mock would have declared.
+
+Gates: `run-checks.sh`, diff read, then `--record`; no existing fixture member was renamed (110
+added lines, no deleted line — no fixture declared an overload whose argument label differs from its
+parameter name); both language modes clean; behaviour checks pass;
+`Tests/Examples/ExampleProjectSpm/test-ios.sh` 19 tests, 0 failures, which is where the
+return-type-discriminated `data()` overloads are exercised.

--- a/specs/004-mock-member-naming/spec.md
+++ b/specs/004-mock-member-naming/spec.md
@@ -1,0 +1,1086 @@
+# 004 — One naming rule for generated mock members
+
+**Status:** Proposed. Nothing here is implemented. §2 states the rule this proposes, §3 records each
+decision with the options considered and a recommendation, §4 phases the work. The phases are
+separable: P1 changes no output, P2 is the change the measurements below argue for, and P3–P4 are
+consolidations that can be dropped without affecting P2.
+
+**Measurements:** every number, path and quoted string in §1 was produced on 2026-09-11 against
+`master` at `8034c2b`, using working copies present on this machine: the eval lab
+(`/Volumes/DATA01/Projects/modaal-agent-devto-mock-generation-lab`), its run root
+(`/Volumes/DATA01/mock-lab`), `kotlin-ksp-mocks` and `modaal-firebase-wrappers`. Nothing in any
+repository was changed to take them; the two transform measurements in §1.2 were taken by copying
+the function under test into a standalone file in the session scratchpad and compiling it.
+
+**Scope of the change:** `templates/Mocks/MockMethod.swift`, `templates/Mocks/MockVar.swift`,
+`templates/Mocks/MockGenerator.swift`, `templates/Mocks/SourceryRuntimeExtensions.swift`,
+`templates/Utility/StringLettercase.swift`, the fixtures and snapshots under `Tests/Checks/`, the
+specs under `Tests/Examples/ExampleProjectSpm/`, `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`,
+`AGENTS.md`/`CLAUDE.md` and `skills/swift-sourcery-mocks/`. It is a breaking change to generated
+output. Outside this repository it touches `modaal-firebase-wrappers` (the regenerate in §5) and one
+paragraph of `kotlin-ksp-mocks/skills/kotlin-ksp-mocks/references/generated-api.md` (§4, P5).
+
+**Not in scope:** an annotation-registry-style declaration file with a CI job checking three sources
+for drift. Member naming stays gated by the snapshot diff and by review while the rule is being
+iterated on; §3 D7 records the deferred option.
+
+**Obsoletes:** nothing.
+
+**Follows:** 003 §4 option 1 (bump `modaal-firebase-wrappers` and commit its regenerated output).
+That bump is required by this change rather than optional, and §5 states how the two combine.
+
+---
+
+## 0. TL;DR
+
+1. A mocked **method**'s bookkeeping prefix is rewritten before use — backticks stripped, `(` and
+   `:` turned into `_`, then camel-cased and first-word-lowercased (`MockMethod.swift:50-62`,
+   `:254-261`). A mocked **property**'s prefix is the declared name, unchanged
+   (`MockVar.swift:8-10`). Both appear in one generated class: `stream3_4()` produces
+   `stream34Subject` beside `updates1_1` producing `updates1_1Subject` (§1.1).
+2. The method transform is many-to-one and can trap. `perform1_0`, `perform10` and `perform_1_0` all
+   produce `perform10`; an all-uppercase method name (`func URL()`) aborts generation with
+   `Fatal error: String index is out of bounds` (§1.2).
+3. An overloaded method appends the capitalized argument label **and** the capitalized parameter
+   name for every parameter, so `func end(atDocument document:)` produces `endAtDocumentDocument`
+   and `func reference(withPath path:)` produces `referenceWithPathPath` (§1.3).
+4. The same declaration produces different names in different mocks: `func data() -> [String: Any]?`
+   is `dataCallCount` in `DocumentSnapshotProtocolMock` and `dataStringAnyOptionalCallCount` in
+   `QueryDocumentSnapshotProtocolMock` (§1.4).
+5. In one lab run an agent wrote `perform3_0CallCount` — the declared name — and
+   `load9_0ReturnValue` — a suffix from another generator's dialect — and the build named both
+   (§1.5).
+6. Nothing states the derivation rule. `SKILL.md`'s member table writes `<method>` and `<var>`
+   without saying how either is derived; the overload rule is in `references/generated-api.md` only,
+   which a `--restricted` eval arm cannot open (§1.7). `SKILL.md:202` also states a member name the
+   templates do not emit (§1.7).
+7. Member names are composed at 32 sites across three template files (§1.8).
+8. A stored property requirement generates no read counter: `<var>GetCount` exists only where the
+   getter is already computed (`MockVar.swift:64-118`). The Kotlin processor has the same gap
+   (`MockRenderer.kt:127-140`), and a lab run planned 20 test cases against a `value6_0GetCount`
+   that does not exist before re-reading and replanning
+   (`findings/what-the-runs-said-about-the-work.md` §2).
+9. Nothing checks that a property's generated names are unique: `MockMethod.from` guards methods
+   (`MockMethod.swift:24-26`) and `MockVar.from` guards nothing (`MockVar.swift:17-20`), so a
+   protocol declaring both `draft` and `draftGetCount` emits the same declaration twice and the
+   generated file does not compile (§3 D9).
+10. **The rule this proposes:** the prefix is the declared name with backticks removed, for a method
+    and a property alike; an overloaded method appends its selector's labels; every property
+    requirement carries `GetCount`, `GetHandler`, a `_<var>` store and — when settable — `SetCount`;
+    an effectful requirement carries the accessor it declares; a publisher member hands back a
+    `Deferred` the mock owns, counting subscriptions, cancellations, values delivered and
+    completions, with `<name>OutputHandler` and `<name>Outputs` beside the values, and an
+    `AnyObserver` member records `<name>Events` the way a method records `<method>Args`; every
+    emitted name goes through one uniqueness check; and the suffix set is fixed and lives in one
+    file (§2).
+
+---
+
+## 1. Measured
+
+### 1.1 Two transforms in one generated class
+
+`MockMethod.swift:50-62` builds a method's prefix and ends with `.swiftifiedMethodName`
+(`MockMethod.swift:254-261`), which replaces `(` with `_`, drops `)`, replaces `:` with `_`, drops
+backticks, calls `camelCased()` (`templates/Utility/StringLettercase.swift:86-110`) and then
+`lowercasedFirstWord()` (`:37-50`). `camelCased()` splits on `_` and capitalizes each component, so
+the underscores are removed.
+
+`MockVar.swift:8-10` returns `variable.name` with no transform.
+
+Measured on the mock generated inside lab run `swift-G-r3-10x2-s1-20260911-155532`
+(`work/tree/.build/plugins/outputs/tree/PaymentsServiceTests/destination/SourcerySwiftCodegenPlugin/.generatedFiles/Sourcery.Mocks/Mocks.generated.swift`),
+whose protocols are at `work/tree/Sources/PaymentsKit/Protocols.swift`: **19 of 19 declared methods
+produce a prefix that differs from the declared name**, and every property prefix is the declared
+name.
+
+| declared | generated |
+| --- | --- |
+| `func perform1_0()` | `perform10CallCount`, `perform10Handler` |
+| `func load1_4(id:)` | `load14CallCount`, `load14Args`, `load14Handler` |
+| `func stream3_4() -> AnyPublisher<String, Never>` | `stream34CallCount`, `stream34Subject` |
+| `var setting4_2: Int { get set }` | `setting4_2SetCount` |
+| `var updates1_1: AnyPublisher<String, Never> { get }` | `updates1_1GetCount`, `updates1_1Subject` |
+
+The last two rows and the third are in the same generated file: a stream declared as a method loses
+its underscore, a stream declared as a property keeps it.
+
+### 1.2 The method transform is many-to-one, and one input traps
+
+`swiftifiedMethodName` maps distinct declarations onto one prefix. Measured by compiling
+`StringLettercase.swift`'s `snakeToCamelCase` and `lowerFirstWord` verbatim into a standalone file
+and running the pipeline over a list of inputs:
+
+| input | output |
+| --- | --- |
+| `perform1_0` | `perform10` |
+| `perform10` | `perform10` |
+| `snake_case_name` | `snakeCaseName` |
+| `_private` | `_Private` |
+| `URLFor` | `urlFor` |
+| `HTTPGet` | `httpGet` |
+| `` `do` `` | `do` |
+
+Two methods whose names differ only by underscore placement therefore collide. The collision is
+caught: `MockMethod.from` (`MockMethod.swift:24-26`) throws `MockError.internalError` when
+duplicates survive disambiguation. Its message is
+`"Mock generator: not all duplicates resolved: \(mockedMethods.map { $0.mockedMethodName })"`, which
+lists every mocked name in the type and names no action. §2.2 step 4 states what it names instead.
+
+**An all-uppercase method name aborts generation.** `lowerFirstWord`'s loop
+(`StringLettercase.swift:39-43`) indexes `scalars[idx]` before testing `idx` against
+`scalars.endIndex`, so a string of uppercase scalars runs off the end. Measured by compiling that
+function verbatim (`swiftc -Onone`) and calling it with `"URL"`:
+
+```
+Swift/StringIndexValidation.swift:121: Fatal error: String index is out of bounds
+```
+
+`func URL()` and `func ID()` are legal Swift protocol requirements. No fixture under
+`Tests/Checks/Fixtures/` and no protocol in `Tests/Examples/` declares one, so no lane covers this.
+The property path never calls the transform, so a property named `URL` generates.
+
+### 1.3 An overloaded method carries the label and the parameter name
+
+`MockMethod.swift:53-59` appends, per parameter: the capitalized argument label when the label is
+present **and** differs from the parameter name, then the capitalized parameter name.
+
+Measured in `modaal-firebase-wrappers`'s committed output (generated at templates 0.2.15, pinned at
+`scripts/generate-mocks.sh:9`):
+
+| declaration | emitted prefix |
+| --- | --- |
+| `func end(atDocument document: DocumentSnapshotProtocol)` (`Sources/ModaalFirestore/Protocols/QueryProtocol.swift:15`) | `endAtDocumentDocument` |
+| `func end(at fieldValues: [Any])` (`:21`) | `endAtFieldValues` |
+| `func reference(withPath path: String)` (`Sources/ModaalCloudStorage/Protocols/CloudStorageProtocol.swift:9`) | `referenceWithPathPath` |
+| `func reference(forURL url: String)` (`:8`) | `referenceForURLUrl` |
+| `func document(_ path: String)` | `documentPath` (`ModaalFirestoreMocks.swift:63-71`) |
+
+The selector a Swift reader writes for the first row is `end(atDocument:)`. The prefix repeats the
+label's last word as the parameter's name.
+
+### 1.4 One declaration, two names, decided by the rest of the mock
+
+`MockMethod.from` gives the plain prefix to the overload with the fewest parameters
+(`MockMethod.swift:395-434`) and falls back to a return-type-derived suffix when long names still
+collide (`:436-450`, `:277-300`). The requirement set includes inherited requirements, so a refining
+protocol changes the names of members it does not declare.
+
+In `modaal-firebase-wrappers/Sources/ModaalFirebaseMocks/Generated/ModaalFirestoreMocks.swift`:
+
+- `DocumentSnapshotProtocolMock` (`:305`) — `var dataCallCount` (`:327`), from
+  `func data() -> [String: Any]?`.
+- `QueryDocumentSnapshotProtocolMock` (`:405`), which refines it and adds
+  `func data() -> [String: Any]` — `var dataStringAnyCallCount` (`:427`) and
+  `var dataStringAnyOptionalCallCount` (`:436`).
+
+Across that repository's 7 generated files there are **107 distinct `<method>CallCount` prefixes
+over 152 emitted call counters, and 28 of the 107 are not equal to any `func` name declared anywhere
+in the repository** — that is, 26% of the method vocabulary cannot be read off a declaration's name
+at all.
+
+### 1.5 What this costs a run
+
+`RESULTS.md` §"Round 3 on three models" ¶2 reports G ÷ H in dollars: Swift 1.30 / 1.44 / **2.80**
+for `opus-5` / `sonnet-5` / `haiku-4.5`, Kotlin 1.48 / 1.00 / 0.96. The Swift generator arm on
+`haiku-4.5` took 41 turns, 7 builds and the only 2 build errors in that sweep, against sonnet's
+21/3/0 and opus's 14/3/0.
+
+One transcript carries the naming failure directly. In
+`/Volumes/DATA01/mock-lab/swift-G-r3-10x2-s1-20260911-182818/sessions/session.jsonl`:
+
+```
+error: value of type 'Dep3ServiceMock' has no member 'perform3_0CallCount'
+error: value of type 'Dep9ServiceMock' has no member 'load9_0ReturnValue'
+```
+
+The first is the declared name (`perform3_0`), which the generator had emitted as `perform30`. The
+second is a suffix (`ReturnValue`) from another Swift mock generator's vocabulary. No other
+`swift-*` run in that root wrote a member name the compiler rejected.
+
+The nearest Kotlin equivalent, in `kotlin-G-r3-10x2-s1-20260911-183602`, is
+`No parameter with name 'value4_0' found.` — the run spelled the member the way the interface
+declares it and was wrong about **which** members exist (a constructor-seeded property), not about
+how a name is spelled.
+
+`findings/what-the-runs-said-about-the-work.md` §2 records what both generator arms asked for when
+asked for one thing that would have made the job faster: the naming rule, stated where they would
+see it.
+
+### 1.6 What the Kotlin processor does
+
+`kotlin-ksp-mocks/mocks-processor/src/main/kotlin/dev/modaal/mocks/MockRenderer.kt`:
+
+- the prefix is the declared name, used verbatim (`:169`, `:191`, and `renderProperty` at `:105`);
+- an overload group is ordered by parameter count, the first keeps the plain name, the others append
+  their capitalized parameter names (`:83-97`);
+- a residual collision is a hard error naming the collisions (`:99-102`).
+
+Kotlin has no argument labels, so `update(id:force:)` → `updateIdForce` is the same on both sides
+today. The transform in §1.1 has no counterpart there.
+
+### 1.7 Where the rule is stated, and one place it is stated wrongly
+
+- `skills/swift-sourcery-mocks/SKILL.md:195-202` lists the suffixes against `<method>` and `<var>`
+  and never says how `<method>` or `<var>` is derived from a declaration.
+- The overload rule appears once, in `skills/swift-sourcery-mocks/references/generated-api.md`
+  §"Overloads". `Tests/Evals/README.md` records that under `--restricted` the with-skill arm cannot
+  open `references/*.md`, so a case run that way is answered from `SKILL.md` alone.
+- `README.md` §"Generated Mock API" and §"Recorded arguments" show the suffixes on worked examples
+  and state no derivation rule either.
+- No document in this repository or in the skill tree mentions the transform in §1.1.
+- `SKILL.md:202` reads: `` | `<method>CancelCallCount` | for a method returning `AnyCancellable` or
+  a `Disposable`: how many times the returned token was cancelled | ``. For `Disposable` the
+  templates emit `<method>DisposeCallCount` and `<method>DisposeHandler`
+  (`SourceryRuntimeExtensions.swift:431-436`). The documented name does not exist.
+
+A lab run did read the reference file and still read the generated output:
+`swift-G-r3-10x2-s1-20260911-181640` runs
+`sed -n 1,200p .claude/skills/swift-sourcery-mocks/references/generated-api.md`, then locates and
+prints `Mocks.generated.swift`.
+
+### 1.8 Where the names are built
+
+A member name is composed by interpolating a prefix with a suffix literal at **32 sites in three
+files**: `MockMethod.swift` 3 (through `mockedVarCallCountName` `:156-158`, `mockedVarArgsName`
+`:164-166`, `mockMethodHandlerName` `:210-212`), `MockVar.swift` 11 (`:73-113`),
+`SourceryRuntimeExtensions.swift` 18 (`:326-352`, `:398-436`). The two `fatalError` strings are
+written at `MockMethod.swift:146` and `MockVar.swift:91`, in different words:
+
+```swift
+methodImpl += "fatalError(\"\(mockHandler.0) expected to be set.\")"          // MockMethod.swift:146
+SourceCode("fatalError(\"`\(mockedVariableName)GetHandler` must be set!\")")  // MockVar.swift:91
+```
+
+`kotlin-ksp-mocks/skills/kotlin-ksp-mocks/references/generated-api.md` §"The same vocabulary in the
+Swift twin" records the divergence as a fact about this repository.
+
+### 1.9 What a consumer's tests assert on
+
+`/Volumes/DATA01/Projects/popapp/Apps/FabFun` generates mocks through the SPM plugin across 43 spec
+files. Its `Package.swift` files pin `from: "0.2.11"` and `Package.resolved` holds 0.2.11 exactly,
+so these mocks predate argument recording, which landed in 0.4.0 (`629a28e`, "Record the arguments
+of every mocked call"). Counted over those spec files:
+
+| what the test writes | references |
+| --- | ---: |
+| `<name>CallCount` | 84 |
+| `<name>Subject.onNext(…)` — driving a stream the mock exposes | 17 |
+| `<var>GetHandler = { Observable.just(…) }` — supplying a stream | 13 |
+| `<name>EventCallCount` | 1 |
+| `<name>EventHandler = { … }` | **0** |
+| `<name>Args` | 0 — the version has none |
+
+The single `AnyObserver` assertion is `LessonInteractorSpec.swift:220`,
+`expect(presenter.lessonObserverEventCallCount) == 1`, while the code under test pushes a particular
+value: `LessonInteractor.swift:173`, `presenter.lessonObserver().onNext(lesson)`. Asserting *which*
+lesson would take a handler that appends into a local array, and no spec file in the repository does
+that for any member.
+
+`modaal-agent-duet-services`, whose mocks do carry argument recording, inverts the ratio: **15
+`Args` references against 2 `CallCount`**, and they assert both what crossed and what did not —
+`XCTAssertEqual(high.handleOpenUrlArgs, [url])` and
+`XCTAssertEqual(catchAll.handleOpenUrlArgs, [], "a pre-settle event must not dispatch")`
+(`swift/Tests/ServicesTests/InboundAppServicesWorkerTests.swift:38`, `:102`).
+
+Where a recorder exists, tests assert on the recorded values. Where a counter and an observing
+handler exist, they assert the count and leave the value untested.
+
+---
+
+## 2. The rule this proposes
+
+### 2.1 The prefix is the declared name
+
+For every mocked member — method and property alike — the bookkeeping prefix is the member's
+declared name with backticks removed, and nothing else: no case change, no underscore removal, no
+first-word lowercasing.
+
+| declared | prefix |
+| --- | --- |
+| `func perform1_0()` | `perform1_0` |
+| `var setting4_2: Int { get set }` | `setting4_2` |
+| `func ID() -> String` | `ID` |
+| ``func `do`()`` | `do` |
+
+Stated for a reader in one sentence: **a mock member is the declared name plus the suffix.**
+
+This removes the transform at `MockMethod.swift:254-261`, the many-to-one mapping in §1.2 and the
+trap in §1.2, and makes the Swift prefix rule the same sentence as the Kotlin one (§1.6).
+
+### 2.2 An overloaded method appends its selector's labels
+
+When two or more requirements of the mock's full requirement set — inherited requirements included —
+share a base name, the chain is:
+
+1. The overload with the fewest parameters keeps the plain prefix. Between two with the same count,
+   the one whose first parameter has no argument label keeps it (`MockMethod.swift:412-422`,
+   unchanged).
+2. Every other overload appends, per parameter in declaration order, the capitalized **argument
+   label**, or the capitalized parameter name when the label is `_`.
+3. If step 2 leaves a collision, every overload in the group takes the form in step 2 and a suffix
+   derived from the return type is appended (`MockMethod.swift:277-300`, unchanged).
+4. If a collision survives step 3, generation fails naming the colliding members and
+   `/// sourcery: methodName = "customName"`.
+
+Step 2 is the change: today the label **and** the parameter name are both appended when they differ.
+
+| declaration | today | proposed |
+| --- | --- | --- |
+| `func end(atDocument document:)` | `endAtDocumentDocument` | `endAtDocument` |
+| `func end(at fieldValues:)` | `endAtFieldValues` | `endAt` |
+| `func reference(withPath path:)` | `referenceWithPathPath` | `referenceWithPath` |
+| `func update(id:force:)` | `updateIdForce` | `updateIdForce` |
+| `func putData(_ data:metadata:completion:)` | `putDataDataMetadataCompletion` | `putDataDataMetadataCompletion` |
+
+The last two rows are the Kotlin-comparable case (label equal to name, or absent), and they do not
+move.
+
+### 2.3 One suffix set
+
+| suffix | on | emitted when |
+| --- | --- | --- |
+| `CallCount` | method | always |
+| `Args` | method | at least one recordable parameter (`CONTRIBUTING.md` §"Design rules already decided") |
+| `Handler` | method | always |
+| `GetCount`, `GetHandler` | property | always (§2.5) |
+| `SetCount` | property | the requirement is `{ get set }` |
+| `_` prefix | property | `_<var>` is the stored value a test seeds or reads without moving a counter (§2.5) |
+| `Subject` | method, property | `AnyPublisher`, `Observable`, `Single` |
+| `SubscribeCount` | method, property | the type is `AnyPublisher` — the code under test subscribed (§2.7) |
+| `SubscribeCancelCount` | method, property | the type is `AnyPublisher` — it cancelled (§2.7) |
+| `OutputCount`, `OutputHandler`, `Outputs` | method, property | the type is `AnyPublisher` — values the member **delivered**: counted, handed to the handler, recorded (§2.7) |
+| `CompletionCount` | method, property | the type is `AnyPublisher` — the stream finished or failed (§2.7) |
+| `CancelCallCount`, `CancelHandler` | method | the return type is `AnyCancellable` |
+| `DisposeCallCount`, `DisposeHandler` | method | the return type is `Disposable` |
+| `EventCallCount`, `EventHandler`, `Events` | method, property | the type is `AnyObserver` — events pushed **in**: counted, handed to the handler, recorded (§2.7) |
+
+A returned token's suffix is the name of the call that token exposes: `cancel()` on `AnyCancellable`
+gives `Cancel*`, `dispose()` on RxSwift's `Disposable` gives `Dispose*`. Both stay (D4), and
+`SKILL.md:202` — which documents `<method>CancelCallCount` for either return type — states each
+against its own (§1.7).
+
+**A counter gets a handler where the shape being mirrored has one** (D12). Which have one, and why:
+`<method>CallCount`/`<method>Handler` and `<var>GetCount`/`<var>GetHandler`, the member's own, which
+**supply** what it returns; `<name>EventCallCount`/`<name>EventHandler` and
+`<name>OutputCount`/`<name>OutputHandler`, the payload crossing the member — pushed in on an
+`AnyObserver`, delivered out on an `AnyPublisher`; and `<name>CancelCallCount`/`<name>CancelHandler`
+with `<name>DisposeCallCount`/`<name>DisposeHandler`, the token the mock built being released. The
+rest are counters alone: `<var>SetCount`, `<name>SubscribeCount`, `<name>SubscribeCancelCount` and
+`<name>CompletionCount`. A handler beside a counter **observes** and returns nothing, which is what
+separates it from the two that supply.
+
+**What crosses a stream member is recorded, the way a method's arguments are** (D13). `<method>Args`
+has no counterpart on a stream member today, so a test that wants the value rather than the count
+writes a handler that appends into an array of its own — measured at zero occurrences across a
+43-spec consumer (§1.9). `<name>Events: [Event<Element>]` on an `AnyObserver` member and
+`<name>Outputs: [Output]` on an `AnyPublisher` one close that gap. Both are appended before the
+handler runs, both sit under the existing `skipArgumentRecording` opt-out, and for the same reason a
+method's arguments do: a recorded value lives as long as the mock. RxSwift's `Event` declares no
+`Equatable` conformance — `RxSwift/Sources/RxSwift/Event.swift:13-101` carries
+`CustomDebugStringConvertible` and `EventConvertible` and nothing else — so the value idiom on that
+side is `mock.<name>Events.compactMap(\.element)`, with `error` and `isCompleted` for the terminal
+ones; `[Output]` on the Combine side compares directly.
+
+`EventCallCount` counts calls of `on(_:)` on the `AnyObserver` the member handed back:
+`sut.entityObserver().onNext("next element")` moves `entityObserverEventCallCount`, while
+`entityObserverCallCount` counts the calls that produced the observer
+(`Tests/Examples/ExampleProjectSpm/Sources/ExampleProjectSpmTests/SwiftSourceryTemplatesMocksSpec.swift:48-55`).
+It is emitted for a property requirement as well as a method one — `Protocols.swift:19` in that
+example declares `var bindingTarget: AnyObserver<UploadAPI.LocalFile> { get }`, and `MockVar`
+reaches the same branch (`MockVar.swift:51-62`, `SourceryRuntimeExtensions.swift:345-354`). An
+`AnyPublisher` member runs the opposite direction — the mock produces and the test drives
+`<name>Subject` — so it has no delivery from the code under test to count. §8 question 4 carries
+what could be counted there instead.
+
+### 2.4 Two diagnostics, one wording
+
+| condition | text |
+| --- | --- |
+| a method with no handler and no defaultable return | `<prefix>Handler expected to be set.` |
+| a `handler`-annotated property read with no handler | `<prefix>GetHandler expected to be set.` |
+| overload names still colliding after §2.2 step 3 | names each colliding member and `methodName = "…"` |
+
+The second replaces `` `<prefix>GetHandler` must be set! `` (`MockVar.swift:91`). The first is
+already the string `kotlin-ksp-mocks` matches byte for byte.
+
+### 2.5 Every property requirement is counted
+
+A stored property is emitted today as storage with a `didSet` (`MockVar.swift:64-118`), so a read
+cannot be observed and `<var>GetCount` exists only where the getter is already computed — a stream
+member or one annotated `/// sourcery: handler`. Under this rule every property requirement
+generates the same members, and the value moves to a backing store named `_<var>`:
+
+```swift
+var draft: String {
+    get {
+        draftGetCount += 1
+        if let handler = draftGetHandler { return handler() }
+        return _draft
+    }
+    set {
+        draftSetCount += 1
+        _draft = newValue
+    }
+}
+var draftGetCount: Int = 0
+var draftGetHandler: (() -> String)? = nil
+var draftSetCount: Int = 0
+var _draft: String = ""
+```
+
+Six rules the shape carries:
+
+- **Construction counts no set.** The generated initializer assigns `_<var>`
+  (`MockGenerator.swift:69-77` assigns `<var>` today) and keeps its argument label `<var>`, so a
+  consumer's `Mock(analytics:)` call is unchanged and `README.md` §"Generated Mock API"'s statement
+  stays true once the property is computed.
+- **A test seeds and reads through `_<var>`** when it does not want to move a counter. Assigning
+  `mock.draft` moves `SetCount` today and will move it after this change too; reading `mock.draft`
+  starts moving `GetCount`.
+- **`/// sourcery: const` keeps its meaning on the value:** the storage is a `let` and the computed
+  property is get-only.
+- **`/// sourcery: handler` narrows to what distinguishes it:** no storage, and a read with no
+  handler set traps with §2.4's string.
+- **Isolation is unchanged:** under a global actor a `nonisolated` requirement's storage and
+  counters take `nonisolated(unsafe)` and its accessors `nonisolated` (`MockVar.swift:34-45`).
+- **A protocol that declares `_<var>` itself collides**, as one declaring `<var>GetCount` does
+  today. D9 puts every emitted name under one uniqueness check, so both fail generation naming the
+  two members instead of emitting a file that does not compile.
+
+`kotlin-ksp-mocks` emits `SetCount` alone for a stored property (`MockRenderer.kt:127-140`) and its
+skill states that absence, so this is the one point where the two dialects differ until that
+processor follows. §8 question 4 carries it.
+
+### 2.6 An effectful property requirement generates the accessor it declares
+
+`var x: T { get async throws }` is parsed — `Variable.isAsync` and `Variable.throws` are
+`SourceryRuntime`'s `Variable.swift:30` and `:33` — and ignored by the mock template, which emits a
+plain stored property that does not satisfy the requirement. `CONTRIBUTING.md` §"Open items" records
+the reason it was left: the shape it needs is a computed accessor over a separate backing store, and
+that was a naming decision nobody had taken. §2.5 makes that shape every property's, so this case is
+the same emission with the effects carried through:
+
+```swift
+var config: Config {
+    get async throws {
+        configGetCount += 1
+        if let handler = configGetHandler { return try await handler() }
+        return _config
+    }
+}
+var configGetCount: Int = 0
+var configGetHandler: (() async throws -> Config)? = nil
+var _config: Config
+```
+
+- The accessor declares exactly the effects the requirement declares — `get async`, `get throws`,
+  `get async throws` — and `<var>GetHandler`'s type carries the same pair.
+- Swift has no effectful setter, so an effectful requirement is get-only and generates no
+  `SetCount`. `_<var>` stays assignable, which is how a test seeds it.
+- A type with no default value is constructor-seeded, as §2.5 leaves it.
+- **A typed throw is out of scope.** `get throws(E)` reaches the template as
+  `Variable.throwsTypeName` (`Variable.swift:36`), and `Method.throwsTypeName` (`Method.swift:75`)
+  is the same fact on the method side; `MockMethod.swift:319-321` writes bare `throws` for a method
+  today, and a witness that throws `any Error` does not satisfy a requirement that throws `E`. Both
+  paths get one diagnostic naming the member instead of an emission that fails at the consumer's
+  conformance (§8 question 1).
+
+### 2.7 A publisher member hands back a construct the mock owns
+
+An `AnyPublisher` member erases its subject at read time and consults its handler there
+(`SourceryRuntimeExtensions.swift:360-408`), so the mock records that the code under test asked for
+the stream and nothing about what it did with it. The member instead returns a `Deferred` whose
+closure the mock owns — the Combine construct closest to the `AnyObserver` the RxSwift branch builds
+inline (§2.3, D11):
+
+```swift
+var ownMemories: AnyPublisher<[MemoryDrop], Never> {
+    ownMemoriesGetCount += 1
+    return Deferred { [weak self, subject = ownMemoriesSubject] () -> AnyPublisher<[MemoryDrop], Never> in
+        self?.ownMemoriesSubscribeCount += 1
+        if let handler = self?.ownMemoriesGetHandler {
+            return handler()
+        }
+        return subject.eraseToAnyPublisher()
+    }
+    .handleEvents(
+        receiveOutput: { [weak self] value in
+            self?.ownMemoriesOutputCount += 1
+            self?.ownMemoriesOutputs.append(value)
+            self?.ownMemoriesOutputHandler?(value)
+        },
+        receiveCompletion: { [weak self] _ in self?.ownMemoriesCompletionCount += 1 },
+        receiveCancel: { [weak self] in self?.ownMemoriesSubscribeCancelCount += 1 })
+    .eraseToAnyPublisher()
+}
+var ownMemoriesGetCount: Int = 0
+var ownMemoriesGetHandler: (() -> AnyPublisher<[MemoryDrop], Never>)? = nil
+var ownMemoriesSubscribeCount: Int = 0
+var ownMemoriesSubscribeCancelCount: Int = 0
+var ownMemoriesOutputCount: Int = 0
+var ownMemoriesOutputs: [[MemoryDrop]] = []
+var ownMemoriesOutputHandler: (([MemoryDrop]) -> Void)? = nil
+var ownMemoriesCompletionCount: Int = 0
+lazy var ownMemoriesSubject = PassthroughSubject<[MemoryDrop], Never>()
+```
+
+A method keeps its handler at call time, where the arguments are and where the member's `async` and
+`throws` apply; only the subject fallback is deferred:
+
+```swift
+func share(id: String) throws -> AnyPublisher<String, Error> {
+    shareCallCount += 1
+    shareArgs.append(id)
+    if let __shareHandler = self.shareHandler {
+        return try __shareHandler(id)
+    }
+    return Deferred { [weak self, subject = shareSubject] () -> AnyPublisher<String, Error> in
+        self?.shareSubscribeCount += 1
+        return subject.eraseToAnyPublisher()
+    }
+    .handleEvents(   // the same three hooks, against the method's own names
+        receiveOutput: { [weak self] value in
+            self?.shareOutputCount += 1
+            self?.shareOutputs.append(value)
+            self?.shareOutputHandler?(value)
+        },
+        receiveCompletion: { [weak self] _ in self?.shareCompletionCount += 1 },
+        receiveCancel: { [weak self] in self?.shareSubscribeCancelCount += 1 })
+    .eraseToAnyPublisher()
+}
+```
+
+Five rules the shape carries:
+
+- **The counters record what crossed the member, which is the `AnyObserver` construct's rule read in
+  the other direction.** There, `<name>EventCallCount` counts what the code under test pushed in;
+  here, `<name>OutputCount` counts what the member delivered out and `<name>CompletionCount` the
+  completions. It records delivery rather than sending: a value sent while nobody is subscribed is
+  dropped by the `PassthroughSubject` and counts nothing, a value delivered to two subscribers
+  counts twice — the same per-recipient multiplicity the observer side has — and a stream supplied
+  by `<var>GetHandler` is counted as well, because the operators wrap whatever the closure returned.
+  The suffix is Combine's own word for its values, the way D4 takes `cancel()` and `dispose()` from
+  their frameworks; `EventCallCount` stays RxSwift's.
+- **`<name>SubscribeCount` counts subscriptions and `<name>SubscribeCancelCount` counts the
+  cancellations of them.** `<var>GetCount` and `<method>CallCount` keep counting reads and calls, so
+  a test can tell "asked for the stream" from "subscribed" from "was actually sent something".
+- **`<name>Outputs` records each delivered value and `<name>OutputHandler` runs after it**, in the
+  order `<method>CallCount` / `<method>Args` / `<method>Handler` already establishes. A test asserts
+  `mock.<name>Outputs == [expected]` with no handler written at all; the handler stays for what a
+  recorder cannot do, which is to see each value as it lands and send the next one from inside it —
+  how a test drives a chain deterministically without subscribing itself. The other three counters
+  have no handler and no recorder (D12): the `AnyObserver` shape this mirrors carries one of each
+  for the payload and none for the lifecycle. `<name>SubscribeCount` sits in the `Deferred` closure
+  rather than on `handleEvents(receiveRequest:)`, which counts demand requests — measured at 3 for
+  two values under `flatMap(maxPublishers: .max(1))`.
+- **A property's `<var>GetHandler` is read inside the closure**, so a handler seeded after the code
+  under test captured the publisher decides the stream. A method's `<method>Handler` cannot move
+  there: it takes the call's arguments and may be `async` or `throws`.
+- **The closure captures the subject directly and the mock weakly.** The stream therefore still
+  delivers after the mock is released, and only the counting stops. Capturing the mock strongly
+  would make every publisher member retain it, which is the hazard `skipArgumentRecording` exists
+  for.
+- **The subject kind is unchanged.** `subject = "CurrentValue"` still replays to a late subscriber,
+  and the default `PassthroughSubject` still delivers nothing to one.
+
+Measured against the shapes above, with Swift 6.3.3: both typecheck at zero diagnostics under
+`-swift-version 5 -strict-concurrency=complete` and under `-swift-version 6` on a `@MainActor`
+class, and 22 runtime checks pass — reads counted at read and subscriptions at subscribe,
+cancellation counted, a handler seeded after capture winning, two subscriptions counted twice, a
+`CurrentValue` member replaying to a late subscriber, the default `PassthroughSubject` still
+delivering nothing to one and everything after it, the stream still delivering after the mock is
+released, a send with nobody subscribed counting no output, one send to two subscribers counting
+two, a handler-supplied stream's values and completion counted, and `<name>OutputHandler` firing
+after its counter and sending the next value from inside itself. Those checks are what P7 adds to
+`Tests/Checks/Behaviour/Main.swift`'s `checkCombineStreams`.
+
+The RxSwift branches keep their shape here. `Observable` and `Single` have
+`do(onSubscribe:onDispose:)` as the same hook; §8 question 5 carries whether to mirror it.
+
+### 2.8 What does not change
+
+`<Protocol>Mock`, `Any<Protocol>`, `<X>Component` / `<X>ComponentBase`; name-sorted member emission;
+the initializer-seeded bag; argument recording and its opt-outs; what an unset handler returns for
+every return type in §1's table; which subject backs a publisher member and what
+`subject = "CurrentValue"` does to it; the `methodName`, `handler`, `init`, `const` and `subject`
+annotations, with the two meanings §2.5 restates. The member **sets** change in three places only,
+each of them additive: §2.5 for every property, §2.6 for an effectful one, §2.7 for a publisher.
+
+---
+
+## 3. Decisions
+
+### D1 — the prefix transform
+
+- **(a) Declared name verbatim (recommended).** One sentence for a reader; removes the trap in §1.2;
+  matches `MockRenderer.kt`.
+- (b) Apply the method transform to properties too. Makes both sides regular and keeps the method
+  names already in consumers' tests, at the cost of renaming every property member whose declaration
+  carries an underscore and keeping a transform that no reader can invert.
+- (c) Leave it. The measured failure in §1.5 stays, and the rule cannot be stated in `SKILL.md` in
+  fewer than a paragraph.
+
+### D2 — the overload long form
+
+- **(a) Selector labels only (recommended).** `end(atDocument:)` → `endAtDocument`. Derivable from
+  the selector a reader already writes.
+- (b) Keep label plus parameter name. Nothing to migrate for overload-heavy consumers; keeps
+  `referenceWithPathPath`, and keeps a rule that takes two sentences and an exception to state.
+- (c) Parameter names only, as Kotlin does. Cannot distinguish `update(id:)` from
+  `update(with id:)`, which Swift allows and Kotlin cannot express.
+
+Under (a) the residual ambiguity — two overloads with the same labels and different parameter types
+— falls to §2.2 step 3 and then to step 4's error. Under (b) the same two overloads are
+distinguished whenever their parameter names differ.
+
+### D3 — the "fewest parameters keeps the plain name" tie-break
+
+- **(a) Keep it, and state that the requirement set includes inherited requirements (recommended).**
+  It is what `MockRenderer.kt:83-97` does, and it is what keeps a test compiling when a wider
+  overload is added later.
+- (b) Give every member of an overload group the long form. Removes the tie-break but not the
+  set-dependence — whether a group exists at all still depends on the refinement closure — and
+  renames every short-form overload in every consumer.
+
+§1.4's `data()` case is reached by either option: it is the return-type fallback, and the only
+control a declaration has over it is `methodName = "…"`. P8 documents that.
+
+### D4 — the returned-token suffix
+
+- **(a) Keep `Dispose*` for `Disposable` and `Cancel*` for `AnyCancellable`, and correct
+  `SKILL.md:202` (recommended).** Each suffix is the call the returned token exposes —
+  `Disposable.dispose()`, `AnyCancellable.cancel()` — so a reader who knows the framework derives
+  the member, and no RxSwift consumer is renamed.
+- (b) Rename `Dispose*` to `Cancel*`. One suffix across both frameworks and one row fewer in §2.3's
+  table, against a rename no measurement asked for and a member named after neither the declaration
+  nor the framework's own verb.
+
+Under (a) the correction is a documentation one: `SKILL.md:202` documents `<method>CancelCallCount`
+for `Disposable` and `AnyCancellable` alike, and states each against its own return type instead
+(P8).
+
+### D5 — where the rule is implemented
+
+- **(a) One file, `templates/Mocks/MockNaming.swift` (recommended).** It holds the prefix derivation
+  for a method and for a property, the overload chain, every suffix, and the two `fatalError`
+  strings. `MockMethod.swift`, `MockVar.swift` and `SourceryRuntimeExtensions.swift` call it; the 32
+  interpolation sites in §1.8 become calls.
+- (b) Leave the sites where they are and document the rule. A member added at its own site picks its
+  own words there, which is how the method trap string (`MockMethod.swift:146`) and the property one
+  (`MockVar.swift:91`) came to differ by three words and a pair of backticks (§1.8).
+
+### D6 — migration aids for consumers
+
+- **(a) None beyond the CHANGELOG (recommended).** Every stale name is a compile error naming the
+  member and the type. `CHANGELOG.md` carries the rule change, the three categories of rename and
+  the worked list from §5.
+- (b) Emit `@available(*, deprecated, renamed:)` aliases for one release. The generator would have
+  to keep both rules to know the old name, which is the condition this spec removes.
+
+### D7 — the drift gate
+
+- **(a) Review-only, for now (recommended; decided when this spec was commissioned).** The snapshot
+  diff under `Tests/Checks/Snapshots/` is where a naming change becomes visible; `AGENTS.md` gains
+  one line naming `MockNaming.swift` as the single home, under §"State a rule once".
+- (b) A check in `run-checks.sh` failing on a suffix literal outside `MockNaming.swift`: one
+  `grep -nE` over `templates/Mocks/`, plus its red control under `--self-test`. Deferred until the
+  rule stops moving; §8 question 3 states the trigger.
+
+### D8 — a read counter on every property
+
+- **(a) `GetCount`, `GetHandler` and the `_<var>` store on every property requirement
+  (recommended).** One sentence then covers every property, and a run stops having to read the
+  generated file to learn which members a property has. The Kotlin arm at round 3 planned 20 cases
+  against a `value6_0GetCount` that does not exist (`findings/what-the-runs-said-about-the-work.md`
+  §2).
+- (b) `GetCount` alone on a stored property. Same mechanics — a read cannot be counted without a
+  backing store — for a vocabulary that still needs `GetHandler`'s exception stated.
+- (c) Leave stored properties uncounted and state the exception in `SKILL.md`'s body, which is the
+  one-line move the Kotlin run asked for in its own repository.
+
+(a) and (b) cost the same rewrite and the same regenerate diff: 21 property members in
+`Tests/Checks/Snapshots/Mocks.generated.swift` and 73 in `modaal-firebase-wrappers` change shape
+(§5). (c) costs one sentence and keeps `kotlin-ksp-mocks` comparable on this point.
+
+### D9 — the backing store's name, and collisions in general
+
+Nothing checks a property's generated names today. `MockMethod.from` guards duplicate *method* names
+(`MockMethod.swift:24-26`); `MockVar.from` uniques the requirements by name and nothing more
+(`MockVar.swift:17-20`), so a protocol declaring both `draft` and `draftGetCount` emits two
+`var draftGetCount` declarations and the generated file does not compile, with no diagnostic from
+the template saying why. §2.5 adds one more name per property to that surface.
+
+- **(a) Spell the store `_<var>`, and put every emitted name under one uniqueness check
+  (recommended).** The check lives beside the rest of the vocabulary in `MockNaming.swift`, covers
+  methods, properties and bookkeeping alike, and fails generation naming the protocol, the two
+  members and `methodName = "…"`. It subsumes §2.2 step 4 and closes the property gap that predates
+  this spec. The underscore is what the generator already uses for names it owns — `__<name>Handler`
+  for the handler local inside every generated method (`MockMethod.swift:243-244`).
+- (b) Spell it `<var>Storage` with the same check. Self-describing at the use site
+  (`mock.draftStorage`), and a likelier collision: a protocol declaring `draftStorage` is more
+  plausible than one declaring `_draft`.
+- (c) No store, because no stored property is counted — D8 option (c), where the question does not
+  arise and the `<var>GetCount` collision stays unchecked.
+
+The check is what decides the outcome under (a) and (b) alike: a spelling only changes the odds, and
+this generator already has one collision class that reaches the consumer's compiler rather than a
+diagnostic.
+
+### D10 — effectful property requirements
+
+- **(a) Implement them with §2.5's shape (recommended).** The work is the accessor's effects and the
+  handler's type; `CONTRIBUTING.md` §"Open items" gives the blocker as the missing naming decision,
+  which §2.5 takes. It costs one phase (P6) and one fixture, and it closes an open item rather than
+  adding one.
+- (b) Leave them, and keep the open item. The template keeps emitting a property that does not
+  satisfy the requirement, which fails at the consumer's conformance rather than in generation — the
+  outcome `CONTRIBUTING.md` §"Design rules already decided" rules out for a Component.
+- (c) Reject them with a diagnostic. Cheaper than (a) by one phase, and it removes a shape the
+  Component template already forwards (`Tests/Checks/Fixtures/Forwarding.swift`,
+  `ProfileDependency`).
+
+Typed throws stays out under all three (§2.6, §8 question 1).
+
+### D11 — what an `AnyPublisher` member returns
+
+`AnyObserver` is a sink: the mock builds it inline and the closure it owns counts every event the
+code under test pushes (`SourceryRuntimeExtensions.swift:345-354`). `AnyPublisher` is a source, and
+Combine has no closure-based initializer to mirror that shape — `AnyPublisher.init` takes a
+publisher, where RxSwift's `AnyObserver.init` takes an event handler. The two constructs that give a
+mock a closure of its own on the source side are `Deferred`, whose closure runs once per
+subscription and returns the publisher to use, and
+`handleEvents(receiveSubscription:receiveCancel:)`, which observes without changing the stream.
+
+Both compile at this repository's gate — measured on a `@MainActor` class with Swift 6.3.3, zero
+diagnostics under `-swift-version 5 -strict-concurrency=complete` and under `-swift-version 6` — and
+the tree already mutates a counter from an escaping closure on an isolated mock
+(`Tests/Checks/Snapshots/Mocks.generated.swift:52-56`).
+
+- (a) Keep the subject and count subscriptions, without the closure. The getter erases
+  `<name>Subject.handleEvents(…)` instead of the bare subject and gains `<name>SubscribeCount` and
+  `<name>SubscribeCancelCount`. No stream semantics change, no consumer break, and a test can assert
+  that the code under test actually subscribed rather than inferring it from `<name>GetCount`.
+- **(b) Emit the `Deferred` construct, keeping the subject as its fallback (recommended, and §2.7
+  states it).** The member returns a closure the mock owns, which counts the subscription, consults
+  `<name>GetHandler` / `<name>Handler` and falls back to `<name>Subject`. It subsumes (a)'s counting
+  and it makes a handler set *after* the code under test captured the publisher take effect, because
+  the handler is read at subscribe time rather than at read time. The consequence I expected it to
+  carry — a publisher held past the mock's life going `Empty` — does not arise: the closure captures
+  the **subject** directly and the mock weakly, so the stream still delivers and only the counting
+  stops (§2.7, measured). Capturing the mock strongly instead would make the returned publisher
+  retain it, which is the hazard `skipArgumentRecording` exists for.
+- (c) Make `.automatic` mean "no subject": the member returns what `<name>GetHandler` /
+  `<name>Handler` gives and traps when unset, and `subject = "Passthrough"` becomes the opt-in.
+  **Not recommended.** 11 of the 13 subject-backed members in
+  `Tests/Checks/Snapshots/Mocks.generated.swift` are un-annotated and would trap on first read until
+  seeded; `CONTRIBUTING.md` §"Design rules already decided" records the subject default as taken;
+  and `kotlin-ksp-mocks` channel-backs every `Flow` member for the same reason
+  (`MockRenderer.kt:116`, `:183`), so the dialect would differ on the shape both generators are most
+  used for.
+
+- (d) Generate a publisher type of our own — an `EmittingPublisher<Output, Failure>` built from a
+  closure, which is the literal translation of `AnyObserver.init(eventHandler:)`. It can be emitted
+  without colliding: `Mocks.swifttemplate` would declare it `private`, which is file-scoped in
+  Swift, the way `TypeErase.swifttemplate:46` already emits `private class _Any<Type>Base` — and
+  that matters, because a module can hold several generated files, seven of them in
+  `modaal-firebase-wrappers/Sources/ModaalFirebaseMocks/Generated/`. What it costs is a
+  `Subscription` that honours `request(_:)`: a custom publisher that ignores demand misbehaves under
+  `flatMap(maxPublishers:)`, `buffer` and `zip`, `PassthroughSubject` already implements that
+  correctly, and the demand behaviour of generated code would become something
+  `Tests/Checks/Behaviour/Main.swift` has to cover. (b) gives the same closure ownership with no
+  type and no demand code.
+
+§2.3 gains `SubscribeCount`, `SubscribeCancelCount`, `OutputCount` and `CompletionCount` against a
+publisher member, §2.5 is unaffected, and the work is P7. The output pair is what makes the
+publisher member the mirror of the `AnyObserver` one rather than only a subject with a subscription
+count; naming it `<name>EventCallCount` instead would give a cross-platform codebase one word for
+"crossed this member" at the cost of D4's rule that a suffix is the framework's own word, and it is
+a one-word change if that trade is worth making. `modaal-firebase-wrappers` has no publisher
+requirement in any mocked protocol, so its regenerate diff does not move under any of the four; the
+13 subject-backed members in `Tests/Checks/Snapshots/Mocks.generated.swift` each gain two counters
+and five lines.
+
+**What the Kotlin twin would do.** Nothing it needs a new type for: a replayed flow takes
+`onStart`/`onCompletion`, so `<prop>Channel.receiveAsFlow().onStart { … }` carries the same two
+counters D11 (a) adds here. Three facts about that side, for whoever takes the separate iteration
+(§8): `flowElement` matches `kotlinx.coroutines.flow.Flow` exactly (`KspMocksProcessor.kt:147`), so
+a `StateFlow` or `SharedFlow` requirement is not channel-backed but constructor-seeded — usable, and
+undocumented in that skill's property table; a sink-shaped requirement (`FlowCollector`,
+`SendChannel`) reaches no branch there, which is the same gap Combine's `AnySubscriber` has here (§8
+question 4); and `EventCallCount` has no Kotlin counterpart at all, which neither repository's twin
+table says — `skills/swift-sourcery-mocks/references/generated-api.md:218` names only
+`<method>CancelCallCount`, and
+`kotlin-ksp-mocks/skills/kotlin-ksp-mocks/references/generated-api.md:212` names the same one.
+
+### D12 — which counters get a handler
+
+`<method>CallCount` has `<method>Handler`, `<var>GetCount` has `<var>GetHandler`,
+`<method>EventCallCount` has `<method>EventHandler`, and the two token counters have theirs.
+`<var>SetCount` does not, and §2.7 adds four more counters.
+
+- **(b) Add `<name>OutputHandler` alone (taken).** It is the mirror of `<method>EventHandler` — the
+  payload crossing the member, pushed in on an `AnyObserver`, delivered out on an `AnyPublisher`.
+  `<name>SubscribeCount`, `<name>SubscribeCancelCount` and `<name>CompletionCount` stay counters,
+  because the shape being mirrored carries no handler for the lifecycle, and `<var>SetCount` stays
+  as it is.
+- (a) Pair every counter with a handler: `<var>SetHandler`, `<name>SubscribeHandler`,
+  `<name>SubscribeCancelHandler` and `<name>CompletionHandler` as well. Measured to work — each
+  fires after its counter and the shape compiles at the gate — and rejected as speculative: no
+  measurement asked for them, and an `AnyPublisher` requirement would carry 12 members against 9.
+- (c) No new handlers, leaving the `AnyObserver` and `AnyPublisher` shapes asymmetric on the one
+  member a test reaches for.
+
+**The rule this sets for what comes next:** a counter gets a handler where the construct being
+mirrored has one. That is D4's rule applied to handlers instead of suffixes — take the shape from
+what is being mirrored rather than from what would be symmetrical on paper.
+
+One measured fact (b) removes the need to document: a `send` made synchronously from inside a
+subscribe-time hook is dropped, because Combine has not established demand at that point — true of
+the `Deferred` closure, of `handleEvents(receiveSubscription:)` and of `(receiveRequest:)`, while
+the same send scheduled with `DispatchQueue.main.async` is delivered. With (b) there is no such hook
+for a test to write it in: it seeds `<name>Subject` after the code under test has subscribed, or
+supplies a stream through `<var>GetHandler`, which is what `README.md` §"Combine" already says.
+
+### D13 — recording what a stream member carried
+
+A method records its arguments; a stream member records nothing. §1.9 measures what that costs: in
+43 spec files of a consumer, `<name>EventHandler` is assigned **0** times and the one assertion on
+an `AnyObserver` member checks a count while the code under test pushes a particular value. In a
+consumer whose mocks do record, `Args` outnumbers `CallCount` 15 to 2.
+
+- **(a) Record on both stream shapes (recommended).** `<name>Events: [Event<Element>]` on an
+  `AnyObserver` member, `<name>Outputs: [Output]` on an `AnyPublisher` one, appended before the
+  handler runs. `skipArgumentRecording` already means "do not retain what crossed this member" and
+  covers both, which needs its registry record's target widened from protocol and method to
+  protocol, method and variable (`templates/Annotations/AnnotationRegistry.swift`, and the tables
+  `Scripts/render-annotations.sh` renders).
+- (b) Record on the publisher only. Leaves the observer member — the one §1.9 measures a test giving
+  up on — as it is.
+- (c) No recorder. A test that wants the value writes a handler that appends into its own array,
+  which no spec file in that consumer does for any member.
+
+Two facts (a) has to carry. A publisher records per subscription, so one send to two subscribers
+appends twice, matching `<name>OutputCount`. And RxSwift's `Event` has no `Equatable` conformance
+(`Event.swift:13-101`), so `<name>Events` is read through `compactMap(\.element)`, `error` and
+`isCompleted` rather than compared whole; `[Output]` compares directly.
+
+---
+
+## 4. Phasing
+
+**P1 — extract, with no change to output.** Add `templates/Mocks/MockNaming.swift` and route the 32
+sites of §1.8 through it, moving today's rules verbatim, including the transform. Gate:
+`Tests/Checks/run-checks.sh` passes with no `--record` — the snapshots are byte-identical. This
+phase is the one that makes P2–P4 reviewable as one diff each.
+
+**P2 — the prefix (§2.1, D1).** Delete `swiftifiedMethodName` and whatever in
+`templates/Utility/StringLettercase.swift` is left with no caller (`camelCased` is also used by
+`returnTypeDiscriminatorSuffix`, `uppercasedFirstLetter` by the overload long form). New fixtures in
+`Tests/Checks/Fixtures/Vocabulary.swift` or a file beside it: a method whose name carries an
+underscore next to a property whose name does, an all-uppercase method name, a backtick-escaped
+method name, and a protocol whose two methods collide under the old transform and do not under the
+new one. Run the gates, read the snapshot diff, then `--record`. The prefix is what the RxSwift and
+type-erasure branches interpolate, so `Tests/Examples/ExampleProjectSpm/test-ios.sh` runs too
+(`AGENTS.md` §"Review generated output as a snapshot diff").
+
+**P3 — the overload long form and the collision check (§2.2, D2, D9).** The check over every emitted
+name lands here, covering properties and bookkeeping as well as overloads, so P5's `_<var>` arrives
+under a guard that already exists. Fixtures: an overload pair whose argument label differs from the
+parameter name, one that reaches §2.2 step 4, and a red control — a protocol declaring both `draft`
+and `draftGetCount` — which `run-checks.sh` runs the way it runs the near-miss section, since a
+fixture that fails generation fails the whole lane. Snapshot diff, then `--record`.
+
+**P4 — the diagnostic wording (§2.4).** One emitted string changes (`MockVar.swift:91`), and
+`Tests/Checks/Fixtures/` has to carry a `handler`-annotated property for the snapshot to show it. No
+suffix moves: D4 keeps `Dispose*` and `Cancel*` against their own return types, and what is left is
+the documentation correction in P8.
+
+**P5 — the property read counter (§2.5, D8, D9).** `MockVar.swift`'s stored branch becomes a
+computed accessor over `_<var>`, and `MockGenerator.swift:69-77` assigns the store while keeping the
+initializer's argument label. Gates: the snapshot diff (21 property members change shape), both
+language modes, and `Tests/Checks/Behaviour/Main.swift` gaining two checks — construction counts no
+set, one read counts one get. This phase is separable from P2–P4 and can be taken alone.
+
+**P6 — effectful property requirements (§2.6, D10).** `MockVar.swift` reads `variable.isAsync` and
+`variable.throws` and writes them into the accessor and the handler type; a typed throw is refused
+with a diagnostic naming the member. Fixture: `Tests/Checks/Fixtures/` gains a `ProtocolMock`
+protocol carrying `{ get async throws }`, `{ get async }` and `{ get throws }` — today the only
+effectful requirement in the tree is `Forwarding.swift:105`, which is `DuetComponent` alone, so the
+mock template has never seen one. `Tests/Checks/Behaviour/Main.swift` awaits one and catches one.
+Depends on P5.
+
+**P7 — the publisher construct and the stream recorders (§2.7, D11, D13).** The `AnyObserver` branch
+(`SourceryRuntimeExtensions.swift:345-354`) gains `<name>Events`, and
+`templates/Annotations/AnnotationRegistry.swift`'s `skipArgumentRecording` record widens to
+variables. `SourceryRuntimeExtensions.swift`'s `AnyPublisher` branch (`:360-408`) emits the
+`Deferred`, and `MockVar.swift` stops consulting `<var>GetHandler` at read time for a publisher
+property — the one place where the property branch and the smart-default branch have to agree, so
+both go through `MockNaming.swift`'s member names and one emission. Gates: the snapshot diff (13
+publisher members, four counters, one handler and one recorder each), both language modes,
+`checkCombineStreams` gaining the checks §2.7 measured, and a behaviour check that
+`skipArgumentRecording` suppresses both recorders. The `AnyObserver` half needs
+`Tests/Examples/ExampleProjectSpm/test-ios.sh`, which is where that shape is covered. Independent of
+P2–P6.
+
+**P8 — the documents.**
+
+- `skills/swift-sourcery-mocks/SKILL.md`: a block in the body stating §2.1 in one sentence, §2.2 in
+  three lines, the §2.3 table (replacing the current one, `:202`'s correction included), and one
+  line each for §2.5's property members, §2.6's effectful accessor and §2.7's subscription counters.
+  The body is 250 lines against the 400-line ceiling (`AGENTS.md` §"The skill is for adopters").
+- `skills/swift-sourcery-mocks/references/generated-api.md`: the worked examples, the full overload
+  chain including step 4, §1.4's refinement case with `methodName` as the answer, §2.5's property
+  shape, §2.7's publisher shape with the late-seeded handler spelled out, and the twin table gaining
+  the rows where the two generators now differ — `Dispose*` beside `Cancel*`, the stored-property
+  read count, and the subscription counters.
+- `skills/swift-sourcery-mocks/references/troubleshooting.md`: a row for `has no member '<name>'`
+  naming §2.1 and §2.2, a row for a property read count that moved because the test read the
+  property rather than `_<var>` (§2.5), and a row for `<name>SubscribeCount` staying at zero because
+  the code under test read the publisher without subscribing (§2.7).
+- `README.md` §"Generated Mock API": the same rule statement and the §2.3 table. §"Combine": the
+  subject is still what a test drives, `<name>SubscribeCount` is how it asserts the code under test
+  subscribed, and a `<var>GetHandler` set after the publisher was captured now takes effect.
+- `CONTRIBUTING.md` §"Where to change what": a subsection naming `MockNaming.swift` as the place a
+  member name is built; §"Design rules already decided": the rule in §2.1–§2.7, with the publisher
+  entry amended rather than replaced — the subject and its default are unchanged, and what is added
+  is the construct around them; §"Open items": the effectful-property entry deleted, since P6 closes
+  it, and typed throws added in its place (§8 question 1).
+- `AGENTS.md` §"State a rule once" and its `CLAUDE.md` copy: one line naming `MockNaming.swift`.
+- `kotlin-ksp-mocks/skills/kotlin-ksp-mocks/references/generated-api.md`: the sentence recording
+  that the Swift property getter traps with different words is superseded by §2.4, and the twin
+  table gains two rows the two generators do not share — the stored-property read count, and
+  `<method>EventCallCount` for an `AnyObserver` member, which neither table names today (D11). A
+  follow-up in that repository, and adopting §2.5 there is a separate iteration (§8).
+- `skills/swift-sourcery-mocks/references/generated-api.md`'s twin table, the same two rows from
+  this side.
+- `Tests/Evals/`: a sixth case asking what a test asserts on for a protocol whose members carry
+  underscores and one overload pair. `.claude-plugin/plugin.json`'s `experimental.evals` already
+  names the directory; SC13 checks the case parses.
+
+**P9 — release.** `CHANGELOG.md` entry under the format that file's header states: **Generated
+output** (the two rename categories of §2.1 and §2.2 with before/after, and §2.5's added property
+members), **Breaking** (every test naming a renamed member stops compiling; regenerate and fix what
+the compiler names), **Adopting** (the two lanes' regenerate commands, and `_<var>` for a test that
+reads a mock property without moving its count). The entry is written before the tag, and the
+consumer delta in §5 is measured into it (`AGENTS.md` §"Do not tag without measuring the consumer").
+
+---
+
+## 5. What rides along from 003
+
+003 §4 option 1 — bump `modaal-firebase-wrappers` and commit its regenerated output — stops being
+optional under this change: that repository is pinned at templates `0.2.15`
+(`scripts/generate-mocks.sh:9`), and a consumer five releases behind cannot show a one-release delta
+for the entry P9 writes. 003 §4 option 2 (state the two-generation method in `CONTRIBUTING.md`)
+remains independent and is not required here.
+
+**What the bump costs, measured.** Regenerating that repository against `master` produced
+`7 files changed, 218 insertions(+)`, no deletions (003 §1.4). This change adds renames and property
+members on top. Its 47 long-form method member groups were re-derived with a script implementing
+§2.2 step 2; the script reproduces 37 of the 47 names the templates actually emitted, the 10 misses
+being the four return-type-discriminated `data…` names it does not implement and six whose trailing
+closure parameter its splitter drops:
+
+- **§2.1 renames: none.** No protocol in that repository declares a method whose name carries an
+  underscore or leading capitals.
+- **§2.2 renames: 27 member groups, 15 distinct names** — `referenceForURLUrl` → `referenceForURL`,
+  `referenceWithPathPath` → `referenceWithPath`, `signInWithEmailEmailPasswordCompletion` →
+  `signInWithEmailPasswordCompletion`, `endAtDocumentDocument` → `endAtDocument`, `endAtFieldValues`
+  → `endAt`, `endBeforeDocumentDocument` → `endBeforeDocument`, `endBeforeFieldValues` →
+  `endBefore`, `limitToValue` → `limitTo`, `limitToLastValue` → `limitToLast`,
+  `startAtDocumentDocument` → `startAtDocument`, `startAtFieldValues` → `startAt`,
+  `startAfterDocumentDocument` → `startAfterDocument`, `startAfterFieldValues` → `startAfter`,
+  `setDataDataForDocumentDocumentMerge` → `setDataDataForDocumentMerge`,
+  `setDataDataForDocumentDocumentMergeFields` → `setDataDataForDocumentMergeFields`. Each carries a
+  `CallCount`, a `Handler` and, where the method records, an `Args`.
+- **§2.3 renames: none.** D4 keeps `Dispose*` and `Cancel*` apart, and that repository declares no
+  `Disposable` or `AnyObserver` return type in any case.
+- **§2.4 changes: none.** No declaration in that repository carries `/// sourcery: handler`, so no
+  property getter traps there.
+- **§2.5 additions: 73 property members** gain `GetCount`, `GetHandler` and the `_<var>` store, at
+  four added lines each. Additive: nothing that compiles against those mocks today stops compiling,
+  and the count is comparable to the 218 insertions the version bump alone produces.
+- **§2.6 changes: none.** No requirement in that repository is declared `{ get async }`,
+  `{ get throws }` or `{ get async throws }`.
+- **§2.7 and D12 additions: none** — no mocked protocol there declares an `AnyPublisher` member.
+
+Its own tests carry 127 references to a mock member; **9 of them, in 2 files, name a member §2.2
+renames** — `setDataDataForDocumentDocumentMerge` (4), `setDataDataForDocumentDocumentMergeFields`
+(4) and `signInWithEmailEmailPasswordCompletion` (1). The rest of the renames land only in the
+committed generated files, and in whatever repository downstream imports that mocks module.
+
+---
+
+## 6. What a consumer does
+
+1. **Plugin lane** — rebuild. The mock regenerates and the compiler names every test that used a
+   renamed member.
+2. **CLI lane** — `mock-templates generate`, then `mock-templates validate` in CI. The fingerprint
+   block changes with the body.
+3. **What to expect**, in the order a codebase is likely to hit it: an overloaded method whose
+   argument label differs from its parameter name (§2.2); a method whose declared name carries an
+   underscore or leading capitals (§2.1). A method returning an RxSwift `Disposable` keeps
+   `<method>DisposeCallCount` (D4).
+4. **A property read starts counting.** `mock.draft` moves `draftGetCount`; `mock._draft` reads and
+   seeds the same value without moving a counter (§2.5).
+5. **A publisher member gains four counters** — `<name>SubscribeCount`,
+   `<name>SubscribeCancelCount`, `<name>OutputCount`, `<name>CompletionCount` — and one handler,
+   `<name>OutputHandler`, and one recorder, `<name>Outputs` — an `AnyObserver` member gains
+   `<name>Events` the same way; a property's `<var>GetHandler` is read when the code under test
+   subscribes rather than when it reads the property (§2.7). Driving `<name>Subject` is unchanged,
+   and a value sent while nobody is subscribed still goes nowhere; `<name>OutputCount` is how a test
+   sees that.
+6. A member that must keep its old name takes `/// sourcery: methodName = "oldName"` on the
+   declaration.
+
+---
+
+## 7. Not measured
+
+- Whether `SourceryRuntime.Variable.name` carries backticks for a keyword-named property (``var
+  `default`: Int``). It decides whether §2.1's backtick removal is load-bearing on the property path
+  or a no-op. No fixture declares one.
+- Whether any consumer declares an all-uppercase method name. Neither `modaal-firebase-wrappers` nor
+  `Tests/Examples/` does; the trap in §1.2 is reachable but unobserved in the wild.
+- How much of the Swift G ÷ H ratio in §1.5 the rule change recovers. The lab's grouping key carries
+  `tool_sha256` and `skill_sha256` (`RESULTS.md` §"In flight"), so rows measured after this change
+  cannot be averaged with rows measured before it: the comparison is a re-run of `swift-G` at round
+  3 on the same seeds, against the recorded rows.
+- Whether `Tests/Evals`' five existing cases change answers under the new `SKILL.md` block. Each
+  case is model calls and no CI job runs them.
+- How often a consumer's test reads a mock property inside an assertion. §2.5 makes those reads move
+  `<var>GetCount`, which can fail no build and can only change what a *new* assertion on that count
+  would read.
+
+## 8. Open questions
+
+1. **What does a typed throw generate?** `get throws(E)` and `func f() throws(E)` reach the
+   templates as `Variable.throwsTypeName` and `Method.throwsTypeName`, and
+   `MockMethod.swift:319-321` writes bare `throws` for the method case today. A witness throwing
+   `any Error` does not satisfy a requirement throwing `E`, so both paths need either the typed form
+   emitted or a diagnostic; §2.6 chooses the diagnostic and does not measure what emitting the typed
+   form would cost. No fixture and no consumer protocol in reach declares one.
+2. **Does `public` mock generation interact with this?** `CONTRIBUTING.md` §"Open items" lists the
+   member sites an access-level change would touch — `MockGenerator.swift`, `MockMethod.swift`,
+   `MockVar.swift` — which are the same sites P1 moves. Doing P1 first makes that change one file
+   smaller; doing them together doubles the review.
+3. **When does D7(b) stop being deferred?** The trigger is the rule no longer moving: after P5 lands
+   and one release has been cut against it.
+4. **Does a consumer need `AnySubscriber`?** Combine's dual of `AnyObserver` reaches no branch of
+   `smartDefaultValueImplementation` and falls through to `MockError.noDefaultValue`, so a
+   requirement returning one is constructor-seeded or traps for want of a handler. It is a coverage
+   gap rather than a naming one, and no protocol in reach declares it. What an `AnyPublisher` member
+   could count instead is D11.
+
+5. **Do the RxSwift branches mirror §2.7?** `Observable` and `Single` expose
+   `do(onSubscribe:onDispose:)`, which is the same hook `Deferred` plus `handleEvents` gives on the
+   Combine side, and `AnyObserver` already counts what the code under test delivers. Unmeasured:
+   whether `asObservable()` on a `PublishSubject` composes with it at the gate, and whether any
+   consumer asserts subscription counts today by other means. The example lane
+   (`Tests/Examples/ExampleProjectSpm/test-ios.sh`) is the only place it could be measured.
+
+**Decided, and recorded here because the question was asked:** `kotlin-ksp-mocks` adopting §2.5 is a
+separate iteration in that repository. Until it lands, its stored-property branch emits `SetCount`
+alone (`MockRenderer.kt:127-140`) and the twin table in each repository names the row the other does
+not carry (P8).

--- a/specs/004-mock-member-naming/spec.md
+++ b/specs/004-mock-member-naming/spec.md
@@ -1335,3 +1335,63 @@ Gates: `run-checks.sh`, diff read, then `--record` — 74 added lines, no delete
 modes clean; behaviour checks pass; `Tests/Examples/ExampleProjectSpm/test-ios.sh` 19 tests, 0
 failures. P8 deletes `CONTRIBUTING.md` §"Open items"'s effectful-property entry, which this phase
 closes, and adds typed throws in its place.
+
+### P7 — the publisher construct, and what a stream member records
+
+`SourceryRuntimeExtensions.smartDefaultValueImplementation` now returns
+`(getterImplementation: [SourceCode], mockedVariableHandlers: [SourceCode], suppliesHandlerConsultation: Bool)`
+and takes `recordsStreamValues`. The third element is what lets the publisher branch own the handler
+read: `MockVar` emits its own `if let handler = <var>GetHandler` only when the branch does not, so
+the handler is consulted once, at subscribe time (§2.7), rather than twice at two different moments.
+
+**The `AnyPublisher` branch emits §2.7's construct verbatim**, in the property form (the
+`<var>GetHandler` read inside the `Deferred` closure) and the method form (only the subject fallback
+deferred; `<method>Handler` stays at call time, where its arguments are). Nine members per publisher
+requirement, in the order §2.7 lists them.
+
+**The `AnyObserver` branch gains `<name>Events: [Event<Element>]`**, appended between the counter and
+the handler — the order `<method>CallCount` / `<method>Args` / `<method>Handler` already sets, so a
+handler that traps does not un-make the event.
+
+`SourceCode` gains one property, `trailer`: text emitted immediately after a block's closing brace.
+It is what lets `handleEvents(receiveOutput: { … }, receiveCompletion: …, receiveCancel: …)` be
+built as a block rather than as a hand-indented multi-line string literal, which is how the `Single`
+branch's body is written and why that body carries hardcoded leading spaces. The `Deferred`, the
+`.handleEvents(…)` and the `.eraseToAnyPublisher()` are three siblings at one level — Swift parses a
+leading-dot line after a closing brace as a continuation.
+
+`AnnotationRegistry.skipArgumentRecording`'s target widens to `Protocol / method / variable` and its
+effect names all three arrays; `Scripts/render-annotations.sh --write` re-rendered `README.md`,
+`SKILL.md` and `references/writing-testable-protocols.md`. On a method the opt-out already excluded
+generics, and `<method>Outputs` takes that exclusion too, for the same reason: the element type would
+name the method's generic parameters and a stored property can only name the class's.
+
+**One refusal §2.7 implies and does not state.** An `AnyPublisher` requirement declared `{ get async }`
+or `{ get throws }` cannot carry its effects into a synchronous `Deferred` closure, and before P7 it
+emitted an accessor whose effects the subject erase satisfied by accident. `MockVar` throws
+`MockError.effectfulStreamRequirement` naming the protocol, the member and the two ways out. The
+`refusal` gate carries it as a seventh case.
+
+Fixtures: `Streams.swift` gains `FrameStreaming` (a recording member, an opted-out member and an
+opted-out method) and `FrameRetaining` (the opt-out on the type).
+`Tests/Checks/Behaviour/Main.swift` gains `checkPublisherCounting`, 22 assertions — every check §2.7
+records as measured, run against the emitted shapes rather than against a scratch file:
+
+reading counts a read and no subscription; subscribing counts a subscription; a send with nobody
+subscribed counts no output; a delivered value counts one and is recorded; one send to two
+subscribers counts twice; a completion is counted per subscription; an open subscription counts no
+cancel and `cancel()` counts one; a handler seeded *after* the publisher was captured decides the
+stream, and its values and its completion are counted; `<name>OutputHandler` sees each value and can
+send the next from inside itself, with the recorder holding both; a method's handler still answers at
+call time and bypasses the deferred subject entirely; the stream still delivers after the mock is
+released; and `skipArgumentRecording` suppresses the recorder while leaving the counter and the
+output handler working.
+
+`Tests/Examples/ExampleProjectSpm`'s `SwiftSourceryTemplatesMocksSpec` gains the assertion §1.9
+measured a consumer giving up on — `expect(sut.entityObserverEvents.compactMap(\.element)) ==
+["next element"]` beside the existing `entityObserverEventCallCount` assertion, on the same pushed
+value.
+
+Gates: `run-checks.sh`, diff read, then `--record` — 353 added lines, 25 deleted; both language
+modes clean; behaviour checks pass; `run-annotation-checks.sh` and `run-skill-checks.sh` pass after
+the re-render; `Tests/Examples/ExampleProjectSpm/test-ios.sh` 20 tests, 0 failures.

--- a/specs/004-mock-member-naming/spec.md
+++ b/specs/004-mock-member-naming/spec.md
@@ -1395,3 +1395,82 @@ value.
 Gates: `run-checks.sh`, diff read, then `--record` — 353 added lines, 25 deleted; both language
 modes clean; behaviour checks pass; `run-annotation-checks.sh` and `run-skill-checks.sh` pass after
 the re-render; `Tests/Examples/ExampleProjectSpm/test-ios.sh` 20 tests, 0 failures.
+
+### P8 — the documents
+
+Each document states the rule for its own reader, and none re-derives another's reasoning.
+
+- **`SKILL.md`** — §2.1 in one sentence, §2.2 in four, and the §2.3 table rebuilt with an "on"
+  column: `_<var>`, the four publisher counters, `<name>Outputs` / `<name>OutputHandler`,
+  `<name>Events`, and **`Dispose*` on its own row beside `Cancel*`**, which is `:202`'s correction —
+  that line documented `<method>CancelCallCount` for both return types. Three sentences follow for
+  §2.5's property members, §2.6's effectful accessor and §2.7's subscribe-time handler. 282 lines
+  against the 400-line ceiling.
+- **`references/generated-api.md`** — the naming rule at the top, the full overload chain including
+  step 4, §1.4's refinement case with `methodName` named as the answer, §2.5's property shape with
+  `const` and `handler`, §2.6's effectful accessor, `Cancel*` and `Dispose*` against their own return
+  types, and the twin table gaining a second table of the rows the two generators do **not** share.
+- **`references/stream-members.md` is new.** The publisher and RxSwift material did not fit: with
+  §2.7's shape written out, `generated-api.md` reached 337 lines against a 250-line ceiling
+  (`AGENTS.md` §"The skill is for adopters"). Splitting is the better half of the trade — a
+  reference costs nothing until the agent opens it — so the stream shapes, the four counters, the
+  late-seeded handler, the delivery-not-sending rule and the `AnyObserver` recorder live in their
+  own 89-line file, and `generated-api.md` (249) carries a five-line summary and a link. P8's plan
+  assumed one file; it is now two.
+- **`references/troubleshooting.md`** — three new sections: `has no member '<name>'` (§2.1 and
+  §2.2, including that a refinement can move a name), a property read count that moved because the
+  test read the property rather than `_<var>` (§2.5), and `<name>SubscribeCount` at zero (§2.7,
+  with delivery-not-sending and the method-handler-bypasses-the-subject case).
+- **`README.md`** §"Generated Mock API" — the rule and the full §2.3 suffix table, with
+  `MockNaming.swift` named as where every name is built; two new key-feature bullets for §2.5 and
+  §2.6. §"Combine" — a table of which counter answers which question, the subscribe-time handler,
+  the `skipArgumentRecording` opt-out and the effectful-publisher refusal. What the subject is and
+  what `subject = "CurrentValue"` does is unchanged, and says so.
+- **`CONTRIBUTING.md`** — §"Where to change what" gains "A mock member's name", naming
+  `MockNaming.swift` and the fact that the uniqueness check reads names back out of the emitted
+  declarations, so a new member is covered without being enumerated. §"Design rules already decided"
+  gains three rules (§2.1–§2.2, §2.5, §2.6) and the publisher entry is **amended rather than
+  replaced** — the subject and its default are unchanged and what is added is the construct around
+  them. §"Open items" loses the effectful-property entry, which P6 closed, and gains typed throws
+  and `AnySubscriber` (§8 questions 1 and 4).
+- **`AGENTS.md` / `CLAUDE.md`** §"State a rule once" — one bullet naming `MockNaming.swift`, kept
+  byte-identical with `cp`.
+- **`Tests/Evals/member-names`** — the sixth case. It asks which members a mock gives for
+  `setting4_2`, `pageSize`, `perform1_0()`, `ID()` and a three-way `end` overload group, with the
+  generated file deliberately out of reach. Five graders: the skill fired (with-arm only), the
+  prefix is verbatim (failing on `perform10CallCount`, `iDCallCount` or one rule for methods and
+  another for properties), the overload names (failing on `endAtFieldValuesCallCount` — the label
+  *and* the name — or on the plain name going to the wrong overload), the property members (failing
+  if a read-only requirement is said to generate none), and a regex for `perform1_0CallCount`. The
+  five-prompt count in `AGENTS.md`, `CONTRIBUTING.md` and `Tests/Evals/README.md` is now six.
+
+**Not done here, and why.** `kotlin-ksp-mocks/skills/kotlin-ksp-mocks/references/generated-api.md`'s
+twin table is a change to another repository, which P8 itself records as "a follow-up in that
+repository". The Swift-side half of that pair — the table naming the rows the two generators do not
+share — is in `references/generated-api.md` as of this phase, so the two tables are out of step
+until that follow-up lands. See the P9 amendment below.
+
+Gates: `run-skill-checks.sh` (SC5 at 282 / 249 / 89 lines, SC8 every link resolves, SC9 no version
+literal — a first draft of the troubleshooting entry named the release the transform changed in and
+SC9 caught it, SC13 six cases and 23 graders), `run-annotation-checks.sh` after the re-render, and
+`run-checks.sh`.
+
+### P9 amendment — re-align the Kotlin twin before the tag
+
+Superseding §4 P9's ordering, and recorded here because it was decided while P8 was being written:
+**the two repositories are brought back into step before this change is tagged**, not after. What
+that covers, and what each repository owes:
+
+1. `kotlin-ksp-mocks`' twin table gains the rows this side now names (P8's list above) — the
+   stored-property read counter, the publisher counters and recorders, and `<method>EventCallCount`
+   for an `AnyObserver` member, none of which either table carried before (D11).
+2. Whether `kotlin-ksp-mocks` adopts §2.5 — `GetCount`, `GetHandler` and a backing store on every
+   property requirement rather than `SetCount` alone (`MockRenderer.kt:127-140`, re-measured in
+   §9's P5 entry) — is decided before the tag rather than left open. If it does not, both twin
+   tables say so in the same words.
+3. `CHANGELOG.md`'s entry names the state of the twin as of the tag, so a consumer testing the same
+   logic on both platforms reads one answer rather than inferring it from two tables written at
+   different times.
+
+The rest of §4 P9 stands: the entry's three headings, the consumer delta from §5 measured into it,
+and the entry written before the tag.

--- a/specs/004-mock-member-naming/spec.md
+++ b/specs/004-mock-member-naming/spec.md
@@ -1474,3 +1474,40 @@ that covers, and what each repository owes:
 
 The rest of §4 P9 stands: the entry's three headings, the consumer delta from §5 measured into it,
 and the entry written before the tag.
+
+### P9 — the CHANGELOG entry, and the consumer measured
+
+`CHANGELOG.md` gains an `## Unreleased` entry under the three headings that file's header states,
+above the annotation-name entry and shipping in the same release as it. **Generated output** carries
+the two rename categories with before/after, §2.5's property members, §2.6's accessor, §2.7's
+construct and counters, and the two diagnostics that replace silent failures. **Breaking** carries
+the consumer table below and the reason no deprecated aliases are emitted — the generator would have
+to keep both naming rules to know the old name, which is the condition D6 removes. **Adopting**
+carries the two lanes' commands, `_<var>` for a test that reads a mock property, and the publisher
+member's new surface.
+
+**The consumer was regenerated, not estimated.** `modaal-firebase-wrappers`' seven modules were
+generated from this working tree into a scratch directory — its own tree was left untouched — and
+diffed against its committed output at templates 0.2.15.
+
+| measured | §5 predicted | actual |
+| --- | --- | --- |
+| files, lines | `7 files, 218 insertions` for the bump alone | 7 files, **1706 → 2934 lines**; 274 generated members → 515 |
+| §2.1 renames | none | **none** — confirmed; no removed name carries an underscore or leading capitals |
+| §2.2 renames | 27 member groups, 15 distinct names | **30 members over 15 declarations** — the 15 names §5 listed, each with a `CallCount` and a `Handler`; §5's "27 member groups" counted groups, not members |
+| §2.5 additions | 73 property members | **168 members over 56 requirements** — `GetCount`, `GetHandler` and `_<var>` each. §5's 73 is the number of `<method>Args` arrays the version bump adds, which its script evidently counted instead |
+| §2.3, §2.4, §2.6, §2.7 | none | **none** — confirmed |
+| its own tests that stop compiling | 9 references in 2 files | **9 references in 2 files** — `setDataDataForDocumentDocumentMerge*` (4), `setDataDataForDocumentDocumentMergeFields*` (4), `signInWithEmailEmailPasswordCompletionHandler` (1) |
+
+So §5's two errors are in the same direction and both under-count: it read member *groups* where the
+entry reads members, and it attributed the version bump's `Args` arrays to §2.5. The rename surface
+it predicted — which declarations move, and which of the consumer's own tests break — is exact.
+
+**Not done, and it is the gate on the tag.** The tag is not cut, and per the P9 amendment above it
+cannot be until `kotlin-ksp-mocks` is brought into step: its twin table, and the decision on whether
+it adopts §2.5. `CHANGELOG.md`'s entry names where the rule is stated and where it is built; the
+sentence naming the state of the twin as of the tag is written when that decision is taken.
+
+Lanes run at this phase, all green: `run-checks.sh`, `run-skill-checks.sh`,
+`run-annotation-checks.sh`, `run-cli-checks.sh`, `run-plugin-checks.sh`, and
+`Tests/Examples/ExampleProjectSpm/test-ios.sh` at P7. `run-xcode-checks.sh` was not run.

--- a/specs/004-mock-member-naming/spec.md
+++ b/specs/004-mock-member-naming/spec.md
@@ -2084,3 +2084,114 @@ in §12.6 is superseded. What that settles:
 
 P12, P13 and P14 are §12.7 as written. P12 and P13 close §9's P9 amendment; P14 does not block the
 tag and lands with them because it is one fixture and a re-record.
+
+---
+
+## 13. What landed: P12, P13 and P14
+
+### P12 — the get-only witness (D18 (a))
+
+`MockVar.swift:178` is now `let hasSetter = !hasEffects && variable.isMutable`; the `<var>SetCount`
+guard at `:195` reduces to `hasSetter`; the `if variable.isMutable` guard inside the setter body is
+gone, because only a `{ get set }` requirement reaches a setter at all. The comment at `:167-177`
+that recorded why P5 kept the witness settable is replaced by the rule it retires.
+
+The emitted-rule table in §9's P5 entry takes one new value: `{ get }` gives a witness with `get`
+only, and `<var>SetCount` is still not emitted. Every other row stands — `const` and `handler` were
+get-only already, and an effectful requirement has no setter to lose.
+
+| measured | value |
+| --- | --- |
+| snapshot | 92 lines added, 207 removed; 23 witnesses become a bare computed body, no member name moved |
+| `modaal-firebase-wrappers`, regenerated from this tree | 3148 → **2803 lines**; 73 → **4** `set` blocks, the 69 §12.3 predicted |
+| assignment sites in this repository | **5**, each now `_<var>` |
+
+**§12.3 measured three of those five, and it was reading one file.** The other two are outside
+`Tests/Checks/Behaviour/Main.swift`: `sut.profileID` in the example project's
+`SwiftSourceryTemplatesMocksSpec.swift`, and `mock.profileID` in
+`Tests/Checks/PluginFixture/Tests/AppTests/AppTests.swift`. Both were found by a lane rather than by
+the grep, which is what the lanes are for; the consumer figure of 12 is from a grep over the same
+kind of tree and carries the same risk of missing one.
+
+`Main.swift:46` asserted `"a read-only requirement is settable on the mock"`. It now reads
+`"a read-only requirement is seeded through its store"` and seeds `_recordPermission`.
+
+**Documents.** `CHANGELOG.md` states it as the second source break in this release, with `_<var>` as
+the fix at each site, the new 2803 total and two measured rows; `Adopting` gains a fourth step.
+`CONTRIBUTING.md` §"Design rules already decided", `README.md`'s member table, `SKILL.md`'s member
+table and `references/generated-api.md` each restate the rule.
+`references/troubleshooting.md` gains `## cannot assign to property: 'x' is a get-only property`.
+
+**Two lane defects found, neither caused by this phase and neither fixed.**
+
+1. **`Tests/Examples/ExampleProjectSpm/test-ios.sh` exits 0 when the build fails.** Its log carried
+   `Testing failed: Cannot assign to property: 'profileID' is a get-only property`,
+   `Testing cancelled because the build failed.` and `** TEST FAILED **`, and the script still
+   returned 0. A lane that cannot fail is a lane CI cannot gate on: read the log, not the status.
+2. **`run-plugin-checks.sh` leaves its fixture scratch unusable after a failed run.** The next
+   invocation fails with `couldn't build … because of missing inputs` naming the two generated
+   files. `rm -rf .build/plugin-checks` and re-running is green. This is the second thing that
+   directory does to a second run — §11 records the bundle-route warm-scratch defect.
+
+### P13 — the twin table (D19 (a))
+
+`references/generated-api.md`'s Swift → Kotlin table now says what item 1 of their §12.3 gives:
+`<prop>GetCount` and `<prop>GetHandler` on **every** property there rather than on a `Flow` property
+only; `<prop>SetCount` on a `var` requirement; `_<var>` → `_<prop>`, named as the only way to seed a
+read-only requirement on either side; the six stream counters on a `Flow`-returning function or a
+read-only `Flow` property; and `<name>Subject` against `<fn>Channel` with what separates them,
+broadcast against single-consumer.
+
+Two rows left "Members with no counterpart there" because they now have one. One row joined it: a
+method whose handler supplies the publisher counts nothing here and is wrapped there, which is the
+divergence D20 (a) leaves for a later release.
+
+The transitional row their §12.3 item 1 describes — a settable witness for a `{ get }` requirement —
+was never written, because P12 landed in the same branch.
+
+No template change, so no snapshot moved. The file is back at 249 lines against SC5's 250, paid for
+by dropping a sentence P12 had duplicated into the table, and it carries no version literal (SC9).
+
+### P14 — the overload tie-break in the snapshot (D21 (a))
+
+`NamingUnlabelledOverload` declares `send(_ value: String)` and `send(to target: String)` — the same
+parameter count, one of them unlabelled, which is the input `areInAscendingOrder` decides and no
+fixture in either repository had. The snapshot shows `send(_:)` keeping `send*` and `send(to:)`
+taking `sendTo*`, with P10's comment above the second. 47 added lines, nothing else moved.
+`Tests/Checks/README.md` gains the row.
+
+### The record 004 owes (item 4 of their §12.3)
+
+It is written here rather than in a follow-up file, because 004 is still being worked on and this
+repository's rule is that a spec in flight takes new sections.
+
+- **§8's closing paragraph** reads "Until it lands, its stored-property branch emits `SetCount`
+  alone (`MockRenderer.kt:127-140`)". That is superseded: `kotlin-ksp-mocks`' P1 to P3 landed
+  `<prop>GetCount`, `<prop>GetHandler`, `<prop>SetCount` and `_<prop>` on every property, and the
+  six stream counters. §2.5 is adopted there, by its own D2, with `override val` where this side had
+  `var` until D18.
+- **P8's row** for `kotlin-ksp-mocks/skills/kotlin-ksp-mocks/references/generated-api.md` — and the
+  "Not done here, and why" paragraph under P8 — describe the two tables as out of step until a
+  follow-up lands in that repository. Half of that is now closed from this side: P13 corrected this
+  repository's table. The other half is their §12.2, which is their work.
+
+### What §9's P9 amendment still gates on
+
+P12 and P13 are this repository's half. The tag also waits on `kotlin-ksp-mocks`' §12.2 — its D16
+(a) file header and per-member comment, and its D17 (a) `find` in `SKILL.md` — because a published
+version there is immutable, so both land before its 0.3.0 rather than after. Nothing in this
+repository blocks on them; the amendment's wording is "re-align with the kotlin-ksp repo", and the
+re-alignment is one ruling set applied on both sides.
+
+Open after this branch, and neither is a gate: **D20 (a)**, wrapping a method's handler-supplied
+publisher, recorded in their §11.7 as well; and their **D18 (c)**, which leaves a Kotlin interface
+declaring a keyword-named requirement generating a file that fails its consumer's compile with no
+diagnostic naming the requirement. §2.1's backtick rule here is unaffected.
+
+### Lanes
+
+`run-checks.sh` (snapshot re-recorded twice, after each diff was read), `run-skill-checks.sh`,
+`run-annotation-checks.sh`, `run-cli-checks.sh`, `run-plugin-checks.sh` (cold, after clearing its
+scratch) and `Tests/Examples/ExampleProjectSpm/test-ios.sh` at 20 tests, 0 failures — its log read
+rather than its exit status. `run-xcode-checks.sh` was not run. The skill body measures ~4.9k tokens
+on invoke at 208 lines, unchanged by P12's one-row edit, against 002 §3.1's 5,000-token floor.

--- a/templates/Annotations/AnnotationRegistry.swift
+++ b/templates/Annotations/AnnotationRegistry.swift
@@ -206,8 +206,8 @@ enum AnnotationRegistry {
         name: "skipArgumentRecording",
         aliases: [],
         kind: .option,
-        target: "Protocol / method",
-        effect: "Do not generate `<method>Args`; call counting and the handler are unaffected",
+        target: "Protocol / method / variable",
+        effect: "Do not generate `<method>Args`, `<name>Outputs` or `<name>Events`; counting and the handlers are unaffected",
         valueHint: nil
     )
 

--- a/templates/Component.swifttemplate
+++ b/templates/Component.swifttemplate
@@ -4,6 +4,7 @@
 <%- includeFile("Utility/Generics") -%>
 <%- includeFile("Utility/String") -%>
 <%- includeFile("Utility/StringLettercase") -%>
+<%- includeFile("Mocks/MockNaming") -%>
 <%- includeFile("Mocks/MockMethod") -%>
 <%- includeFile("Mocks/MockVar") -%>
 <%- includeFile("Mocks/MockGenerator") -%>

--- a/templates/Mocks.swifttemplate
+++ b/templates/Mocks.swifttemplate
@@ -4,6 +4,7 @@
 <%- includeFile("Utility/Generics") -%>
 <%- includeFile("Utility/String") -%>
 <%- includeFile("Utility/StringLettercase") -%>
+<%- includeFile("Mocks/MockNaming") -%>
 <%- includeFile("Mocks/MockMethod") -%>
 <%- includeFile("Mocks/MockVar") -%>
 <%- includeFile("Mocks/MockGenerator") -%>

--- a/templates/Mocks/MockGenerator.swift
+++ b/templates/Mocks/MockGenerator.swift
@@ -9,6 +9,10 @@ case noDefaultValue(typeName: TypeName)
 /// something impossible and must reach them.
 case unseedableSubject(typeName: TypeName, member: String)
 case duplicateGenericTypeName(context: String)
+/// Two members of one mock would carry the same name. The generated file
+/// would not compile, and before this case it did not — with nothing from
+/// the template saying which two members collided (`spec.md` D9).
+case collidingMemberNames(typeName: String, memberName: String)
 case internalError(message: String)
 }
 
@@ -86,6 +90,15 @@ class MockGenerator {
                 mock += mockMethodsFlattened
             }
 
+            // Every name the class declares, checked once, after the members
+            // that produce them have all been emitted. It covers a requirement
+            // colliding with another requirement's bookkeeping, two
+            // requirements producing one prefix, and the stream members' own
+            // names — whichever branch emitted them.
+            try MockNaming.checkForCollisions(
+                amongMemberDeclarations: mock.nested.map { $0.line },
+                typeName: type.name)
+
             topScope += mock
         }
 
@@ -144,6 +157,14 @@ extension MockError: LocalizedError {
                 `\(member)GetHandler` in the test to a stream that replays, or give the type a default value.
                 """
         case .duplicateGenericTypeName(let context): return "Duplicate generic type name found while generating mock implementation: \(context)"
+        case .collidingMemberNames(let typeName, let memberName):
+            return """
+                `\(typeName)Mock` would declare `\(memberName)` twice. A requirement of \
+                `\(typeName)` collides with a bookkeeping member generated for another \
+                requirement, or two requirements produce the same name. Rename the requirement, \
+                or — for a method — name its members outright with \
+                `/// sourcery: methodName = "customName"` on the declaration.
+                """
         case .internalError(let message): return "Internal error: \(message)"
         }
     }

--- a/templates/Mocks/MockGenerator.swift
+++ b/templates/Mocks/MockGenerator.swift
@@ -18,6 +18,10 @@ case collidingMemberNames(typeName: String, memberName: String)
 /// requirement is refused in generation rather than at the consumer's
 /// conformance (`spec.md` §2.6, §8 question 1).
 case typedThrowsUnsupported(typeName: String, member: String, errorTypeName: String)
+/// An `AnyPublisher` requirement declared `{ get async }` or `{ get throws }`.
+/// The construct it returns reads its handler from inside a synchronous
+/// closure, which cannot await or rethrow (`spec.md` §2.7).
+case effectfulStreamRequirement(typeName: String, member: String)
 case internalError(message: String)
 }
 
@@ -171,6 +175,14 @@ extension MockError: LocalizedError {
                 bare `throws`, and a witness that throws `any Error` does not satisfy a requirement \
                 that throws `\(errorTypeName)`. Declare the requirement `throws` on the protocol, or \
                 write this double by hand.
+                """
+        case .effectfulStreamRequirement(let typeName, let member):
+            return """
+                `\(typeName).\(member)` returns a publisher and is declared `async` or `throws`. \
+                The generated member hands back a `Deferred` whose closure reads \
+                `\(member)GetHandler` when the code under test subscribes, and that closure is \
+                synchronous. Drop the effects from the requirement, or return the stream from a \
+                method instead, where the handler is called with the method's own effects.
                 """
         case .collidingMemberNames(let typeName, let memberName):
             return """

--- a/templates/Mocks/MockGenerator.swift
+++ b/templates/Mocks/MockGenerator.swift
@@ -42,6 +42,10 @@ class MockGenerator {
         }
         var topScope = TopScope()
 
+        // The naming rule, stated once at the top of the file (D14(a)).
+        topScope += Constants.NEWL
+        topScope += MockNaming.fileNamingHeaderLines
+
         for type in types {
             let mockVars = MockVar.from(type)
             let variablesToInit = mockVars.filter { $0.provideValueInInitializer }.map { (mockedVariableName: $0.mockedVariableName, variable: $0.variable, defaultValue: try? $0.variable.typeName.defaultValue()) }
@@ -49,6 +53,17 @@ class MockGenerator {
 
             topScope += Constants.NEWL
             topScope += "// MARK: - \(type.name)"
+
+            // The rule again, in the slice an agent lands in (D14(b)), and then
+            // this class's index of the members that do not follow it (D15(b)).
+            // Both lines of the index and the line above the witness come from
+            // one call per method, so they cannot disagree.
+            topScope += MockNaming.classNamingHeaderLines
+            let namingComments = mockMethods.compactMap { $0.namingComment }
+            if !namingComments.isEmpty {
+                topScope += MockNaming.namingIndexHeaderLine
+                topScope += namingComments.map { MockNaming.namingIndexLine($0) }
+            }
 
             let genericTypes: [GenericTypeInfo] = (type.genericTypes + mockMethods.flatMap { $0.genericTypes }).merged()
 

--- a/templates/Mocks/MockGenerator.swift
+++ b/templates/Mocks/MockGenerator.swift
@@ -13,6 +13,11 @@ case duplicateGenericTypeName(context: String)
 /// would not compile, and before this case it did not — with nothing from
 /// the template saying which two members collided (`spec.md` D9).
 case collidingMemberNames(typeName: String, memberName: String)
+/// A requirement declaring `throws(E)`. The templates write bare `throws`,
+/// and a witness throwing `any Error` does not satisfy it — so the
+/// requirement is refused in generation rather than at the consumer's
+/// conformance (`spec.md` §2.6, §8 question 1).
+case typedThrowsUnsupported(typeName: String, member: String, errorTypeName: String)
 case internalError(message: String)
 }
 
@@ -160,6 +165,13 @@ extension MockError: LocalizedError {
                 `\(member)GetHandler` in the test to a stream that replays, or give the type a default value.
                 """
         case .duplicateGenericTypeName(let context): return "Duplicate generic type name found while generating mock implementation: \(context)"
+        case .typedThrowsUnsupported(let typeName, let member, let errorTypeName):
+            return """
+                `\(typeName).\(member)` is declared `throws(\(errorTypeName))`. The generated mock writes \
+                bare `throws`, and a witness that throws `any Error` does not satisfy a requirement \
+                that throws `\(errorTypeName)`. Declare the requirement `throws` on the protocol, or \
+                write this double by hand.
+                """
         case .collidingMemberNames(let typeName, let memberName):
             return """
                 `\(typeName)Mock` would declare `\(memberName)` twice. A requirement of \

--- a/templates/Mocks/MockGenerator.swift
+++ b/templates/Mocks/MockGenerator.swift
@@ -76,7 +76,10 @@ class MockGenerator {
                     return "\($0.mockedVariableName): \($0.variable.typeName.declaredName)\(defaultValue)"
                 }.joined(separator: ", ")
                 let initImpl = SourceCode("init(\(argumentList))")
-                initImpl += variablesToInit.map { "self.\($0.mockedVariableName) = \($0.mockedVariableName)" }
+                // The parameter keeps the requirement's own name and the
+                // assignment targets the store, so a consumer's `Mock(analytics:)`
+                // is unchanged and construction moves no counter (§2.5).
+                initImpl += variablesToInit.map { "self.\(MockNaming.store($0.mockedVariableName)) = \($0.mockedVariableName)" }
                 mock += Constants.NEWL
                 mock += "// MARK: - Initializer"
                 mock += initImpl

--- a/templates/Mocks/MockMethod.swift
+++ b/templates/Mocks/MockMethod.swift
@@ -21,6 +21,15 @@ class MockMethod {
         let mockedMethods = allMethods
             .map { MockMethod(type: type, method: $0, genericTypePrefix: genericTypePrefix, useShortName: true) }
             .minimumNonConflictingPermutation
+        // The same refusal `MockVar` makes: `MockMethod.throwingDecl` writes
+        // bare `throws`, which does not satisfy `throws(E)`.
+        if let typedThrow = allMethods.lazy.compactMap({ method -> (String, String)? in
+            guard let throwsTypeName = method.throwsTypeName else { return nil }
+            return (method.name, throwsTypeName.name)
+        }).first {
+            throw MockError.typedThrowsUnsupported(typeName: type.name, member: typedThrow.0, errorTypeName: typedThrow.1)
+        }
+
         // §2.2 step 4: the long form and then the return-type discriminator
         // both left a collision. Two overloads share their labels, their
         // parameter count and their return type, and differ only in a parameter

--- a/templates/Mocks/MockMethod.swift
+++ b/templates/Mocks/MockMethod.swift
@@ -21,8 +21,12 @@ class MockMethod {
         let mockedMethods = allMethods
             .map { MockMethod(type: type, method: $0, genericTypePrefix: genericTypePrefix, useShortName: true) }
             .minimumNonConflictingPermutation
-        guard !mockedMethods.hasDuplicateMockedMethodNames else {
-            throw MockError.internalError(message: "Mock generator: not all duplicates resolved: \(mockedMethods.map { $0.mockedMethodName })!")
+        // §2.2 step 4: the long form and then the return-type discriminator
+        // both left a collision. Two overloads share their labels, their
+        // parameter count and their return type, and differ only in a parameter
+        // type — which no part of the name derives from.
+        if let collidingName = mockedMethods.duplicateMockedMethodName {
+            throw MockError.collidingMemberNames(typeName: type.name, memberName: MockNaming.callCount(collidingName))
         }
         return mockedMethods.sorted { $0.mockedMethodName < $1.mockedMethodName }
     }
@@ -404,15 +408,20 @@ private extension Collection where Element == MockMethod {
     }
 
     var hasDuplicateMockedMethodNames: Bool {
+        return duplicateMockedMethodName != nil
+    }
+
+    /// The first prefix two of these methods share, or `nil`.
+    var duplicateMockedMethodName: String? {
         var mockedMethodNames = Set<String>()
         for nextItem in self {
             let key = nextItem.mockedMethodName
             if mockedMethodNames.contains(key) {
-                return true
+                return key
             }
             mockedMethodNames.insert(key)
         }
-        return false
+        return nil
     }
 }
 

--- a/templates/Mocks/MockMethod.swift
+++ b/templates/Mocks/MockMethod.swift
@@ -42,6 +42,13 @@ class MockMethod {
 }
 
 extension MockMethod {
+    /// The line recording that this method's members are not named after its
+    /// declaration, or `nil` when they are. `MockMethod` emits it above the
+    /// witness and `MockGenerator` repeats it in the class's index (D15(c)).
+    var namingComment: String? {
+        return mockedPrefix.comment
+    }
+
     var isVoid: Bool {
         return method.returnTypeName.isVoid
     }
@@ -60,20 +67,22 @@ extension MockMethod {
         return method.annotations(for: AnnotationRegistry.methodName).first
     }
 
-    fileprivate var mockedMethodName: String {
-        if let annotatedMethodName = annotatedMethodName {
-            return annotatedMethodName
-        }
+    /// The prefix this method's members carry, and — when that prefix is not
+    /// the declared name — the comment that records it. One call produces both,
+    /// which is what stops the comment and the member disagreeing (D16).
+    fileprivate var mockedPrefix: MockNaming.MethodPrefix {
         return MockNaming.methodPrefix(
+            selectorName: method.selectorName,
             callName: method.callName,
             longFormComponents: useShortName ? [] : method.parameters.map {
                 MockNaming.overloadComponent(argumentLabel: $0.argumentLabel, parameterName: $0.name)
             },
-            returnTypeDiscriminator: useReturnTypeInName ? returnTypeDiscriminator : nil)
+            returnTypeName: useReturnTypeInName ? method.returnTypeName.name : nil,
+            annotatedName: annotatedMethodName)
     }
 
-    fileprivate var returnTypeDiscriminator: String {
-        return MockNaming.returnTypeDiscriminator(forTypeNamed: method.returnTypeName.name)
+    fileprivate var mockedMethodName: String {
+        return mockedPrefix.prefix
     }
 
     /// `nonisolated` is restated on the mock only when the mock class carries a
@@ -152,6 +161,9 @@ extension MockMethod {
         }
 
         var result = TopScope()
+        if let namingComment = namingComment {
+            result += MockNaming.namingCommentLine(namingComment)
+        }
         result += methodImpl
         result += mockMethodHandlers.nested
         return result.nested

--- a/templates/Mocks/MockMethod.swift
+++ b/templates/Mocks/MockMethod.swift
@@ -51,26 +51,16 @@ extension MockMethod {
         if let annotatedMethodName = annotatedMethodName {
             return annotatedMethodName
         }
-        var result: [String] = [method.callName]
-        if !useShortName {
-            result += method.parameters.map {
-                let argumentLabel = $0.argumentLabel == nil ? "" : $0.argumentLabel != $0.name ? $0.argumentLabel!.uppercasedFirstLetter() : ""
-                return "\(argumentLabel)\($0.name.uppercasedFirstLetter())"
-            }
-        }
-        if useReturnTypeInName {
-            result += [returnTypeDiscriminator]
-        }
-        return result.joined().swiftifiedMethodName
+        return MockNaming.methodPrefix(
+            callName: method.callName,
+            longFormComponents: useShortName ? [] : method.parameters.map {
+                MockNaming.overloadComponent(argumentLabel: $0.argumentLabel, parameterName: $0.name)
+            },
+            returnTypeDiscriminator: useReturnTypeInName ? returnTypeDiscriminator : nil)
     }
 
-    /// Suffix derived from the method's return type, used to disambiguate
-    /// overloads that share the same name *and* the same parameter list but
-    /// differ only by return type (e.g., a refining protocol overriding
-    /// `func data() -> [String: Any]?` with `func data() -> [String: Any]`).
-    /// Such overloads cannot be distinguished by parameter labels alone.
     fileprivate var returnTypeDiscriminator: String {
-        return method.returnTypeName.name.returnTypeDiscriminatorSuffix
+        return MockNaming.returnTypeDiscriminator(forTypeNamed: method.returnTypeName.name)
     }
 
     /// `nonisolated` is restated on the mock only when the mock class carries a
@@ -143,7 +133,7 @@ extension MockMethod {
                 methodImpl += SourceCode("return \(defaultValue)")
             } else {
                 // fatal
-                methodImpl += "fatalError(\"\(mockHandler.0) expected to be set.\")"
+                methodImpl += "fatalError(\"\(MockNaming.handlerExpectedMessage(handlerName: mockHandler.0))\")"
             }
         }
 
@@ -154,7 +144,7 @@ extension MockMethod {
     }
 
     private var mockedVarCallCountName: String {
-        return "\(mockedMethodName)CallCount"
+        return MockNaming.callCount(mockedMethodName)
     }
 
     private var mockCallCountImpl: (String, SourceCode) {
@@ -162,7 +152,7 @@ extension MockMethod {
     }
 
     private var mockedVarArgsName: String {
-        return "\(mockedMethodName)Args"
+        return MockNaming.args(mockedMethodName)
     }
 
     /// The parameters whose values every call appends to `<method>Args`, in
@@ -208,7 +198,7 @@ extension MockMethod {
     }
 
     private var mockMethodHandlerName: String {
-        return "\(mockedMethodName)Handler"
+        return MockNaming.handler(mockedMethodName)
     }
 
     private var mockMethodHandlerReturnType: String {
@@ -240,8 +230,9 @@ extension MockMethod {
         let invocationThrowing = method.`throws` ? "try " : method.`rethrows` ? "try! " : ""
         let invocationAwaiting = method.isAsync ? "await " : ""
         let handlerName = mockHandlerImpl.0
-        return SourceCode("if let __\(handlerName) = self.\(handlerName)") {[
-            SourceCode("\(returning)\(invocationThrowing)\(invocationAwaiting)__\(handlerName)(\(parameters))\(forceCastingToGenericReturnValue)")
+        let handlerLocal = MockNaming.handlerLocal(handlerName)
+        return SourceCode("if let \(handlerLocal) = self.\(handlerName)") {[
+            SourceCode("\(returning)\(invocationThrowing)\(invocationAwaiting)\(handlerLocal)(\(parameters))\(forceCastingToGenericReturnValue)")
         ]}
     }
 }
@@ -251,57 +242,14 @@ private struct Regex {
 }
 
 private extension String {
-    var swiftifiedMethodName: String {
-        return self
-            .replacingOccurrences(of: "(", with: "_")
-            .replacingOccurrences(of: ")", with: "")
-            .replacingOccurrences(of: ":", with: "_")
-            .replacingOccurrences(of: "`", with: "")
-            .camelCased()
-            .lowercasedFirstWord()
-    }
-
     func resolvingGenericPlaceholders(prefix genericTypePrefix: String) -> String {
         return replacingOccurrences(of: Regex.placeholderPattern, with: "\(genericTypePrefix)$1", options: .regularExpression)
-    }
-
-    /// Sanitizes a return-type string into a stable, readable suffix suitable
-    /// for inclusion in a mock variable name. Used as the last-resort
-    /// disambiguator for overloads that share name and parameter list.
-    ///
-    /// Examples:
-    /// - `[String: Any]?` → `StringAnyOptional`
-    /// - `[String: Any]`  → `StringAny`
-    /// - `String?`        → `StringOptional`
-    /// - `String`         → `String`
-    var returnTypeDiscriminatorSuffix: String {
-        var sanitized = self
-            .replacingOccurrences(of: "?", with: "_Optional")
-            .replacingOccurrences(of: "!", with: "_Forced")
-            .replacingOccurrences(of: "[", with: "_")
-            .replacingOccurrences(of: "]", with: "_")
-            .replacingOccurrences(of: "(", with: "_")
-            .replacingOccurrences(of: ")", with: "_")
-            .replacingOccurrences(of: "<", with: "_")
-            .replacingOccurrences(of: ">", with: "_")
-            .replacingOccurrences(of: ":", with: "_")
-            .replacingOccurrences(of: ",", with: "_")
-            .replacingOccurrences(of: ".", with: "_")
-            .replacingOccurrences(of: "&", with: "_")
-            .replacingOccurrences(of: "`", with: "")
-            .replacingOccurrences(of: " ", with: "_")
-        while sanitized.contains("__") {
-            sanitized = sanitized.replacingOccurrences(of: "__", with: "_")
-        }
-        sanitized = sanitized.trimmingCharacters(in: CharacterSet(charactersIn: "_"))
-        // Force snake_case → CamelCase. `camelCased()` splits on `_`.
-        return sanitized.camelCased().uppercasedFirstLetter()
     }
 }
 
 private extension MockMethod {
     var shortNameKey: String {
-        return method.shortName.swiftifiedMethodName
+        return MockNaming.overloadGroupKey(shortName: method.shortName)
     }
 }
 

--- a/templates/Mocks/MockMethod.swift
+++ b/templates/Mocks/MockMethod.swift
@@ -138,10 +138,11 @@ extension MockMethod {
                     isProperty: false,
                     mockVariablePrefix: mockedMethodName,
                     forceCastingToReturnTypeName: isGeneric,
-                    requestedSubjectKind: method.requestedSubjectKind)
+                    requestedSubjectKind: method.requestedSubjectKind,
+                    recordsStreamValues: recordsStreamValues)
 
-                methodImpl += smartDefaultValueImplementation.0
-                mockMethodHandlers += smartDefaultValueImplementation.1.isolated(storageIsolationDecl)
+                methodImpl += smartDefaultValueImplementation.getterImplementation
+                mockMethodHandlers += smartDefaultValueImplementation.mockedVariableHandlers.isolated(storageIsolationDecl)
             } else if method.returnTypeName.hasDefaultValue, let defaultValue = try? method.returnTypeName.defaultValue() {
                 methodImpl += SourceCode("return \(defaultValue)")
             } else {
@@ -179,10 +180,18 @@ extension MockMethod {
     ///   would produce `[(objects: S, …)]` on a class whose `S` is a different
     ///   type.
     private var recordedParameters: [SourceryRuntime.MethodParameter] {
-        guard !isGeneric,
-              !method.isAnnotatedSkipArgumentRecording,
-              !type.isAnnotatedSkipArgumentRecording else { return [] }
+        guard recordsStreamValues else { return [] }
         return method.parameters.filter { $0.isRecordable }
+    }
+
+    /// The same opt-outs, applied to `<method>Outputs` / `<method>Events` on a
+    /// method returning a stream (D13). A generic method is excluded for the
+    /// reason its arguments are: the element type names the *method's* generic
+    /// parameters, and a stored property can only name the class's.
+    private var recordsStreamValues: Bool {
+        return !isGeneric
+            && !method.isAnnotatedSkipArgumentRecording
+            && !type.isAnnotatedSkipArgumentRecording
     }
 
     /// The recorded-arguments array and the line that appends to it, or `nil`

--- a/templates/Mocks/MockNaming.swift
+++ b/templates/Mocks/MockNaming.swift
@@ -41,15 +41,16 @@ enum MockNaming {
         return components.joined()
     }
 
-    /// One parameter's contribution to an overload's long-form prefix.
+    /// One parameter's contribution to an overload's long-form prefix (§2.2
+    /// step 2): the capitalized argument label, or the capitalized parameter
+    /// name when the parameter has no label.
+    ///
+    /// The label is what the caller writes, so `func end(atDocument document:)`
+    /// gives `endAtDocument` rather than `endAtDocumentDocument`. Where label
+    /// and name are the same word, or there is no label, this is the name —
+    /// `func update(id:force:)` gives `updateIdForce` either way.
     static func overloadComponent(argumentLabel: String?, parameterName: String) -> String {
-        let label: String
-        if let argumentLabel = argumentLabel, argumentLabel != parameterName {
-            label = argumentLabel.uppercasedFirstLetter()
-        } else {
-            label = ""
-        }
-        return "\(label)\(parameterName.uppercasedFirstLetter())"
+        return (argumentLabel ?? parameterName).withoutBackticks.uppercasedFirstLetter()
     }
 
     /// The key overloads are grouped under before the disambiguation chain runs.
@@ -146,6 +147,55 @@ enum MockNaming {
 
     static func getHandlerExpectedMessage(prefix: String) -> String {
         return "`\(getHandler(prefix))` must be set!"
+    }
+
+    // MARK: - Collisions
+    //
+    // Nothing checked a generated property name before this. `MockMethod.from`
+    // guarded duplicate *method* prefixes and `MockVar.from` uniqued the
+    // requirements by name and no further, so a protocol declaring both `draft`
+    // and `draftSetCount` emitted `var draftSetCount` twice and the generated
+    // file did not compile, with nothing from the template saying why
+    // (`spec.md` D9). The check below reads back what the class declares.
+
+    /// The name a generated member declaration declares, or `nil` when the line
+    /// declares no property.
+    ///
+    /// Only `var` and `let` are read. Two `func`s may legitimately share a base
+    /// name — they are the protocol's own overloads, and Swift allows them —
+    /// while two properties of one class may not, and the bookkeeping members
+    /// are all properties.
+    static func declaredPropertyName(inDeclaration line: String) -> String? {
+        var remainder = Substring(line)
+        var strippedModifier = true
+        while strippedModifier {
+            strippedModifier = false
+            for modifier in declarationModifiers where remainder.hasPrefix(modifier) {
+                remainder = remainder.dropFirst(modifier.count)
+                strippedModifier = true
+            }
+        }
+        guard remainder.hasPrefix("var ") || remainder.hasPrefix("let ") else { return nil }
+        let name = remainder.dropFirst(4).prefix { $0 != ":" && $0 != " " && $0 != "=" }
+        return name.isEmpty ? nil : String(name)
+    }
+
+    private static let declarationModifiers = ["nonisolated(unsafe) ", "nonisolated ", "lazy "]
+
+    /// Fails generation when one mock class declares the same property twice.
+    ///
+    /// - Parameters:
+    ///   - lines: the class's member declarations, in emission order.
+    ///   - typeName: the mocked protocol, for the message.
+    static func checkForCollisions(amongMemberDeclarations lines: [String], typeName: String) throws {
+        var seen = Set<String>()
+        for line in lines {
+            guard let name = declaredPropertyName(inDeclaration: line) else { continue }
+            guard !seen.contains(name) else {
+                throw MockError.collidingMemberNames(typeName: typeName, memberName: name)
+            }
+            seen.insert(name)
+        }
     }
 }
 

--- a/templates/Mocks/MockNaming.swift
+++ b/templates/Mocks/MockNaming.swift
@@ -103,6 +103,114 @@ enum MockNaming {
         return sanitized.camelCased().uppercasedFirstLetter()
     }
 
+    // MARK: - Naming comments
+    //
+    // Three cases leave a prefix a reader cannot derive from the declaration in
+    // front of them (`spec.md` §10.1): an overload's long form, the return-type
+    // discriminator, and `/// sourcery: methodName`. 47 of the 152 methods in
+    // the reference consumer are one of the three, in 10 of its 34 mock
+    // classes. Each gets a comment carrying both spellings — the selector as
+    // declared and the prefix its members take — above the witness and in its
+    // class's index (D15(c)).
+    //
+    // The comment comes from the call that produces the name, so a comment that
+    // disagrees with the member below it cannot be written (D16(a)), and
+    // `Tests/Checks/run-checks.sh`'s naming-comment gate reads both back out of
+    // the generated file (D16(b)).
+
+    /// A method's prefix, and the comment recording it when it is not the
+    /// declared name.
+    struct MethodPrefix {
+        let prefix: String
+        /// `nil` when the prefix is the declared name, which is the case for
+        /// most members.
+        let comment: String?
+    }
+
+    /// The prefix a method's members carry, with that comment.
+    ///
+    /// - Parameters:
+    ///   - selectorName: the requirement as declared — `end(at:)`. One of the
+    ///     two spellings the comment carries, so a search for either finds it.
+    ///   - callName: the method's declared name.
+    ///   - longFormComponents: empty for the overload that keeps the plain
+    ///     name; otherwise one component per parameter, from `overloadComponent`.
+    ///   - returnTypeName: the return type, when the long form left two
+    ///     overloads sharing a name and the discriminator is what separates
+    ///     them; `nil` otherwise. The discriminator is derived from it here, so
+    ///     the token in the name and the type in the comment are one input.
+    ///   - annotatedName: the value of `/// sourcery: methodName`, which
+    ///     replaces the derived prefix outright.
+    static func methodPrefix(
+        selectorName: String,
+        callName: String,
+        longFormComponents: [String] = [],
+        returnTypeName: String? = nil,
+        annotatedName: String? = nil
+    ) -> MethodPrefix {
+        let declaredName = callName.withoutBackticks
+        let prefix: String
+        let cause: String
+        if let annotatedName = annotatedName {
+            prefix = annotatedName
+            cause = "`/// sourcery: \(AnnotationRegistry.methodName.name) = \"\(annotatedName)\"`"
+        } else {
+            prefix = methodPrefix(
+                callName: callName,
+                longFormComponents: longFormComponents,
+                returnTypeDiscriminator: returnTypeName.map { returnTypeDiscriminator(forTypeNamed: $0) })
+            cause = returnTypeName.map { "overload of `\(declaredName)` returning `\($0)`" }
+                ?? "overload of `\(declaredName)`, argument labels appended"
+        }
+        // What decides whether a comment is written is the prefix against the
+        // declared name, not which branch produced it: a method with no
+        // parameters put into long form by its overload group derives the plain
+        // name anyway, and an annotation may repeat the declared name.
+        guard prefix != declaredName else {
+            return MethodPrefix(prefix: prefix, comment: nil)
+        }
+        // `selectorName` is `refresh` for a method that takes nothing and
+        // `end(at:)` for one that does. The comment shows the parentheses
+        // either way, so the spelling it carries is the declaration's.
+        let selector = selectorName.contains("(") ? selectorName : "\(selectorName)()"
+        return MethodPrefix(
+            prefix: prefix,
+            comment: "`\(selector)` members are named `\(prefix)*` — \(cause)")
+    }
+
+    /// The comment as it is emitted above the witness, inside the class.
+    static func namingCommentLine(_ comment: String) -> String { return "// \(comment)" }
+
+    /// The same comment as it is emitted in its class's index. The indent is
+    /// what separates an index entry from the class header sharing its column,
+    /// for a reader and for the gate alike.
+    static func namingIndexLine(_ comment: String) -> String { return "//   \(comment)" }
+
+    /// Introduces the index, and is emitted only for a class that has one.
+    static let namingIndexHeaderLine = "// Not named after their declaration:"
+
+    /// The rule, stated once at the top of a generated file (D14(a)).
+    static var fileNamingHeaderLines: [String] {
+        return [
+            "// Mock member names are the requirement's declared name plus a suffix: `func load()` gives",
+            "// `loadCallCount`, `loadArgs` and `loadHandler`; `var name` gives `nameGetCount`, `nameSetCount`,",
+            "// `nameGetHandler` and the store `_name`. Where a prefix is not the declared name — an overload,",
+            "// a return-type discriminator, `sourcery: \(AnnotationRegistry.methodName.name)` — a comment carrying both spellings",
+            "// sits above the witness and in the index under that class's `// MARK:` line.",
+        ]
+    }
+
+    /// The rule again, under every class's `MARK:` line (D14(b)). A generated
+    /// file is read in slices — the consumer's is 2934 lines — and the file
+    /// header is not in the slice. The same two lines for every class, with
+    /// nothing interpolated from the protocol.
+    static var classNamingHeaderLines: [String] {
+        return [
+            "// Members are the requirement's declared name plus a suffix — `load` gives `loadCallCount`,",
+            "// `loadArgs`, `loadHandler`; `name` gives `nameGetCount`, `nameSetCount`, `nameGetHandler`, `_name`.",
+        ]
+    }
+
     // MARK: - Method members
 
     static func callCount(_ prefix: String) -> String { return "\(prefix)CallCount" }

--- a/templates/Mocks/MockNaming.swift
+++ b/templates/Mocks/MockNaming.swift
@@ -119,6 +119,17 @@ enum MockNaming {
     static func getHandler(_ prefix: String) -> String { return "\(prefix)GetHandler" }
     static func setCount(_ prefix: String) -> String { return "\(prefix)SetCount" }
 
+    /// The stored value behind a property requirement's accessors (§2.5). A test
+    /// seeds and reads it without moving a counter, and the generated
+    /// initializer assigns it.
+    ///
+    /// The underscore is what the generator already uses for a name it owns —
+    /// `__<name>Handler` is the handler local inside every generated method — and
+    /// a protocol that declares `_draft` itself is caught by
+    /// `checkForCollisions` rather than emitting a file that does not compile
+    /// (D9).
+    static func store(_ prefix: String) -> String { return "_\(prefix)" }
+
     // MARK: - Stream members
 
     static func subject(_ prefix: String) -> String { return "\(prefix)Subject" }

--- a/templates/Mocks/MockNaming.swift
+++ b/templates/Mocks/MockNaming.swift
@@ -138,15 +138,19 @@ enum MockNaming {
 
     // MARK: - Diagnostics
     //
-    // The text a generated member traps with. `kotlin-ksp-mocks` matches the
-    // method form byte for byte.
+    // The text a generated member traps with, in one wording for a method and a
+    // property alike (§2.4). The property form read
+    // `` `<var>GetHandler` must be set! `` until P4 — three words and a pair of
+    // backticks away from the method's, because each string was written where
+    // its own member was emitted. `kotlin-ksp-mocks` matches this text byte for
+    // byte.
 
     static func handlerExpectedMessage(handlerName: String) -> String {
         return "\(handlerName) expected to be set."
     }
 
     static func getHandlerExpectedMessage(prefix: String) -> String {
-        return "`\(getHandler(prefix))` must be set!"
+        return handlerExpectedMessage(handlerName: getHandler(prefix))
     }
 
     // MARK: - Collisions

--- a/templates/Mocks/MockNaming.swift
+++ b/templates/Mocks/MockNaming.swift
@@ -17,7 +17,10 @@ enum MockNaming {
 
     // MARK: - Prefixes
 
-    /// The prefix every generated member of a method carries.
+    /// The prefix every generated member of a method carries: the declared name
+    /// with backticks removed, and nothing else — no case change, no underscore
+    /// removal, no first-word lowercasing (`spec.md` §2.1). `func perform1_0()`
+    /// gives `perform1_0`, `func ID()` gives `ID`, `` func `do`() `` gives `do`.
     ///
     /// - Parameters:
     ///   - callName: the method's declared name.
@@ -30,12 +33,12 @@ enum MockNaming {
         longFormComponents: [String] = [],
         returnTypeDiscriminator: String? = nil
     ) -> String {
-        var components = [callName]
+        var components = [callName.withoutBackticks]
         components += longFormComponents
         if let returnTypeDiscriminator = returnTypeDiscriminator {
             components += [returnTypeDiscriminator]
         }
-        return components.joined().swiftifiedMemberName
+        return components.joined()
     }
 
     /// One parameter's contribution to an overload's long-form prefix.
@@ -52,12 +55,16 @@ enum MockNaming {
     /// The key overloads are grouped under before the disambiguation chain runs.
     /// Two declarations share a group when they share this key.
     static func overloadGroupKey(shortName: String) -> String {
-        return shortName.swiftifiedMemberName
+        return shortName.withoutBackticks
     }
 
-    /// The prefix every generated member of a property carries.
+    /// The prefix every generated member of a property carries, under §2.1's
+    /// one rule: `var setting4_2: Int` gives `setting4_2`. A keyword-named
+    /// requirement keeps its backticks where it is *declared* — `` var `default`:
+    /// Int `` is the witness — and drops them here, because `` `default`GetCount ``
+    /// is not an identifier.
     static func variablePrefix(name: String) -> String {
-        return name
+        return name.withoutBackticks
     }
 
     /// Suffix derived from a method's return type, used to disambiguate
@@ -143,14 +150,9 @@ enum MockNaming {
 }
 
 private extension String {
-    /// The transform applied to a composed method prefix.
-    var swiftifiedMemberName: String {
-        return self
-            .replacingOccurrences(of: "(", with: "_")
-            .replacingOccurrences(of: ")", with: "")
-            .replacingOccurrences(of: ":", with: "_")
-            .replacingOccurrences(of: "`", with: "")
-            .camelCased()
-            .lowercasedFirstWord()
+    /// Backticks escape a keyword at the declaration and are not part of the
+    /// name. They are the whole of §2.1's transform.
+    var withoutBackticks: String {
+        return replacingOccurrences(of: "`", with: "")
     }
 }

--- a/templates/Mocks/MockNaming.swift
+++ b/templates/Mocks/MockNaming.swift
@@ -1,0 +1,156 @@
+import Foundation
+import SourceryRuntime
+
+/// The one place a generated mock member's name is built.
+///
+/// `MockMethod`, `MockVar`, `MockGenerator` and `SourceryRuntimeExtensions` ask
+/// for a name here instead of interpolating a suffix where the member is
+/// emitted. That is what keeps the vocabulary one vocabulary: the method trap
+/// string and the property trap string came to differ by three words and a pair
+/// of backticks because each was written at its own site
+/// (`specs/004-mock-member-naming/spec.md` §1.8).
+///
+/// A member name is a **prefix**, derived from the declaration, and a
+/// **suffix** naming what the member records. `spec.md` §2 states the rule;
+/// `AGENTS.md` §"State a rule once" names this file as its home.
+enum MockNaming {
+
+    // MARK: - Prefixes
+
+    /// The prefix every generated member of a method carries.
+    ///
+    /// - Parameters:
+    ///   - callName: the method's declared name.
+    ///   - longFormComponents: empty for the overload that keeps the plain name;
+    ///     otherwise one component per parameter, from `overloadComponent`.
+    ///   - returnTypeDiscriminator: the last-resort overload disambiguator, or
+    ///     `nil`.
+    static func methodPrefix(
+        callName: String,
+        longFormComponents: [String] = [],
+        returnTypeDiscriminator: String? = nil
+    ) -> String {
+        var components = [callName]
+        components += longFormComponents
+        if let returnTypeDiscriminator = returnTypeDiscriminator {
+            components += [returnTypeDiscriminator]
+        }
+        return components.joined().swiftifiedMemberName
+    }
+
+    /// One parameter's contribution to an overload's long-form prefix.
+    static func overloadComponent(argumentLabel: String?, parameterName: String) -> String {
+        let label: String
+        if let argumentLabel = argumentLabel, argumentLabel != parameterName {
+            label = argumentLabel.uppercasedFirstLetter()
+        } else {
+            label = ""
+        }
+        return "\(label)\(parameterName.uppercasedFirstLetter())"
+    }
+
+    /// The key overloads are grouped under before the disambiguation chain runs.
+    /// Two declarations share a group when they share this key.
+    static func overloadGroupKey(shortName: String) -> String {
+        return shortName.swiftifiedMemberName
+    }
+
+    /// The prefix every generated member of a property carries.
+    static func variablePrefix(name: String) -> String {
+        return name
+    }
+
+    /// Suffix derived from a method's return type, used to disambiguate
+    /// overloads that share the same name *and* the same parameter list but
+    /// differ only by return type (e.g., a refining protocol overriding
+    /// `func data() -> [String: Any]?` with `func data() -> [String: Any]`).
+    /// Such overloads cannot be distinguished by parameter labels alone.
+    ///
+    /// Examples:
+    /// - `[String: Any]?` → `StringAnyOptional`
+    /// - `[String: Any]`  → `StringAny`
+    /// - `String?`        → `StringOptional`
+    /// - `String`         → `String`
+    static func returnTypeDiscriminator(forTypeNamed typeName: String) -> String {
+        var sanitized = typeName
+            .replacingOccurrences(of: "?", with: "_Optional")
+            .replacingOccurrences(of: "!", with: "_Forced")
+            .replacingOccurrences(of: "[", with: "_")
+            .replacingOccurrences(of: "]", with: "_")
+            .replacingOccurrences(of: "(", with: "_")
+            .replacingOccurrences(of: ")", with: "_")
+            .replacingOccurrences(of: "<", with: "_")
+            .replacingOccurrences(of: ">", with: "_")
+            .replacingOccurrences(of: ":", with: "_")
+            .replacingOccurrences(of: ",", with: "_")
+            .replacingOccurrences(of: ".", with: "_")
+            .replacingOccurrences(of: "&", with: "_")
+            .replacingOccurrences(of: "`", with: "")
+            .replacingOccurrences(of: " ", with: "_")
+        while sanitized.contains("__") {
+            sanitized = sanitized.replacingOccurrences(of: "__", with: "_")
+        }
+        sanitized = sanitized.trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+        // Force snake_case → CamelCase. `camelCased()` splits on `_`.
+        return sanitized.camelCased().uppercasedFirstLetter()
+    }
+
+    // MARK: - Method members
+
+    static func callCount(_ prefix: String) -> String { return "\(prefix)CallCount" }
+    static func args(_ prefix: String) -> String { return "\(prefix)Args" }
+    static func handler(_ prefix: String) -> String { return "\(prefix)Handler" }
+
+    /// The local a generated method binds its handler to before calling it. The
+    /// underscores are what keep it from shadowing a parameter of the same name.
+    static func handlerLocal(_ handlerName: String) -> String { return "__\(handlerName)" }
+
+    // MARK: - Property members
+
+    static func getCount(_ prefix: String) -> String { return "\(prefix)GetCount" }
+    static func getHandler(_ prefix: String) -> String { return "\(prefix)GetHandler" }
+    static func setCount(_ prefix: String) -> String { return "\(prefix)SetCount" }
+
+    // MARK: - Stream members
+
+    static func subject(_ prefix: String) -> String { return "\(prefix)Subject" }
+    static func eventCallCount(_ prefix: String) -> String { return "\(prefix)EventCallCount" }
+    static func eventHandler(_ prefix: String) -> String { return "\(prefix)EventHandler" }
+
+    // MARK: - Returned-token members
+    //
+    // The suffix is the name of the call the returned token exposes:
+    // `AnyCancellable.cancel()` gives `Cancel*`, RxSwift's `Disposable.dispose()`
+    // gives `Dispose*` (`spec.md` D4).
+
+    static func cancelCallCount(_ prefix: String) -> String { return "\(prefix)CancelCallCount" }
+    static func cancelHandler(_ prefix: String) -> String { return "\(prefix)CancelHandler" }
+    static func disposeCallCount(_ prefix: String) -> String { return "\(prefix)DisposeCallCount" }
+    static func disposeHandler(_ prefix: String) -> String { return "\(prefix)DisposeHandler" }
+
+    // MARK: - Diagnostics
+    //
+    // The text a generated member traps with. `kotlin-ksp-mocks` matches the
+    // method form byte for byte.
+
+    static func handlerExpectedMessage(handlerName: String) -> String {
+        return "\(handlerName) expected to be set."
+    }
+
+    static func getHandlerExpectedMessage(prefix: String) -> String {
+        return "`\(getHandler(prefix))` must be set!"
+    }
+}
+
+private extension String {
+    /// The transform applied to a composed method prefix.
+    var swiftifiedMemberName: String {
+        return self
+            .replacingOccurrences(of: "(", with: "_")
+            .replacingOccurrences(of: ")", with: "")
+            .replacingOccurrences(of: ":", with: "_")
+            .replacingOccurrences(of: "`", with: "")
+            .camelCased()
+            .lowercasedFirstWord()
+    }
+}

--- a/templates/Mocks/MockNaming.swift
+++ b/templates/Mocks/MockNaming.swift
@@ -135,6 +135,14 @@ enum MockNaming {
     static func subject(_ prefix: String) -> String { return "\(prefix)Subject" }
     static func eventCallCount(_ prefix: String) -> String { return "\(prefix)EventCallCount" }
     static func eventHandler(_ prefix: String) -> String { return "\(prefix)EventHandler" }
+    static func events(_ prefix: String) -> String { return "\(prefix)Events" }
+
+    static func subscribeCount(_ prefix: String) -> String { return "\(prefix)SubscribeCount" }
+    static func subscribeCancelCount(_ prefix: String) -> String { return "\(prefix)SubscribeCancelCount" }
+    static func outputCount(_ prefix: String) -> String { return "\(prefix)OutputCount" }
+    static func outputs(_ prefix: String) -> String { return "\(prefix)Outputs" }
+    static func outputHandler(_ prefix: String) -> String { return "\(prefix)OutputHandler" }
+    static func completionCount(_ prefix: String) -> String { return "\(prefix)CompletionCount" }
 
     // MARK: - Returned-token members
     //

--- a/templates/Mocks/MockVar.swift
+++ b/templates/Mocks/MockVar.swift
@@ -70,12 +70,20 @@ extension MockVar {
     /// falls through to plain storage below. An impossible `subject` annotation
     /// is not that case and is rethrown: swallowing it emitted a stored property
     /// with no initializer, and the generated file did not compile.
-    private func smartDefaultValueImplementation() throws -> (getterImplementation: SourceCode, mockedVariableHandlers: [SourceCode])? {
+    /// Whether this requirement keeps `<name>Outputs` / `<name>Events`.
+    /// `/// sourcery: skipArgumentRecording` on the requirement or on the
+    /// protocol turns it off, the way it turns `<method>Args` off (D13).
+    fileprivate var recordsStreamValues: Bool {
+        return !variable.isAnnotatedSkipArgumentRecording && !type.isAnnotatedSkipArgumentRecording
+    }
+
+    private func smartDefaultValueImplementation() throws -> (getterImplementation: [SourceCode], mockedVariableHandlers: [SourceCode], suppliesHandlerConsultation: Bool)? {
         do {
             return try variable.typeName.smartDefaultValueImplementation(
                 isProperty: true,
                 mockVariablePrefix: mockedVariableName,
-                requestedSubjectKind: variable.requestedSubjectKind)
+                requestedSubjectKind: variable.requestedSubjectKind,
+                recordsStreamValues: recordsStreamValues)
         } catch MockError.unseedableSubject(let typeName, let member) {
             throw MockError.unseedableSubject(typeName: typeName, member: member)
         } catch {
@@ -119,13 +127,23 @@ extension MockVar {
             variable.typeName.hasComplexTypeWithSmartDefaultValue(isProperty: true),
             let smartDefaultValueImplementation = try smartDefaultValueImplementation() {
 
-            let getterImplementation: [SourceCode] = [
-                SourceCode("\(MockNaming.getCount(mockedVariableName)) += 1"),
-                SourceCode("if let handler = \(MockNaming.getHandler(mockedVariableName))") {[
-                    SourceCode("return \(effectfulCallDecl)handler()")
-                ]},
-                smartDefaultValueImplementation.getterImplementation
+            // The publisher branch reads `<var>GetHandler` inside the construct
+            // it returns, at subscribe time — so the read-time consultation here
+            // would make the handler decide the stream twice, at two different
+            // moments (§2.7). Its accessor cannot carry effects either: the
+            // `Deferred` closure is not `async`.
+            if smartDefaultValueImplementation.suppliesHandlerConsultation, hasEffects {
+                throw MockError.effectfulStreamRequirement(typeName: type.name, member: variable.name)
+            }
+            var getterImplementation: [SourceCode] = [
+                SourceCode("\(MockNaming.getCount(mockedVariableName)) += 1")
             ]
+            if !smartDefaultValueImplementation.suppliesHandlerConsultation {
+                getterImplementation += [SourceCode("if let handler = \(MockNaming.getHandler(mockedVariableName))") {[
+                    SourceCode("return \(effectfulCallDecl)handler()")
+                ]}]
+            }
+            getterImplementation += smartDefaultValueImplementation.getterImplementation
             mockedVariableImplementation = accessor(getter: getterImplementation, setter: nil)
             mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getCount(mockedVariableName)): Int = 0"
             mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getHandler(mockedVariableName)): (()\(effectsDecl) -> \(variable.typeName.declaredName))? = nil"

--- a/templates/Mocks/MockVar.swift
+++ b/templates/Mocks/MockVar.swift
@@ -80,37 +80,66 @@ extension MockVar {
             mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getHandler(mockedVariableName)): (() -> \(variable.typeName.declaredName))? = nil"
             mockedVariableHandlers += smartDefaultValueImplementation.mockedVariableHandlers.isolated(storageIsolationDecl)
         } else {
-            let variableDecl = !variable.isMutable && variable.isAnnotatedConst ? "let" : "var"
-            if variable.isAnnotatedHandler {
-                // Value should be implemented with the `get` handler
-                var getterImplementation: [SourceCode] = [
-                    SourceCode("\(MockNaming.getCount(mockedVariableName)) += 1"),
-                    SourceCode("if let handler = \(MockNaming.getHandler(mockedVariableName))") {[
-                        SourceCode("return handler()")
-                    ]},
-                    SourceCode("fatalError(\"\(MockNaming.getHandlerExpectedMessage(prefix: mockedVariableName))\")")
-                ]
-                if variable.isMutable {
-                    mockedVariableImplementation = SourceCode("\(isolationDecl)var \(variable.name): \(variable.typeName.declaredName)") {[
-                        SourceCode("get", nested: getterImplementation)
-                    ]}
-                } else {
-                    mockedVariableImplementation = SourceCode("\(isolationDecl)var \(variable.name): \(variable.typeName.declaredName)", nested: getterImplementation)
-                }
-                mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getCount(mockedVariableName)): Int = 0"
-                mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getHandler(mockedVariableName)): (() -> \(variable.typeName.declaredName))? = nil"
-            } else if !variable.isAnnotatedInit, variable.typeName.hasDefaultValue, let defaultValue = try? variable.typeName.defaultValue() {
-                // Default value can be guessed.
-                mockedVariableImplementation = SourceCode("\(storageIsolationDecl)\(variableDecl) \(variable.name): \(variable.typeName.declaredName) = \(defaultValue)")
-            } else {
-                // No default value, the value must be provided to the mock class's initializer.
-                mockedVariableImplementation = SourceCode("\(storageIsolationDecl)\(variableDecl) \(variable.name): \(variable.typeName.declaredName)")
-            }
+            // Every property requirement is a computed accessor that counts the
+            // read (§2.5). What differs between the two branches below is where
+            // the value comes from: `/// sourcery: handler` has no storage and
+            // traps when the test has set no handler, everything else falls back
+            // to the store the accessors sit over.
+            let getterImplementation: [SourceCode] = [
+                SourceCode("\(MockNaming.getCount(mockedVariableName)) += 1"),
+                SourceCode("if let handler = \(MockNaming.getHandler(mockedVariableName))") {[
+                    SourceCode("return handler()")
+                ]},
+                variable.isAnnotatedHandler
+                    ? SourceCode("fatalError(\"\(MockNaming.getHandlerExpectedMessage(prefix: mockedVariableName))\")")
+                    : SourceCode("return \(MockNaming.store(mockedVariableName))")
+            ]
+
+            // The witness stays settable wherever it is settable today: a
+            // read-only requirement backed by a `var` store was emitted as a
+            // settable stored property, and a test re-seeds it by assignment.
+            // `const` and `handler` are the two that were not — the first has a
+            // `let`, the second has no storage at all.
+            //
+            // `<var>SetCount` counts a write to a `{ get set }` requirement, and
+            // only that (§2.3): a re-seed of a read-only requirement was
+            // uncounted before this change and stays uncounted.
+            let hasSetter = variable.isMutable || !(variable.isAnnotatedConst || variable.isAnnotatedHandler)
+            var setterImplementation: [SourceCode] = []
             if variable.isMutable {
-                mockedVariableImplementation += SourceCode(variable.isAnnotatedHandler ? "set" : "didSet") {[
-                    SourceCode("\(MockNaming.setCount(mockedVariableName)) += 1")
+                // `didSet` on a stored property was the old shape, and a stored
+                // property cannot count a read.
+                setterImplementation += [SourceCode("\(MockNaming.setCount(mockedVariableName)) += 1")]
+            }
+            if !variable.isAnnotatedHandler {
+                setterImplementation += [SourceCode("\(MockNaming.store(mockedVariableName)) = newValue")]
+            }
+
+            if hasSetter {
+                mockedVariableImplementation = SourceCode("\(isolationDecl)var \(variable.name): \(variable.typeName.declaredName)") {[
+                    SourceCode("get", nested: getterImplementation),
+                    SourceCode("set", nested: setterImplementation)
                 ]}
+            } else {
+                mockedVariableImplementation = SourceCode("\(isolationDecl)var \(variable.name): \(variable.typeName.declaredName)", nested: getterImplementation)
+            }
+
+            mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getCount(mockedVariableName)): Int = 0"
+            mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getHandler(mockedVariableName)): (() -> \(variable.typeName.declaredName))? = nil"
+            if variable.isMutable {
                 mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.setCount(mockedVariableName)): Int = 0"
+            }
+            if !variable.isAnnotatedHandler {
+                // `/// sourcery: const` makes the store a `let`, so the value is
+                // fixed at construction and the accessor is get-only.
+                let storeDecl = !variable.isMutable && variable.isAnnotatedConst ? "let" : "var"
+                let storeName = MockNaming.store(mockedVariableName)
+                if !variable.isAnnotatedInit, variable.typeName.hasDefaultValue, let defaultValue = try? variable.typeName.defaultValue() {
+                    mockedVariableHandlers += "\(storageIsolationDecl)\(storeDecl) \(storeName): \(variable.typeName.declaredName) = \(defaultValue)"
+                } else {
+                    // No default value: the mock class's initializer seeds it.
+                    mockedVariableHandlers += "\(storageIsolationDecl)\(storeDecl) \(storeName): \(variable.typeName.declaredName)"
+                }
             }
         }
         var topScope = TopScope()

--- a/templates/Mocks/MockVar.swift
+++ b/templates/Mocks/MockVar.swift
@@ -43,6 +43,28 @@ extension MockVar {
         return isNonisolated ? "nonisolated(unsafe) " : ""
     }
 
+    /// The effects the requirement declares, in the order Swift writes them.
+    /// `var x: T { get async throws }` is parsed — `Variable.isAsync` and
+    /// `Variable.throws` — and was ignored until §2.6, which emits the accessor
+    /// the requirement declares rather than a stored property that does not
+    /// satisfy it.
+    ///
+    /// Swift has no effectful setter, so an effectful requirement is get-only
+    /// and generates no `<var>SetCount`. `_<var>` stays assignable, which is how
+    /// a test seeds it.
+    fileprivate var effectsDecl: String {
+        return "\(variable.isAsync ? " async" : "")\(variable.`throws` ? " throws" : "")"
+    }
+
+    /// `try `/`await ` for the call into `<var>GetHandler`.
+    fileprivate var effectfulCallDecl: String {
+        return "\(variable.`throws` ? "try " : "")\(variable.isAsync ? "await " : "")"
+    }
+
+    fileprivate var hasEffects: Bool {
+        return variable.isAsync || variable.`throws`
+    }
+
     /// `nil` when this variable's type has no smart default *of a shape this
     /// branch handles* — an `AnyCancellable` or `Disposable` property, say, which
     /// falls through to plain storage below. An impossible `subject` annotation
@@ -61,23 +83,52 @@ extension MockVar {
         }
     }
 
+    /// The witness: a bare getter body where the requirement has no effects and
+    /// no setter, and explicit `get` / `set` blocks otherwise. A bare body
+    /// cannot carry `async` or `throws`.
+    private func accessor(getter: [SourceCode], setter: [SourceCode]?) -> SourceCode {
+        let declaration = "\(isolationDecl)var \(variable.name): \(variable.typeName.declaredName)"
+        if let setter = setter {
+            return SourceCode(declaration) {[
+                SourceCode("get", nested: getter),
+                SourceCode("set", nested: setter)
+            ]}
+        }
+        if hasEffects {
+            return SourceCode(declaration) {[
+                SourceCode("get\(effectsDecl)", nested: getter)
+            ]}
+        }
+        return SourceCode(declaration, nested: getter)
+    }
+
     func mockImpl() throws -> [SourceCode] {
         let mockedVariableImplementation: SourceCode
         let mockedVariableHandlers = TopScope()
+
+        // A typed throw reaches the template as `Variable.throwsTypeName` and
+        // has no emission here: bare `throws` does not satisfy `throws(E)`.
+        if let throwsTypeName = variable.throwsTypeName {
+            throw MockError.typedThrowsUnsupported(
+                typeName: type.name,
+                member: variable.name,
+                errorTypeName: throwsTypeName.name)
+        }
 
         if !variable.isMutable,
             variable.typeName.hasComplexTypeWithSmartDefaultValue(isProperty: true),
             let smartDefaultValueImplementation = try smartDefaultValueImplementation() {
 
-            mockedVariableImplementation = SourceCode("\(isolationDecl)var \(variable.name): \(variable.typeName.declaredName)") {[
+            let getterImplementation: [SourceCode] = [
                 SourceCode("\(MockNaming.getCount(mockedVariableName)) += 1"),
                 SourceCode("if let handler = \(MockNaming.getHandler(mockedVariableName))") {[
-                    SourceCode("return handler()")
+                    SourceCode("return \(effectfulCallDecl)handler()")
                 ]},
                 smartDefaultValueImplementation.getterImplementation
-            ]}
+            ]
+            mockedVariableImplementation = accessor(getter: getterImplementation, setter: nil)
             mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getCount(mockedVariableName)): Int = 0"
-            mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getHandler(mockedVariableName)): (() -> \(variable.typeName.declaredName))? = nil"
+            mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getHandler(mockedVariableName)): (()\(effectsDecl) -> \(variable.typeName.declaredName))? = nil"
             mockedVariableHandlers += smartDefaultValueImplementation.mockedVariableHandlers.isolated(storageIsolationDecl)
         } else {
             // Every property requirement is a computed accessor that counts the
@@ -88,7 +139,7 @@ extension MockVar {
             let getterImplementation: [SourceCode] = [
                 SourceCode("\(MockNaming.getCount(mockedVariableName)) += 1"),
                 SourceCode("if let handler = \(MockNaming.getHandler(mockedVariableName))") {[
-                    SourceCode("return handler()")
+                    SourceCode("return \(effectfulCallDecl)handler()")
                 ]},
                 variable.isAnnotatedHandler
                     ? SourceCode("fatalError(\"\(MockNaming.getHandlerExpectedMessage(prefix: mockedVariableName))\")")
@@ -104,7 +155,9 @@ extension MockVar {
             // `<var>SetCount` counts a write to a `{ get set }` requirement, and
             // only that (§2.3): a re-seed of a read-only requirement was
             // uncounted before this change and stays uncounted.
-            let hasSetter = variable.isMutable || !(variable.isAnnotatedConst || variable.isAnnotatedHandler)
+            // An effectful requirement is get-only: Swift has no effectful
+            // setter, so there is nothing for a mutable form to witness.
+            let hasSetter = !hasEffects && (variable.isMutable || !(variable.isAnnotatedConst || variable.isAnnotatedHandler))
             var setterImplementation: [SourceCode] = []
             if variable.isMutable {
                 // `didSet` on a stored property was the old shape, and a stored
@@ -115,18 +168,13 @@ extension MockVar {
                 setterImplementation += [SourceCode("\(MockNaming.store(mockedVariableName)) = newValue")]
             }
 
-            if hasSetter {
-                mockedVariableImplementation = SourceCode("\(isolationDecl)var \(variable.name): \(variable.typeName.declaredName)") {[
-                    SourceCode("get", nested: getterImplementation),
-                    SourceCode("set", nested: setterImplementation)
-                ]}
-            } else {
-                mockedVariableImplementation = SourceCode("\(isolationDecl)var \(variable.name): \(variable.typeName.declaredName)", nested: getterImplementation)
-            }
+            mockedVariableImplementation = accessor(
+                getter: getterImplementation,
+                setter: hasSetter ? setterImplementation : nil)
 
             mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getCount(mockedVariableName)): Int = 0"
-            mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getHandler(mockedVariableName)): (() -> \(variable.typeName.declaredName))? = nil"
-            if variable.isMutable {
+            mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getHandler(mockedVariableName)): (()\(effectsDecl) -> \(variable.typeName.declaredName))? = nil"
+            if variable.isMutable && hasSetter {
                 mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.setCount(mockedVariableName)): Int = 0"
             }
             if !variable.isAnnotatedHandler {

--- a/templates/Mocks/MockVar.swift
+++ b/templates/Mocks/MockVar.swift
@@ -6,7 +6,7 @@ class MockVar {
     fileprivate let type: SourceryRuntime.`Type`
 
     var mockedVariableName: String {
-        return "\(variable.name)"
+        return MockNaming.variablePrefix(name: variable.name)
     }
 
     init(variable: SourceryRuntime.Variable, type: SourceryRuntime.`Type`) {
@@ -70,25 +70,25 @@ extension MockVar {
             let smartDefaultValueImplementation = try smartDefaultValueImplementation() {
 
             mockedVariableImplementation = SourceCode("\(isolationDecl)var \(variable.name): \(variable.typeName.declaredName)") {[
-                SourceCode("\(mockedVariableName)GetCount += 1"),
-                SourceCode("if let handler = \(mockedVariableName)GetHandler") {[
+                SourceCode("\(MockNaming.getCount(mockedVariableName)) += 1"),
+                SourceCode("if let handler = \(MockNaming.getHandler(mockedVariableName))") {[
                     SourceCode("return handler()")
                 ]},
                 smartDefaultValueImplementation.getterImplementation
             ]}
-            mockedVariableHandlers += "\(storageIsolationDecl)var \(mockedVariableName)GetCount: Int = 0"
-            mockedVariableHandlers += "\(storageIsolationDecl)var \(mockedVariableName)GetHandler: (() -> \(variable.typeName.declaredName))? = nil"
+            mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getCount(mockedVariableName)): Int = 0"
+            mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getHandler(mockedVariableName)): (() -> \(variable.typeName.declaredName))? = nil"
             mockedVariableHandlers += smartDefaultValueImplementation.mockedVariableHandlers.isolated(storageIsolationDecl)
         } else {
             let variableDecl = !variable.isMutable && variable.isAnnotatedConst ? "let" : "var"
             if variable.isAnnotatedHandler {
                 // Value should be implemented with the `get` handler
                 var getterImplementation: [SourceCode] = [
-                    SourceCode("\(mockedVariableName)GetCount += 1"),
-                    SourceCode("if let handler = \(mockedVariableName)GetHandler") {[
+                    SourceCode("\(MockNaming.getCount(mockedVariableName)) += 1"),
+                    SourceCode("if let handler = \(MockNaming.getHandler(mockedVariableName))") {[
                         SourceCode("return handler()")
                     ]},
-                    SourceCode("fatalError(\"`\(mockedVariableName)GetHandler` must be set!\")")
+                    SourceCode("fatalError(\"\(MockNaming.getHandlerExpectedMessage(prefix: mockedVariableName))\")")
                 ]
                 if variable.isMutable {
                     mockedVariableImplementation = SourceCode("\(isolationDecl)var \(variable.name): \(variable.typeName.declaredName)") {[
@@ -97,8 +97,8 @@ extension MockVar {
                 } else {
                     mockedVariableImplementation = SourceCode("\(isolationDecl)var \(variable.name): \(variable.typeName.declaredName)", nested: getterImplementation)
                 }
-                mockedVariableHandlers += "\(storageIsolationDecl)var \(mockedVariableName)GetCount: Int = 0"
-                mockedVariableHandlers += "\(storageIsolationDecl)var \(mockedVariableName)GetHandler: (() -> \(variable.typeName.declaredName))? = nil"
+                mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getCount(mockedVariableName)): Int = 0"
+                mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getHandler(mockedVariableName)): (() -> \(variable.typeName.declaredName))? = nil"
             } else if !variable.isAnnotatedInit, variable.typeName.hasDefaultValue, let defaultValue = try? variable.typeName.defaultValue() {
                 // Default value can be guessed.
                 mockedVariableImplementation = SourceCode("\(storageIsolationDecl)\(variableDecl) \(variable.name): \(variable.typeName.declaredName) = \(defaultValue)")
@@ -108,9 +108,9 @@ extension MockVar {
             }
             if variable.isMutable {
                 mockedVariableImplementation += SourceCode(variable.isAnnotatedHandler ? "set" : "didSet") {[
-                    SourceCode("\(mockedVariableName)SetCount += 1")
+                    SourceCode("\(MockNaming.setCount(mockedVariableName)) += 1")
                 ]}
-                mockedVariableHandlers += "\(storageIsolationDecl)var \(mockedVariableName)SetCount: Int = 0"
+                mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.setCount(mockedVariableName)): Int = 0"
             }
         }
         var topScope = TopScope()

--- a/templates/Mocks/MockVar.swift
+++ b/templates/Mocks/MockVar.swift
@@ -164,24 +164,25 @@ extension MockVar {
                     : SourceCode("return \(MockNaming.store(mockedVariableName))")
             ]
 
-            // The witness stays settable wherever it is settable today: a
-            // read-only requirement backed by a `var` store was emitted as a
-            // settable stored property, and a test re-seeds it by assignment.
-            // `const` and `handler` are the two that were not — the first has a
-            // `let`, the second has no storage at all.
+            // The witness declares what the requirement declares: a `{ get }`
+            // requirement is get-only on the mock, and `_<var>` is how a test
+            // seeds it (§12.2 item 2, D18). P5 emitted a setter for a read-only
+            // requirement — uncounted, so `mock.draft = x` compiled and moved
+            // nothing — which `kotlin-ksp-mocks` §12.4 asked this side to drop,
+            // so that `mock._<var> = value` is the one seed expression on both
+            // platforms. `const` and `handler` were already get-only.
             //
             // `<var>SetCount` counts a write to a `{ get set }` requirement, and
-            // only that (§2.3): a re-seed of a read-only requirement was
-            // uncounted before this change and stays uncounted.
-            // An effectful requirement is get-only: Swift has no effectful
-            // setter, so there is nothing for a mutable form to witness.
-            let hasSetter = !hasEffects && (variable.isMutable || !(variable.isAnnotatedConst || variable.isAnnotatedHandler))
-            var setterImplementation: [SourceCode] = []
-            if variable.isMutable {
-                // `didSet` on a stored property was the old shape, and a stored
-                // property cannot count a read.
-                setterImplementation += [SourceCode("\(MockNaming.setCount(mockedVariableName)) += 1")]
-            }
+            // only that (§2.3). An effectful requirement is get-only too: Swift
+            // has no effectful setter, so there is nothing for a mutable form to
+            // witness.
+            let hasSetter = !hasEffects && variable.isMutable
+            // Only a `{ get set }` requirement reaches the setter now, so the
+            // count is unconditional in it. `didSet` on a stored property was
+            // the old shape, and a stored property cannot count a read.
+            var setterImplementation: [SourceCode] = [
+                SourceCode("\(MockNaming.setCount(mockedVariableName)) += 1")
+            ]
             if !variable.isAnnotatedHandler {
                 setterImplementation += [SourceCode("\(MockNaming.store(mockedVariableName)) = newValue")]
             }
@@ -192,7 +193,7 @@ extension MockVar {
 
             mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getCount(mockedVariableName)): Int = 0"
             mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.getHandler(mockedVariableName)): (()\(effectsDecl) -> \(variable.typeName.declaredName))? = nil"
-            if variable.isMutable && hasSetter {
+            if hasSetter {
                 mockedVariableHandlers += "\(storageIsolationDecl)var \(MockNaming.setCount(mockedVariableName)): Int = 0"
             }
             if !variable.isAnnotatedHandler {

--- a/templates/Mocks/SourceCode.swift
+++ b/templates/Mocks/SourceCode.swift
@@ -11,6 +11,11 @@ class SourceCode {
     let line: String
     var nested: [SourceCode]
     var isBlockMandatory: Bool = false // if `true`, always output curly braces after the line, even if nested is empty, e.g., empty class/function declaration.
+    /// Emitted immediately after the closing brace, with no space. It is what
+    /// lets a block be part of a larger expression — the remaining arguments of
+    /// a call whose first argument is a trailing-style closure, as in
+    /// `handleEvents(receiveOutput: { … }, receiveCompletion: { … })`.
+    var trailer: String = ""
 
     init(_ line: String, nested: [SourceCode] = []) {
         self.line = line
@@ -36,7 +41,7 @@ class SourceCode {
             if !line.contains("{") { // as in, e.g., "return AnyObserver { [weak self] event in"
                 result += " {"
             }
-            result += "\n\(nestedCode)\n\(indent)}"
+            result += "\n\(nestedCode)\n\(indent)}\(trailer)"
         } else if isBlockMandatory {
             result += " {\n\(indent)}"
         }
@@ -52,7 +57,15 @@ extension SourceCode {
         guard !prefix.isEmpty, !line.isEmpty else { return self }
         let copy = SourceCode("\(prefix)\(line)", nested: nested)
         copy.isBlockMandatory = isBlockMandatory
+        copy.trailer = trailer
         return copy
+    }
+
+    /// Sets `trailer` and returns self, so a block that continues an expression
+    /// reads as one construct at the point it is built.
+    func trailing(_ trailer: String) -> SourceCode {
+        self.trailer = trailer
+        return self
     }
 }
 

--- a/templates/Mocks/SourceryRuntimeExtensions.swift
+++ b/templates/Mocks/SourceryRuntimeExtensions.swift
@@ -323,7 +323,7 @@ extension SourceryRuntime.TypeName {
             case "Single":
                 let getterImplementation = SourceCode("return Single.create { (observer: @escaping (SingleEvent<\(returnTypeName)>) -> ()) -> Disposable in") { [
                     SourceCode("""
-                        return self.\(mockVariablePrefix)Subject.subscribe { (event: Event<\(returnTypeName)>) in
+                        return self.\(MockNaming.subject(mockVariablePrefix)).subscribe { (event: Event<\(returnTypeName)>) in
                                         switch event {
                                         case .next(let element):
                                             observer(.success(element))
@@ -335,21 +335,21 @@ extension SourceryRuntime.TypeName {
                                     }
                         """)
                 ]}
-                let mockedVariableHandlers = [SourceCode("lazy var \(mockVariablePrefix)Subject = PublishSubject<\(returnTypeName)>()")]
+                let mockedVariableHandlers = [SourceCode("lazy var \(MockNaming.subject(mockVariablePrefix)) = PublishSubject<\(returnTypeName)>()")]
                 return (getterImplementation, mockedVariableHandlers)
             case "Observable":
                 let optionalMappingClauseForTupleTypes = generic.typeParameters[0].typeName.needsSubjectMapToReturnType ? ".map { $0 }" : ""
-                let getterImplementation = SourceCode("return \(mockVariablePrefix)Subject\(optionalMappingClauseForTupleTypes).as\(generic.name)()\(forceCasting)")
-                let mockedVariableHandlers = [SourceCode("lazy var \(mockVariablePrefix)Subject = PublishSubject<\(returnTypeName)>()")]
+                let getterImplementation = SourceCode("return \(MockNaming.subject(mockVariablePrefix))\(optionalMappingClauseForTupleTypes).as\(generic.name)()\(forceCasting)")
+                let mockedVariableHandlers = [SourceCode("lazy var \(MockNaming.subject(mockVariablePrefix)) = PublishSubject<\(returnTypeName)>()")]
                 return (getterImplementation, mockedVariableHandlers)
             case "AnyObserver":
                 let getterImplementation = SourceCode("return AnyObserver { [weak self] event in") { [
-                    SourceCode("self?.\(mockVariablePrefix)EventCallCount += 1"),
-                    SourceCode("self?.\(mockVariablePrefix)EventHandler?(event)"),
+                    SourceCode("self?.\(MockNaming.eventCallCount(mockVariablePrefix)) += 1"),
+                    SourceCode("self?.\(MockNaming.eventHandler(mockVariablePrefix))?(event)"),
                 ]}
                 let mockedVariableHandlers: [SourceCode] = [
-                    SourceCode("var \(mockVariablePrefix)EventCallCount: Int = 0"),
-                    SourceCode("var \(mockVariablePrefix)EventHandler: ((Event<\(returnTypeName)>) -> ())? = nil"),
+                    SourceCode("var \(MockNaming.eventCallCount(mockVariablePrefix)): Int = 0"),
+                    SourceCode("var \(MockNaming.eventHandler(mockVariablePrefix)): ((Event<\(returnTypeName)>) -> ())? = nil"),
                 ]
                 return (getterImplementation, mockedVariableHandlers)
             default:
@@ -402,8 +402,8 @@ extension SourceryRuntime.TypeName {
                 subjectDecl = "PassthroughSubject<\(outputType), \(failureType)>()"
             }
 
-            let getterImplementation = SourceCode("return \(mockVariablePrefix)Subject.eraseToAnyPublisher()\(forceCasting)")
-            let mockedVariableHandlers = [SourceCode("lazy var \(mockVariablePrefix)Subject = \(subjectDecl)")]
+            let getterImplementation = SourceCode("return \(MockNaming.subject(mockVariablePrefix)).eraseToAnyPublisher()\(forceCasting)")
+            let mockedVariableHandlers = [SourceCode("lazy var \(MockNaming.subject(mockVariablePrefix)) = \(subjectDecl)")]
             return (getterImplementation, mockedVariableHandlers)
         }
 
@@ -415,12 +415,12 @@ extension SourceryRuntime.TypeName {
             // handler.
             guard !isProperty else { throw MockError.noDefaultValue(typeName: self) } // Only functions with `AnyCancellable` return type are supported.
             let getterImplementation = SourceCode("return AnyCancellable { [weak self] in") { [
-                SourceCode("self?.\(mockVariablePrefix)CancelCallCount += 1"),
-                SourceCode("self?.\(mockVariablePrefix)CancelHandler?()"),
+                SourceCode("self?.\(MockNaming.cancelCallCount(mockVariablePrefix)) += 1"),
+                SourceCode("self?.\(MockNaming.cancelHandler(mockVariablePrefix))?()"),
             ]}
             let mockedVariableHandlers: [SourceCode] = [
-                SourceCode("var \(mockVariablePrefix)CancelCallCount: Int = 0"),
-                SourceCode("var \(mockVariablePrefix)CancelHandler: (() -> ())? = nil"),
+                SourceCode("var \(MockNaming.cancelCallCount(mockVariablePrefix)): Int = 0"),
+                SourceCode("var \(MockNaming.cancelHandler(mockVariablePrefix)): (() -> ())? = nil"),
             ]
             return (getterImplementation, mockedVariableHandlers)
         }
@@ -428,12 +428,12 @@ extension SourceryRuntime.TypeName {
         if unwrappedTypeName == "Disposable" {
             guard !isProperty else { throw MockError.noDefaultValue(typeName: self) } // Only functions with `Disposable` return type are supported.
             let getterImplementation = SourceCode("return Disposables.create { [weak self] in") { [
-                SourceCode("self?.\(mockVariablePrefix)DisposeCallCount += 1"),
-                SourceCode("self?.\(mockVariablePrefix)DisposeHandler?()"),
+                SourceCode("self?.\(MockNaming.disposeCallCount(mockVariablePrefix)) += 1"),
+                SourceCode("self?.\(MockNaming.disposeHandler(mockVariablePrefix))?()"),
             ]}
             let mockedVariableHandlers: [SourceCode] = [
-                SourceCode("var \(mockVariablePrefix)DisposeCallCount: Int = 0"),
-                SourceCode("var \(mockVariablePrefix)DisposeHandler: (() -> ())? = nil"),
+                SourceCode("var \(MockNaming.disposeCallCount(mockVariablePrefix)): Int = 0"),
+                SourceCode("var \(MockNaming.disposeHandler(mockVariablePrefix)): (() -> ())? = nil"),
             ]
             return (getterImplementation, mockedVariableHandlers)
         }

--- a/templates/Mocks/SourceryRuntimeExtensions.swift
+++ b/templates/Mocks/SourceryRuntimeExtensions.swift
@@ -311,7 +311,19 @@ extension SourceryRuntime.TypeName {
         return (try? smartDefaultValueImplementation(isProperty: isProperty, mockVariablePrefix: "")) != nil
     }
 
-    func smartDefaultValueImplementation(isProperty: Bool, mockVariablePrefix: String, forceCastingToReturnTypeName: Bool = false, requestedSubjectKind: SubjectKind = .automatic) throws -> (getterImplementation: SourceCode, mockedVariableHandlers: [SourceCode]) {
+    /// The body a member of a stream or token type returns, and the bookkeeping
+    /// that body reads and writes.
+    ///
+    /// - Parameters:
+    ///   - recordsStreamValues: whether the member keeps `<name>Outputs` /
+    ///     `<name>Events`. `/// sourcery: skipArgumentRecording` on the member or
+    ///     on the protocol turns it off, for the reason it turns `<method>Args`
+    ///     off: a recorded value lives as long as the mock (`spec.md` D13).
+    /// - Returns: `suppliesHandlerConsultation` is true when the body reads
+    ///   `<name>GetHandler` itself, so the caller must not emit its own read.
+    ///   The publisher branch does, because the handler is read at subscribe
+    ///   time rather than at read time (§2.7).
+    func smartDefaultValueImplementation(isProperty: Bool, mockVariablePrefix: String, forceCastingToReturnTypeName: Bool = false, requestedSubjectKind: SubjectKind = .automatic, recordsStreamValues: Bool = true) throws -> (getterImplementation: [SourceCode], mockedVariableHandlers: [SourceCode], suppliesHandlerConsultation: Bool) {
         if isGeneric,
             let generic = generic,
             generic.name == "Single" || generic.name == "Observable" || generic.name == "AnyObserver",
@@ -336,22 +348,36 @@ extension SourceryRuntime.TypeName {
                         """)
                 ]}
                 let mockedVariableHandlers = [SourceCode("lazy var \(MockNaming.subject(mockVariablePrefix)) = PublishSubject<\(returnTypeName)>()")]
-                return (getterImplementation, mockedVariableHandlers)
+                return ([getterImplementation], mockedVariableHandlers, false)
             case "Observable":
                 let optionalMappingClauseForTupleTypes = generic.typeParameters[0].typeName.needsSubjectMapToReturnType ? ".map { $0 }" : ""
                 let getterImplementation = SourceCode("return \(MockNaming.subject(mockVariablePrefix))\(optionalMappingClauseForTupleTypes).as\(generic.name)()\(forceCasting)")
                 let mockedVariableHandlers = [SourceCode("lazy var \(MockNaming.subject(mockVariablePrefix)) = PublishSubject<\(returnTypeName)>()")]
-                return (getterImplementation, mockedVariableHandlers)
+                return ([getterImplementation], mockedVariableHandlers, false)
             case "AnyObserver":
+                // What the code under test pushes in is counted, recorded and
+                // handed to the handler, in the order a method's arguments
+                // already establish: the record is written before the handler
+                // runs, so a handler that traps does not un-make the event
+                // (§2.3, D13).
                 let getterImplementation = SourceCode("return AnyObserver { [weak self] event in") { [
                     SourceCode("self?.\(MockNaming.eventCallCount(mockVariablePrefix)) += 1"),
+                ] + (recordsStreamValues ? [
+                    SourceCode("self?.\(MockNaming.events(mockVariablePrefix)).append(event)"),
+                ] : []) + [
                     SourceCode("self?.\(MockNaming.eventHandler(mockVariablePrefix))?(event)"),
                 ]}
                 let mockedVariableHandlers: [SourceCode] = [
                     SourceCode("var \(MockNaming.eventCallCount(mockVariablePrefix)): Int = 0"),
+                ] + (recordsStreamValues ? [
+                    // RxSwift's `Event` declares no `Equatable` conformance, so
+                    // a test reads this through `compactMap(\.element)`, `error`
+                    // and `isCompleted` rather than comparing it whole.
+                    SourceCode("var \(MockNaming.events(mockVariablePrefix)): [Event<\(returnTypeName)>] = []"),
+                ] : []) + [
                     SourceCode("var \(MockNaming.eventHandler(mockVariablePrefix)): ((Event<\(returnTypeName)>) -> ())? = nil"),
                 ]
-                return (getterImplementation, mockedVariableHandlers)
+                return ([getterImplementation], mockedVariableHandlers, false)
             default:
                 fatalError("Should not happen")
             }
@@ -402,9 +428,65 @@ extension SourceryRuntime.TypeName {
                 subjectDecl = "PassthroughSubject<\(outputType), \(failureType)>()"
             }
 
-            let getterImplementation = SourceCode("return \(MockNaming.subject(mockVariablePrefix)).eraseToAnyPublisher()\(forceCasting)")
-            let mockedVariableHandlers = [SourceCode("lazy var \(MockNaming.subject(mockVariablePrefix)) = \(subjectDecl)")]
-            return (getterImplementation, mockedVariableHandlers)
+            // The member hands back a construct the mock owns rather than the
+            // erased subject (§2.7, D11). `Deferred`'s closure runs once per
+            // subscription, which is where the subscription is counted and —
+            // for a property — where `<var>GetHandler` is read, so a handler
+            // seeded after the code under test captured the publisher decides
+            // the stream. A method keeps its handler at call time, where its
+            // arguments are and where its `async` and `throws` apply, so only
+            // the subject fallback is deferred here.
+            //
+            // The closure captures the subject directly and the mock weakly:
+            // the stream still delivers after the mock is released and only the
+            // counting stops. Capturing the mock strongly would make every
+            // publisher member retain it, which is the hazard
+            // `skipArgumentRecording` exists for.
+            let subjectName = MockNaming.subject(mockVariablePrefix)
+            let erasedType = "AnyPublisher<\(outputType), \(failureType)>"
+            var deferredBody: [SourceCode] = [
+                SourceCode("self?.\(MockNaming.subscribeCount(mockVariablePrefix)) += 1")
+            ]
+            if isProperty {
+                deferredBody += [SourceCode("if let handler = self?.\(MockNaming.getHandler(mockVariablePrefix))") {[
+                    SourceCode("return handler()")
+                ]}]
+            }
+            deferredBody += [SourceCode("return subject.eraseToAnyPublisher()")]
+
+            // What the member delivered: counted, recorded, then handed to the
+            // handler. It records delivery rather than sending — a value sent
+            // while nobody is subscribed goes nowhere and counts nothing, and a
+            // value delivered to two subscribers counts twice.
+            var receiveOutputBody: [SourceCode] = [
+                SourceCode("self?.\(MockNaming.outputCount(mockVariablePrefix)) += 1")
+            ]
+            if recordsStreamValues {
+                receiveOutputBody += [SourceCode("self?.\(MockNaming.outputs(mockVariablePrefix)).append(value)")]
+            }
+            receiveOutputBody += [SourceCode("self?.\(MockNaming.outputHandler(mockVariablePrefix))?(value)")]
+
+            let getterImplementation: [SourceCode] = [
+                SourceCode("return Deferred { [weak self, subject = \(subjectName)] () -> \(erasedType) in", nested: deferredBody),
+                SourceCode(".handleEvents(receiveOutput: { [weak self] value in", nested: receiveOutputBody)
+                    .trailing(", receiveCompletion: { [weak self] _ in self?.\(MockNaming.completionCount(mockVariablePrefix)) += 1 }, receiveCancel: { [weak self] in self?.\(MockNaming.subscribeCancelCount(mockVariablePrefix)) += 1 })"),
+                SourceCode(".eraseToAnyPublisher()\(forceCasting)")
+            ]
+
+            var mockedVariableHandlers: [SourceCode] = [
+                SourceCode("var \(MockNaming.subscribeCount(mockVariablePrefix)): Int = 0"),
+                SourceCode("var \(MockNaming.subscribeCancelCount(mockVariablePrefix)): Int = 0"),
+                SourceCode("var \(MockNaming.outputCount(mockVariablePrefix)): Int = 0"),
+            ]
+            if recordsStreamValues {
+                mockedVariableHandlers += [SourceCode("var \(MockNaming.outputs(mockVariablePrefix)): [\(outputType)] = []")]
+            }
+            mockedVariableHandlers += [
+                SourceCode("var \(MockNaming.outputHandler(mockVariablePrefix)): ((\(outputType)) -> Void)? = nil"),
+                SourceCode("var \(MockNaming.completionCount(mockVariablePrefix)): Int = 0"),
+                SourceCode("lazy var \(subjectName) = \(subjectDecl)"),
+            ]
+            return (getterImplementation, mockedVariableHandlers, isProperty)
         }
 
         if unwrappedTypeName == "AnyCancellable" {
@@ -422,7 +504,7 @@ extension SourceryRuntime.TypeName {
                 SourceCode("var \(MockNaming.cancelCallCount(mockVariablePrefix)): Int = 0"),
                 SourceCode("var \(MockNaming.cancelHandler(mockVariablePrefix)): (() -> ())? = nil"),
             ]
-            return (getterImplementation, mockedVariableHandlers)
+            return ([getterImplementation], mockedVariableHandlers, false)
         }
 
         if unwrappedTypeName == "Disposable" {
@@ -435,7 +517,7 @@ extension SourceryRuntime.TypeName {
                 SourceCode("var \(MockNaming.disposeCallCount(mockVariablePrefix)): Int = 0"),
                 SourceCode("var \(MockNaming.disposeHandler(mockVariablePrefix)): (() -> ())? = nil"),
             ]
-            return (getterImplementation, mockedVariableHandlers)
+            return ([getterImplementation], mockedVariableHandlers, false)
         }
 
         throw MockError.noDefaultValue(typeName: self)

--- a/templates/Utility/StringLettercase.swift
+++ b/templates/Utility/StringLettercase.swift
@@ -2,18 +2,17 @@ import Foundation
 
 // Courtesy of https://github.com/SwiftGen/StencilSwiftKit
 
+// Two entry points remain, both called only from `Mocks/MockNaming.swift` and
+// both only by the return-type discriminator that disambiguates overloads
+// differing in return type alone. `lowercasedFirstWord`, `lowercasedFirstLetter`
+// and `snakeCased` went with the prefix transform they served
+// (`specs/004-mock-member-naming/spec.md` §2.1, P2); `lowerFirstWord` is the one
+// that traps on an all-uppercase name — it indexes `scalars[idx]` before testing
+// `idx` against `endIndex`, so `func ID()` crashed generation with "String index
+// is out of bounds" (§1.2).
 extension String {
-    func lowercasedFirstLetter() -> String {
-      return FiltersStrings.lowerFirstLetter(self)
-    }
-    func lowercasedFirstWord() -> String {
-      return FiltersStrings.lowerFirstWord(self)
-    }
     func uppercasedFirstLetter() -> String {
       return FiltersStrings.upperFirstLetter(self)
-    }
-    func snakeCased(toLower: Bool = true) -> String {
-      return FiltersStrings.camelToSnakeCase(self, toLower: toLower)
     }
     func camelCased(stripLeading: Bool = false) -> String {
       return FiltersStrings.snakeToCamelCase(self, stripLeading: stripLeading)
@@ -21,36 +20,6 @@ extension String {
 }
 
 private final class FiltersStrings {
-  /// Lowers the first letter of the string
-  /// e.g. "People picker" gives "people picker", "Sports Stats" gives "sports Stats"
-  static func lowerFirstLetter(_ string: String) -> String {
-    let first = String(string.prefix(1)).lowercased()
-    let other = String(string.dropFirst(1))
-    return first + other
-  }
-
-  /// If the string starts with only one uppercase letter, lowercase that first letter
-  /// If the string starts with multiple uppercase letters, lowercase those first letters
-  /// up to the one before the last uppercase one, but only if the last one is followed by
-  /// a lowercase character.
-  /// e.g. "PeoplePicker" gives "peoplePicker" but "URLChooser" gives "urlChooser"
-  static func lowerFirstWord(_ string: String) -> String {
-    let cs = CharacterSet.uppercaseLetters
-    let scalars = string.unicodeScalars
-    let start = scalars.startIndex
-    var idx = start
-    while let scalar = UnicodeScalar(scalars[idx].value), cs.contains(scalar) && idx <= scalars.endIndex {
-        idx = scalars.index(after: idx)
-    }
-    if idx > scalars.index(after: start) && idx < scalars.endIndex,
-        let scalar = UnicodeScalar(scalars[idx].value),
-        CharacterSet.lowercaseLetters.contains(scalar) {
-        idx = scalars.index(before: idx)
-    }
-    let transformed = String(scalars[start..<idx]).lowercased() + String(scalars[idx..<scalars.endIndex])
-    return transformed
-  }
-
   /// Uppers the first letter of the string
   /// e.g. "people picker" gives "People picker", "sports Stats" gives "Sports Stats"
   ///
@@ -60,21 +29,6 @@ private final class FiltersStrings {
   /// - Returns: the string with first letter being uppercased
   static func upperFirstLetter(_ string: String) -> String {
     return _upperFirstLetter(string)
-  }
-
-  /// Converts camelCase to snake_case. Takes an optional Bool argument for making the string lower case,
-  /// which defaults to true
-  ///
-  /// - Parameters:
-  ///   - value: the value to be processed
-  ///   - arguments: the arguments to the function; expecting zero or one boolean argument
-  /// - Returns: the snake case string
-  static func camelToSnakeCase(_ string: String, toLower: Bool = true) -> String {
-    let snakeCase = snakecase(string)
-    if toLower {
-        return snakeCase.lowercased()
-    }
-    return snakeCase
   }
 
   /// Converts snake_case to camelCase, stripping prefix underscores if needed


### PR DESCRIPTION
One naming rule for every generated mock member, the members a property and a stream requirement were missing, the names that rule does not derive written into the generated file, and the two generators brought back into step.

`specs/004-mock-member-naming/spec.md` is the record: §2 states the rule, §3 the decisions, §9 what each of P1–P9 landed, §10 the two proposals after P9 with §10.5's ruling, §11 what P10 and P11 landed, §12 what `kotlin-ksp-mocks` asks of this repository with §12.8's ruling, §13 what P12–P14 landed.

## Breaking, twice, for every consumer

**1. A mock member's prefix is the requirement's declared name**, with backticks removed and nothing else. It was that for a property and a case-and-underscore transform for a method, so one generated class carried two rules: `func perform1_0()` gave `perform10CallCount`, `func ID()` crashed generation. An overloaded method's long form now appends the capitalized argument label of each parameter rather than the label *and* the name — `endAtDocumentDocument` becomes `endAtDocument`.

**2. A `{ get }` requirement's witness is get-only**, as the requirement is. `mock._<var> = value` is how a test seeds one, and it is the same expression on the Kotlin side. A read-only requirement was emitted as a settable stored property, so `mock.draft = x` compiled and moved no counter.

Every test naming a renamed member, and every assignment to a read-only requirement on a mock, stops compiling. No deprecated aliases are emitted for the names — the generator would have to keep both naming rules to know the old one — and no deprecation window exists for the setter, because `@available(*, deprecated)` marks a property and not one accessor. Nothing can assign a `{ get }` requirement through the protocol, so every broken assignment is code holding the concrete `<Type>Mock`.

Measured against `modaal-firebase-wrappers`, regenerated from this branch and diffed against its committed output at templates 0.2.15: **7 files, 1706 → 2803 lines**, 274 generated members → 515, **9 references in 2 test files** broken by the renames and **12 assignment sites in 5 test files** broken by the get-only witness. `CHANGELOG.md` carries the tables and the one-line fix for each.

## What else changed in the generated output

- **Every property requirement counts its reads.** `<var>GetCount`, `<var>GetHandler` and a `_<var>` store, with the initializer seeding the store — construction still moves no counter and `Mock(analytics:)` keeps its argument label.
- **An effectful property requirement generates the accessor it declares.** `{ get async }`, `{ get throws }`, `{ get async throws }` carry through to the accessor and to `<var>GetHandler`. It emitted a plain stored property before, which does not satisfy the requirement.
- **An `AnyPublisher` member hands back a construct the mock owns** and counts what crossed it: `SubscribeCount`, `SubscribeCancelCount`, `OutputCount`, `Outputs`, `OutputHandler`, `CompletionCount`. An `AnyObserver` member gains `<name>Events`.
- **Two diagnostics replace two silent failures**: two members that would carry one name, and a requirement declaring `throws(E)`. Both name the protocol and the member instead of writing a file the consumer's compiler rejects.
- **One wording for both traps.** A property getter with no handler now traps with `<var>GetHandler expected to be set.`, which is what the method form already said and what `kotlin-ksp-mocks` matches.
- **Every generated file says how its members are named.** Five lines at the top, two under each `// MARK:`, and a comment naming both spellings above any member whose prefix is not its declaration — 47 of them in 10 of the consumer's 34 classes, which is 30% of its methods.

## In step with `kotlin-ksp-mocks`

Its 002 §11 compared that processor against this branch and ruled four decisions; §12 here extracts the four items it hands this side, and §12.8 rules them. Two land here: the get-only witness above, and the twin table in `references/generated-api.md`, whose three stale rows described that processor before its own property-accessor release. `NamingUnlabelledOverload` puts the one divergence neither side had measured — the tie-break between two overloads with equal parameter counts — into the snapshot, so the other generator can read which name this one picks. Left open and recorded on both sides: a method whose handler supplies the publisher counts nothing here and is wrapped there.

## Where the rule lives

`templates/Mocks/MockNaming.swift` builds every name, every suffix, the backing store's spelling, both trap strings, the uniqueness check and the comment — the prefix and its comment come from one call, so they cannot disagree. `AGENTS.md` §"State a rule once" names the file.

## Documentation

`README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, the skill body and `references/generated-api.md`, `stream-members.md` (new), `spm-plugin.md` and `troubleshooting.md`. P11 documents how to find the generated file on the plugin lane: both lanes' path shapes, one `find`, and the build-log remark the plugin already emitted and nothing documented. The skill body was trimmed 297 → 208 lines to bring it back under the 5,000-token compaction floor, ~6.1k → ~4.9k on invoke, by moving to references what they already carried.

## Checks

`run-checks.sh` gains a refusal gate (7 cases) and a naming-comment gate (2 red controls), and the behaviour harness gains 39 assertions over property counting, effectful properties and publisher counting. `run-plugin-checks.sh` gains two fixes found while landing this: it now drops llbuild's `build.db` with the plugin outputs, so a run that failed downstream of generation no longer breaks the next one, and its bundle-route gate gets the cold build the remark it greps for requires. Three of its failure branches piped a diagnostic through `head` and ended the run before `fail` recorded anything; each takes `|| true`.

Green locally: `run-checks.sh`, `run-skill-checks.sh`, `run-annotation-checks.sh`, `run-cli-checks.sh`, `run-plugin-checks.sh` (twice in a row, plus a by-hand red control for the recovery fix), and `Tests/Examples/ExampleProjectSpm/test-ios.sh` at 20 tests. `run-xcode-checks.sh` was not run here; the Xcode lane in CI covers it.

## Before the tag

`kotlin-ksp-mocks` has its own half to land — the in-file naming comments and the `find` in its skill — because a published version there is immutable. Nothing in this repository blocks on it, and the tag is not cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
